### PR TITLE
feat: add WorktreeManager.PushBranch method

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -138,3 +138,13 @@ func RunInWorktree(wtPath, name string, args ...string) ([]byte, error) {
 	}
 	return out, nil
 }
+
+func (m *WorktreeManager) PushBranch(branch string) error {
+	cmd := exec.Command("git", "push", "-u", "origin", branch)
+	cmd.Dir = m.repoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git push -u origin %s: %w\n%s", branch, err, out)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `PushBranch(branch)` method to `WorktreeManager` that runs `git push -u origin <branch>`
- Sets up tracking for new branches needed before PR creation

Closes #39