### PR TITLE
feat: implement MVP Orchestrator with polling loop and start/pause

### DIFF
--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -1,0 +1,207 @@
+package mvp
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/crazy-goat/one-dev-army/internal/config"
+	"github.com/crazy-goat/one-dev-army/internal/git"
+	"github.com/crazy-goat/one-dev-army/internal/github"
+	"github.com/crazy-goat/one-dev-army/internal/opencode"
+)
+
+type Orchestrator struct {
+	cfg         *config.Config
+	worker      *Worker
+	gh          *github.Client
+	oc          *opencode.Client
+	wtMgr       *git.WorktreeManager
+	running     bool
+	paused      bool
+	processing  bool
+	currentTask *Task
+	mu          sync.Mutex
+}
+
+func NewOrchestrator(cfg *config.Config, gh *github.Client, oc *opencode.Client, wtMgr *git.WorktreeManager) *Orchestrator {
+	o := &Orchestrator{
+		cfg:    cfg,
+		gh:     gh,
+		oc:     oc,
+		wtMgr:  wtMgr,
+		paused: true,
+	}
+	o.worker = NewWorker(1, cfg, oc, gh, wtMgr)
+	return o
+}
+
+func (o *Orchestrator) Start() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.paused = false
+	log.Println("[Orchestrator] Started")
+}
+
+func (o *Orchestrator) Pause() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.paused = true
+	log.Println("[Orchestrator] Paused (will finish current ticket)")
+}
+
+func (o *Orchestrator) Stop() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.running = false
+}
+
+func (o *Orchestrator) IsPaused() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.paused
+}
+
+func (o *Orchestrator) IsProcessing() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.processing
+}
+
+func (o *Orchestrator) CurrentTask() *Task {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.currentTask
+}
+
+func (o *Orchestrator) Run(ctx context.Context) error {
+	o.mu.Lock()
+	o.running = true
+	o.mu.Unlock()
+
+	for {
+		o.mu.Lock()
+		running := o.running
+		paused := o.paused
+		o.mu.Unlock()
+
+		if !running {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if paused {
+			select {
+			case <-time.After(5 * time.Second):
+				continue
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		milestone, err := o.gh.GetOldestOpenMilestone()
+		if err != nil {
+			log.Printf("[Orchestrator] Error getting milestone: %v", err)
+			o.sleep(ctx, 30*time.Second)
+			continue
+		}
+		if milestone == nil {
+			log.Println("[Orchestrator] No active milestone, waiting...")
+			o.sleep(ctx, 30*time.Second)
+			continue
+		}
+
+		issues, err := o.gh.ListIssuesForMilestone(milestone.Title)
+		if err != nil {
+			log.Printf("[Orchestrator] Error listing issues: %v", err)
+			o.sleep(ctx, 30*time.Second)
+			continue
+		}
+
+		var nextIssue *github.Issue
+		for i := range issues {
+			if issues[i].State != "open" {
+				continue
+			}
+			if hasLabel(issues[i], "in-progress") || hasLabel(issues[i], "failed") {
+				continue
+			}
+			nextIssue = &issues[i]
+			break
+		}
+
+		if nextIssue == nil {
+			log.Println("[Orchestrator] No available issues in sprint, waiting...")
+			o.sleep(ctx, 30*time.Second)
+			continue
+		}
+
+		log.Printf("[Orchestrator] Processing #%d: %s", nextIssue.Number, nextIssue.Title)
+
+		if err := o.gh.AddLabel(nextIssue.Number, "in-progress"); err != nil {
+			log.Printf("[Orchestrator] Error adding in-progress label: %v", err)
+		}
+
+		task := &Task{
+			Issue:     *nextIssue,
+			Milestone: milestone.Title,
+			Status:    StatusPending,
+		}
+
+		o.mu.Lock()
+		o.processing = true
+		o.currentTask = task
+		o.mu.Unlock()
+
+		processErr := o.worker.Process(ctx, task)
+
+		o.mu.Lock()
+		o.processing = false
+		o.currentTask = nil
+		o.mu.Unlock()
+
+		if processErr != nil {
+			log.Printf("[Orchestrator] Failed #%d: %v", nextIssue.Number, processErr)
+			if err := o.gh.AddLabel(nextIssue.Number, "failed"); err != nil {
+				log.Printf("[Orchestrator] Error adding failed label: %v", err)
+			}
+		} else {
+			prURL := ""
+			if task.Result != nil {
+				prURL = task.Result.PRURL
+			}
+			log.Printf("[Orchestrator] Completed #%d: %s", nextIssue.Number, prURL)
+			if prURL != "" {
+				comment := fmt.Sprintf("Implemented in %s", prURL)
+				if err := o.gh.AddComment(nextIssue.Number, comment); err != nil {
+					log.Printf("[Orchestrator] Error adding comment: %v", err)
+				}
+			}
+		}
+
+		o.sleep(ctx, 5*time.Second)
+	}
+}
+
+func (o *Orchestrator) sleep(ctx context.Context, d time.Duration) {
+	select {
+	case <-time.After(d):
+	case <-ctx.Done():
+	}
+}
+
+func hasLabel(issue github.Issue, name string) bool {
+	for _, l := range issue.Labels {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds `internal/mvp/orchestrator.go` with full Orchestrator implementation
- Thread-safe start/pause/stop controls for dashboard integration
- Polling loop: finds active milestone -> picks open issues -> processes sequentially
- Starts in paused state, requires explicit `Start()` call from UI

Closes #34
Closes #35
Closes #51