### PR TITLE
Fix startup crashes and improve UX

### DIFF
--- a/internal/github/labels.go
+++ b/internal/github/labels.go
@@ -1,6 +1,9 @@
 package github
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 type Label struct {
 	Name  string
@@ -25,11 +28,57 @@ var RequiredLabels = []Label{
 }
 
 func (c *Client) EnsureLabels() error {
+	existing, _ := c.listLabels()
+	existingSet := make(map[string]bool, len(existing))
+	for _, name := range existing {
+		existingSet[name] = true
+	}
+
+	var missing []Label
 	for _, l := range RequiredLabels {
-		_, err := c.gh("label", "create", l.Name, "--color", l.Color, "--force")
-		if err != nil {
-			return fmt.Errorf("creating label %s: %w", l.Name, err)
+		if !existingSet[l.Name] {
+			missing = append(missing, l)
 		}
 	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(missing))
+
+	for _, l := range missing {
+		wg.Add(1)
+		go func(l Label) {
+			defer wg.Done()
+			_, err := c.gh("label", "create", l.Name, "--color", l.Color, "--force")
+			if err != nil {
+				errs <- fmt.Errorf("creating label %s: %w", l.Name, err)
+			}
+		}(l)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		return err
+	}
 	return nil
+}
+
+func (c *Client) listLabels() ([]string, error) {
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	err := c.ghJSON(&labels, "label", "list", "--json", "name", "--limit", "200")
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, len(labels))
+	for i, l := range labels {
+		names[i] = l.Name
+	}
+	return names, nil
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -105,7 +105,7 @@ func CheckConfig(dir string) error {
 	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf(
 			"config not found at %s\n\n"+
-				"  Create .oda/config.yaml in your project root",
+				"  Run: oda init",
 			path,
 		)
 	}

--- a/internal/worker/pool.go
+++ b/internal/worker/pool.go
@@ -12,6 +12,12 @@ type TaskQueue interface {
 	MarkBlocked(taskID int, reason string) error
 }
 
+type EmptyQueue struct{}
+
+func (q *EmptyQueue) Next() (*Task, error)                   { return nil, nil }
+func (q *EmptyQueue) MarkDone(taskID int) error              { return nil }
+func (q *EmptyQueue) MarkBlocked(taskID int, _ string) error { return nil }
+
 type TaskProcessor interface {
 	Process(ctx context.Context, worker *Worker, task *Task) error
 }

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func runServe() error {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
 	fmt.Printf("Starting %d workers...\n", cfg.Workers.Count)
-	pool := worker.NewPool(cfg.Workers.Count, nil, processor)
+	pool := worker.NewPool(cfg.Workers.Count, &worker.EmptyQueue{}, processor)
 	pool.Start(ctx)
 
 	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers)
@@ -165,9 +165,6 @@ func runServe() error {
 		}()
 
 		<-workersDone
-		fmt.Println("All workers finished.")
-
-	case <-workersDone:
 		fmt.Println("All workers finished.")
 
 	case err := <-srvErrCh:


### PR DESCRIPTION
## Summary

- Show `Run: oda init` when config is missing instead of generic message
- EnsureLabels checks existing labels first, creates only missing ones in parallel (goroutines)
- Add `EmptyQueue` to prevent nil pointer panic when no sprint tasks exist
- Keep dashboard running after workers finish, waiting for Ctrl+C

Fixes #1