### PR TITLE
feat: wire MVP orchestrator into main.go and dashboard (#36, #37, #52, #53)

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -21,14 +22,17 @@ type taskCard struct {
 }
 
 type boardData struct {
-	Active     string
-	SprintName string
-	Backlog    []taskCard
-	Progress   []taskCard
-	Review     []taskCard
-	Merging    []taskCard
-	Done       []taskCard
-	Blocked    []taskCard
+	Active       string
+	SprintName   string
+	Paused       bool
+	Processing   bool
+	CurrentIssue string
+	Backlog      []taskCard
+	Progress     []taskCard
+	Review       []taskCard
+	Merging      []taskCard
+	Done         []taskCard
+	Blocked      []taskCard
 }
 
 type backlogData struct {
@@ -80,6 +84,15 @@ func (s *Server) handleBoard(w http.ResponseWriter, r *http.Request) {
 func (s *Server) buildBoardData() boardData {
 	data := boardData{
 		Active: "board",
+		Paused: true,
+	}
+
+	if s.orchestrator != nil {
+		data.Paused = s.orchestrator.IsPaused()
+		data.Processing = s.orchestrator.IsProcessing()
+		if task := s.orchestrator.CurrentTask(); task != nil {
+			data.CurrentIssue = fmt.Sprintf("#%d: %s (%s)", task.Issue.Number, task.Issue.Title, task.Status)
+		}
 	}
 
 	// Get active milestone name
@@ -314,4 +327,60 @@ func placeholderWorkers() []workerCard {
 		{ID: "worker-2", Status: "idle"},
 		{ID: "worker-3", Status: "working", TaskID: 7, Task: "Add unit tests", Stage: "testing", Elapsed: "45s"},
 	}
+}
+
+func (s *Server) handleCurrentTask(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.orchestrator == nil {
+		json.NewEncoder(w).Encode(map[string]any{"active": false})
+		return
+	}
+	task := s.orchestrator.CurrentTask()
+	if task == nil {
+		json.NewEncoder(w).Encode(map[string]any{"active": false})
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{
+		"active":       true,
+		"issue_number": task.Issue.Number,
+		"issue_title":  task.Issue.Title,
+		"status":       string(task.Status),
+		"milestone":    task.Milestone,
+		"branch":       task.Branch,
+	})
+}
+
+func (s *Server) handleSprintStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.orchestrator == nil {
+		json.NewEncoder(w).Encode(map[string]any{"paused": true, "processing": false})
+		return
+	}
+	resp := map[string]any{
+		"paused":     s.orchestrator.IsPaused(),
+		"processing": s.orchestrator.IsProcessing(),
+	}
+	if task := s.orchestrator.CurrentTask(); task != nil {
+		resp["current_issue"] = task.Issue.Number
+		resp["current_status"] = string(task.Status)
+	}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handleSprintStart(w http.ResponseWriter, r *http.Request) {
+	if s.orchestrator == nil {
+		http.Error(w, "orchestrator not configured", http.StatusServiceUnavailable)
+		return
+	}
+	s.orchestrator.Start()
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func (s *Server) handleSprintPause(w http.ResponseWriter, r *http.Request) {
+	if s.orchestrator == nil {
+		http.Error(w, "orchestrator not configured", http.StatusServiceUnavailable)
+		return
+	}
+	s.orchestrator.Pause()
+	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/crazy-goat/one-dev-army/internal/db"
 	"github.com/crazy-goat/one-dev-army/internal/github"
+	"github.com/crazy-goat/one-dev-army/internal/mvp"
 	"github.com/crazy-goat/one-dev-army/internal/worker"
 )
 
@@ -22,11 +23,12 @@ type Server struct {
 	pool          func() []worker.WorkerInfo
 	gh            *github.Client
 	projectNumber int
+	orchestrator  *mvp.Orchestrator
 	mux           *http.ServeMux
 	httpSrv       *http.Server
 }
 
-func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, projectNumber int) (*Server, error) {
+func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, projectNumber int, orchestrator *mvp.Orchestrator) (*Server, error) {
 	tmpls, err := parseTemplates()
 	if err != nil {
 		return nil, err
@@ -40,6 +42,7 @@ func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *g
 		pool:          pool,
 		gh:            gh,
 		projectNumber: projectNumber,
+		orchestrator:  orchestrator,
 		mux:           mux,
 		httpSrv: &http.Server{
 			Addr:    fmt.Sprintf(":%d", port),
@@ -76,6 +79,10 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /backlog", s.handleBacklog)
 	s.mux.HandleFunc("GET /costs", s.handleCosts)
 	s.mux.HandleFunc("GET /api/workers", s.handleWorkers)
+	s.mux.HandleFunc("GET /api/current-task", s.handleCurrentTask)
+	s.mux.HandleFunc("GET /api/sprint/status", s.handleSprintStatus)
+	s.mux.HandleFunc("POST /api/sprint/start", s.handleSprintStart)
+	s.mux.HandleFunc("POST /api/sprint/pause", s.handleSprintPause)
 	s.mux.HandleFunc("POST /epic", s.handleAddEpic)
 	s.mux.HandleFunc("POST /sync", s.handleSync)
 	s.mux.HandleFunc("POST /plan-sprint", s.handlePlanSprint)

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -29,6 +29,18 @@
     {{if .SprintName}}<p style="color:var(--muted);font-size:.9rem;margin-top:.25rem">{{.SprintName}}</p>{{end}}
   </div>
   <div class="board-actions">
+    {{if .Paused}}
+    <form method="post" action="/api/sprint/start" style="display:inline">
+      <button type="submit" class="btn btn-success">Start Sprint</button>
+    </form>
+    {{else}}
+    <form method="post" action="/api/sprint/pause" style="display:inline">
+      <button type="submit" class="btn btn-danger">Pause Sprint</button>
+    </form>
+    {{end}}
+    {{if .Processing}}<span style="color:var(--green);font-size:.85rem;margin-left:.5rem">{{.CurrentIssue}}</span>{{end}}
+    {{if and (not .Paused) (not .Processing)}}<span style="color:var(--green);font-size:.85rem;margin-left:.5rem">Running</span>{{end}}
+    {{if .Paused}}<span style="color:var(--muted);font-size:.85rem;margin-left:.5rem">Paused</span>{{end}}
     <form method="post" action="/sync" style="display:inline">
       <button type="submit" class="btn">Sync</button>
     </form>

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -582,7 +582,7 @@ func TestDashboardRendering(t *testing.T) {
 		}
 	}
 
-	srv, err := dashboard.NewServer(0, store, poolFn, nil, 0)
+	srv, err := dashboard.NewServer(0, store, poolFn, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/crazy-goat/one-dev-army/internal/git"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 	"github.com/crazy-goat/one-dev-army/internal/initialize"
+	"github.com/crazy-goat/one-dev-army/internal/mvp"
 	"github.com/crazy-goat/one-dev-army/internal/opencode"
 	"github.com/crazy-goat/one-dev-army/internal/preflight"
 	"github.com/crazy-goat/one-dev-army/internal/setup"
@@ -214,6 +215,8 @@ func runServe() error {
 
 	processor := worker.NewProcessor(cfg, oc, gh, store, wtMgr)
 
+	orchestrator := mvp.NewOrchestrator(cfg, gh, oc, wtMgr)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -224,7 +227,13 @@ func runServe() error {
 	pool := worker.NewPool(cfg.Workers.Count, &worker.EmptyQueue{}, processor)
 	pool.Start(ctx)
 
-	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers, gh, project.Number)
+	go func() {
+		if err := orchestrator.Run(ctx); err != nil && err != context.Canceled {
+			fmt.Fprintf(os.Stderr, "orchestrator error: %v\n", err)
+		}
+	}()
+
+	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers, gh, project.Number, orchestrator)
 	if err != nil {
 		return fmt.Errorf("creating dashboard server: %w", err)
 	}
@@ -251,6 +260,7 @@ func runServe() error {
 	case <-sigCh:
 		fmt.Println("\nShutting down... Press Ctrl+C again to force quit.")
 		cancel()
+		orchestrator.Stop()
 
 		go func() {
 			<-sigCh


### PR DESCRIPTION
## Summary
- Wires MVP orchestrator into `main.go`: creates orchestrator, runs in goroutine, stops on shutdown (#36)
- Adds dashboard API endpoints for sprint control: `/api/current-task`, `/api/sprint/status`, `/api/sprint/start`, `/api/sprint/pause` (#37, #52)
- Adds Start/Pause Sprint buttons to board UI with conditional display and status indicators (#53)
- Updates `dashboard.NewServer` signature to accept orchestrator, fixes integration test

Closes #36, #37, #52, #53