### PR TITLE
feat: detect and set active sprint milestone on startup

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,11 +8,22 @@ import (
 )
 
 type Client struct {
-	Repo string
+	Repo            string
+	ActiveMilestone *Milestone
 }
 
 func NewClient(repo string) *Client {
 	return &Client{Repo: repo}
+}
+
+// SetActiveMilestone sets the currently active milestone (oldest open sprint)
+func (c *Client) SetActiveMilestone(m *Milestone) {
+	c.ActiveMilestone = m
+}
+
+// GetActiveMilestone returns the currently active milestone or nil if none set
+func (c *Client) GetActiveMilestone() *Milestone {
+	return c.ActiveMilestone
 }
 
 func (c *Client) gh(args ...string) ([]byte, error) {
@@ -37,6 +48,18 @@ func (c *Client) ghNoRepo(args ...string) ([]byte, error) {
 
 func (c *Client) ghJSON(result interface{}, args ...string) error {
 	out, err := c.gh(args...)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(out, result); err != nil {
+		return fmt.Errorf("parsing gh JSON output: %w", err)
+	}
+	return nil
+}
+
+// ghNoRepoJSON runs gh without -R flag and parses JSON output
+func (c *Client) ghNoRepoJSON(result interface{}, args ...string) error {
+	out, err := c.ghNoRepo(args...)
 	if err != nil {
 		return err
 	}

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -3,8 +3,10 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type Issue struct {
@@ -98,27 +100,69 @@ func (c *Client) MergePR(branch string) error {
 }
 
 type Milestone struct {
-	Title  string `json:"title"`
-	Number int    `json:"number"`
-	State  string `json:"state"`
+	Title     string    `json:"title"`
+	Number    int       `json:"number"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+	DueOn     time.Time `json:"due_on"`
 }
 
+// ListMilestones returns all milestones sorted by creation date (newest first)
 func (c *Client) ListMilestones() ([]Milestone, error) {
-	out, err := c.ghNoRepo("api", "repos/"+c.Repo+"/milestones", "--jq", ".[].title")
-	if err != nil {
-		var milestones []Milestone
-		if err2 := c.ghJSON(&milestones, "api", "repos/"+c.Repo+"/milestones"); err2 != nil {
-			return nil, fmt.Errorf("listing milestones: %w", err)
-		}
-		return milestones, nil
-	}
 	var milestones []Milestone
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line != "" {
-			milestones = append(milestones, Milestone{Title: line})
+	if err := c.ghNoRepoJSON(&milestones, "api", "repos/"+c.Repo+"/milestones"); err != nil {
+		return nil, fmt.Errorf("listing milestones: %w", err)
+	}
+
+	// Sort by creation date, newest first
+	sort.Slice(milestones, func(i, j int) bool {
+		return milestones[i].CreatedAt.After(milestones[j].CreatedAt)
+	})
+
+	return milestones, nil
+}
+
+// ListOpenMilestones returns only open (active) milestones sorted by due date
+func (c *Client) ListOpenMilestones() ([]Milestone, error) {
+	all, err := c.ListMilestones()
+	if err != nil {
+		return nil, err
+	}
+
+	var open []Milestone
+	for _, m := range all {
+		if m.State == "open" {
+			open = append(open, m)
 		}
 	}
-	return milestones, nil
+
+	// Sort by due date (closest first)
+	sort.Slice(open, func(i, j int) bool {
+		return open[i].DueOn.Before(open[j].DueOn)
+	})
+
+	return open, nil
+}
+
+// GetOldestOpenMilestone returns the oldest open milestone by creation date
+// This is considered the "active" sprint
+func (c *Client) GetOldestOpenMilestone() (*Milestone, error) {
+	open, err := c.ListOpenMilestones()
+	if err != nil {
+		return nil, err
+	}
+	if len(open) == 0 {
+		return nil, nil
+	}
+	// ListOpenMilestones returns sorted by DueOn, we need oldest by CreatedAt
+	// So we need to find the one with earliest CreatedAt
+	oldest := &open[0]
+	for i := 1; i < len(open); i++ {
+		if open[i].CreatedAt.Before(oldest.CreatedAt) {
+			oldest = &open[i]
+		}
+	}
+	return oldest, nil
 }
 
 func (c *Client) SetMilestone(issueNum int, milestone string) error {

--- a/main.go
+++ b/main.go
@@ -177,6 +177,18 @@ func runServe() error {
 		fmt.Println("  ✓ sprint found")
 	}
 
+	// Detect and set the active sprint (oldest open milestone)
+	activeMilestone, err := gh.GetOldestOpenMilestone()
+	if err != nil {
+		return fmt.Errorf("detecting active sprint: %w", err)
+	}
+	if activeMilestone != nil {
+		gh.SetActiveMilestone(activeMilestone)
+		fmt.Printf("  ✓ active sprint: %s (due: %s)\n", activeMilestone.Title, activeMilestone.DueOn.Format("2006-01-02"))
+	} else {
+		fmt.Println("  ! no active sprint found")
+	}
+
 	projectName := cfg.GitHub.Repo
 	if idx := strings.LastIndex(projectName, "/"); idx >= 0 {
 		projectName = projectName[idx+1:]


### PR DESCRIPTION
## Summary

Automatically detects and sets the active sprint (oldest open milestone) during ODA startup.

## Changes

- Added `GetOldestOpenMilestone()` method to find oldest active sprint by creation date
- Added `ActiveMilestone` field to Client with getter/setter methods
- Set active sprint during "Verifying GitHub setup..." phase with logging
- Fixed `gh api` calls to use `ghNoRepoJSON` (avoids unsupported -R flag)

## Testing

- All tests pass
- Build successful

## Related

Related to #9