### PR TITLE
feat: define MVP Task struct and status constants

### DIFF
--- a/internal/mvp/task.go
+++ b/internal/mvp/task.go
@@ -1,0 +1,31 @@
+package mvp
+
+import "github.com/crazy-goat/one-dev-army/internal/github"
+
+type TaskStatus string
+
+const (
+	StatusPending    TaskStatus = "pending"
+	StatusAnalyzing  TaskStatus = "analyzing"
+	StatusPlanning   TaskStatus = "planning"
+	StatusCoding     TaskStatus = "coding"
+	StatusTesting    TaskStatus = "testing"
+	StatusCreatingPR TaskStatus = "creating_pr"
+	StatusDone       TaskStatus = "done"
+	StatusFailed     TaskStatus = "failed"
+)
+
+type Task struct {
+	Issue     github.Issue
+	Milestone string
+	Branch    string
+	Worktree  string
+	Status    TaskStatus
+	Result    *TaskResult
+}
+
+type TaskResult struct {
+	PRURL   string
+	Error   error
+	Summary string
+}


### PR DESCRIPTION
## Summary
- Adds `internal/mvp/task.go` with `Task`, `TaskStatus`, and `TaskResult` types
- Defines all 8 status constants: pending, analyzing, planning, coding, testing, creating_pr, done, failed

Closes #26