### PR TITLE
feat: ensure at least one sprint milestone exists on startup

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -58,7 +58,7 @@ func (c *Client) AddComment(issueNum int, body string) error {
 }
 
 func (c *Client) CreateMilestone(title string) error {
-	_, err := c.gh("api", "repos/{owner}/{repo}/milestones", "-f", "title="+title)
+	_, err := c.ghNoRepo("api", "repos/"+c.Repo+"/milestones", "-f", "title="+title)
 	if err != nil {
 		return fmt.Errorf("creating milestone %s: %w", title, err)
 	}
@@ -104,10 +104,10 @@ type Milestone struct {
 }
 
 func (c *Client) ListMilestones() ([]Milestone, error) {
-	out, err := c.gh("api", "repos/{owner}/{repo}/milestones", "--jq", ".[].title")
+	out, err := c.ghNoRepo("api", "repos/"+c.Repo+"/milestones", "--jq", ".[].title")
 	if err != nil {
 		var milestones []Milestone
-		if err2 := c.ghJSON(&milestones, "api", "repos/{owner}/{repo}/milestones"); err2 != nil {
+		if err2 := c.ghJSON(&milestones, "api", "repos/"+c.Repo+"/milestones"); err2 != nil {
 			return nil, fmt.Errorf("listing milestones: %w", err)
 		}
 		return milestones, nil

--- a/internal/github/milestones.go
+++ b/internal/github/milestones.go
@@ -1,0 +1,32 @@
+package github
+
+import (
+	"fmt"
+	"time"
+)
+
+// EnsureMilestone checks if at least one milestone exists for the repository.
+// If no milestones exist, it creates a default "Sprint 1" milestone with
+// a due date 2 weeks from now.
+// Returns true if a milestone was created, false if one already existed.
+func (c *Client) EnsureMilestone() (bool, error) {
+	milestones, err := c.ListMilestones()
+	if err != nil {
+		return false, fmt.Errorf("listing milestones: %w", err)
+	}
+
+	if len(milestones) > 0 {
+		return false, nil
+	}
+
+	// No milestones exist, create a default one using gh api
+	dueDate := time.Now().AddDate(0, 0, 14).Format("2006-01-02T15:04:05Z")
+	_, err = c.ghNoRepo("api", "repos/"+c.Repo+"/milestones",
+		"-f", "title=Sprint 1",
+		"-f", "due_on="+dueDate)
+	if err != nil {
+		return false, fmt.Errorf("creating milestone: %w", err)
+	}
+
+	return true, nil
+}

--- a/main.go
+++ b/main.go
@@ -167,6 +167,16 @@ func runServe() error {
 		return fmt.Errorf("ensuring labels: %w", err)
 	}
 
+	created, err := gh.EnsureMilestone()
+	if err != nil {
+		return fmt.Errorf("ensuring milestone: %w", err)
+	}
+	if created {
+		fmt.Println("  ✓ sprint created (Sprint 1)")
+	} else {
+		fmt.Println("  ✓ sprint found")
+	}
+
 	projectName := cfg.GitHub.Repo
 	if idx := strings.LastIndex(projectName, "/"); idx >= 0 {
 		projectName = projectName[idx+1:]


### PR DESCRIPTION
## Summary

Implements automatic sprint (milestone) creation on ODA startup.

## Changes

- Added `EnsureMilestone()` method in `internal/github/milestones.go`
- Checks if any milestones exist on startup
- Creates default "Sprint 1" milestone with 2-week due date if none found
- Integrated into "Verifying GitHub setup..." startup phase
- Fixed `gh api` calls to use `ghNoRepo` (no -R flag support)

## Testing

- All tests pass
- Build successful
- Milestone created successfully in crazy-goat/one-dev-army

## Related

Closes #9