### PR TITLE
feat: add MVP Worker struct, constructor, slug helper, and extractText

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -26,6 +26,14 @@ func NewWorktreeManager(repoDir, worktreesDir string) *WorktreeManager {
 	}
 }
 
+func (m *WorktreeManager) WorktreesDir() string {
+	return m.worktreesDir
+}
+
+func (m *WorktreeManager) RepoDir() string {
+	return m.repoDir
+}
+
 func (m *WorktreeManager) Create(workerName, branch string) (*Worktree, error) {
 	wtPath := filepath.Join(m.worktreesDir, workerName)
 

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -1,0 +1,62 @@
+package mvp
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/crazy-goat/one-dev-army/internal/config"
+	"github.com/crazy-goat/one-dev-army/internal/git"
+	"github.com/crazy-goat/one-dev-army/internal/github"
+	"github.com/crazy-goat/one-dev-army/internal/opencode"
+)
+
+type Worker struct {
+	id      int
+	cfg     *config.Config
+	oc      *opencode.Client
+	gh      *github.Client
+	wtMgr   *git.WorktreeManager
+	baseDir string
+}
+
+func NewWorker(id int, cfg *config.Config, oc *opencode.Client, gh *github.Client, wtMgr *git.WorktreeManager) *Worker {
+	return &Worker{
+		id:      id,
+		cfg:     cfg,
+		oc:      oc,
+		gh:      gh,
+		wtMgr:   wtMgr,
+		baseDir: wtMgr.WorktreesDir(),
+	}
+}
+
+func (w *Worker) Process(ctx context.Context, task *Task) error {
+	return nil
+}
+
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+func slug(title string) string {
+	s := strings.ToLower(title)
+	s = slugRe.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 40 {
+		s = s[:40]
+		s = strings.TrimRight(s, "-")
+	}
+	return s
+}
+
+func extractText(msg *opencode.Message) string {
+	if msg == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, p := range msg.Parts {
+		if p.Type == "text" {
+			sb.WriteString(p.Text)
+		}
+	}
+	return sb.String()
+}


### PR DESCRIPTION
## Summary
- Adds `internal/mvp/worker.go` with `Worker` struct, `NewWorker` constructor, `slug()` helper, and `extractText()` helper
- Adds `WorktreesDir()` and `RepoDir()` accessor methods to `WorktreeManager`

Closes #28
Closes #38