### PR TITLE
feat: auto-start opencode serve if not running

### DIFF
--- a/internal/opencode/server.go
+++ b/internal/opencode/server.go
@@ -1,0 +1,65 @@
+package opencode
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+	"time"
+)
+
+// Server manages a spawned opencode serve process.
+type Server struct {
+	cmd     *exec.Cmd
+	baseURL string
+}
+
+// StartServer starts "opencode serve" as a background process in the given directory.
+// It waits up to timeout for the health check to pass.
+// Returns a *Server that must be stopped via Stop() when done.
+func StartServer(baseURL, dir string, timeout time.Duration) (*Server, error) {
+	cmd := exec.Command("opencode", "serve")
+	cmd.Dir = dir
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting opencode serve: %w", err)
+	}
+
+	s := &Server{cmd: cmd, baseURL: baseURL}
+
+	if err := s.waitHealthy(timeout); err != nil {
+		_ = cmd.Process.Kill()
+		return nil, fmt.Errorf("opencode serve did not become healthy: %w", err)
+	}
+
+	return s, nil
+}
+
+// Stop terminates the spawned opencode serve process.
+func (s *Server) Stop() error {
+	if s.cmd == nil || s.cmd.Process == nil {
+		return nil
+	}
+	if err := s.cmd.Process.Kill(); err != nil {
+		return fmt.Errorf("stopping opencode serve: %w", err)
+	}
+	_ = s.cmd.Wait()
+	return nil
+}
+
+func (s *Server) waitHealthy(timeout time.Duration) error {
+	client := &http.Client{Timeout: 2 * time.Second}
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(s.baseURL + "/global/health")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("timed out after %s", timeout)
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -81,6 +81,13 @@ func CheckGhAuth() error {
 	return nil
 }
 
+func CheckOpencodeInstalled() error {
+	if _, err := exec.LookPath("opencode"); err != nil {
+		return fmt.Errorf("opencode binary not found in PATH\n\n%s", opencodeInstallInstructions())
+	}
+	return nil
+}
+
 func CheckOpencode(url string) error {
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Get(url + "/global/health")

--- a/main.go
+++ b/main.go
@@ -77,8 +77,10 @@ func runServe() error {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
 
+	const opencodeURL = "http://localhost:4096"
+
 	fmt.Println("Running preflight checks...")
-	results := preflight.RunAll(dir, "http://localhost:4096")
+	results := preflight.RunAll(dir, opencodeURL)
 	allOK := true
 	for _, r := range results {
 		if r.OK {
@@ -88,7 +90,49 @@ func runServe() error {
 			allOK = false
 		}
 	}
+
+	// If opencode is not reachable, try to auto-start it.
+	var spawnedServer *opencode.Server
 	if !allOK {
+		opencodeOK := true
+		for _, r := range results {
+			if r.Name == "opencode" && !r.OK {
+				opencodeOK = false
+				break
+			}
+		}
+
+		if !opencodeOK {
+			// Check if opencode binary is installed before trying to start it.
+			if err := preflight.CheckOpencodeInstalled(); err != nil {
+				return err
+			}
+
+			fmt.Println("  → opencode not running, starting opencode serve...")
+			spawnedServer, err = opencode.StartServer(opencodeURL, dir, 10*time.Second)
+			if err != nil {
+				return fmt.Errorf("auto-starting opencode serve: %w\n\n  Start manually: opencode serve", err)
+			}
+			fmt.Println("  ✓ opencode serve started")
+
+			// Re-run preflight now that opencode is up.
+			results = preflight.RunAll(dir, opencodeURL)
+			allOK = true
+			for _, r := range results {
+				if r.OK {
+					fmt.Printf("  ✓ %s\n", r.Name)
+				} else {
+					fmt.Printf("  ✗ %s: %s\n", r.Name, r.Message)
+					allOK = false
+				}
+			}
+		}
+	}
+
+	if !allOK {
+		if spawnedServer != nil {
+			_ = spawnedServer.Stop()
+		}
 		return fmt.Errorf("preflight checks failed")
 	}
 	fmt.Println()
@@ -190,6 +234,13 @@ func runServe() error {
 	defer shutdownCancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		return fmt.Errorf("shutting down dashboard: %w", err)
+	}
+
+	if spawnedServer != nil {
+		fmt.Println("Stopping opencode serve...")
+		if err := spawnedServer.Stop(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: stopping opencode serve: %v\n", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- If `opencode serve` is not reachable on startup, ODA now checks if the `opencode` binary is in PATH — if not, shows platform-specific install instructions and exits
- If binary is installed but not running, ODA automatically starts `opencode serve` as a background process in the project directory and waits up to 10s for the health check to pass
- On ODA shutdown, the spawned process is terminated; if opencode was already running before ODA started, it is left untouched

## Changes

- `internal/preflight/preflight.go` — added `CheckOpencodeInstalled()` 
- `internal/opencode/server.go` — new file with `StartServer()` / `Stop()` managing the spawned process
- `main.go` — auto-start logic integrated into `runServe()`

Closes #5