### PR TITLE
test: add unit tests for MVP task, worker, and orchestrator (#44, #45, #46, #48)

### DIFF
--- a/internal/mvp/orchestrator_test.go
+++ b/internal/mvp/orchestrator_test.go
@@ -1,0 +1,156 @@
+package mvp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/crazy-goat/one-dev-army/internal/github"
+)
+
+func TestOrchestratorStartPause(t *testing.T) {
+	o := &Orchestrator{paused: true}
+
+	if !o.IsPaused() {
+		t.Error("new orchestrator should be paused")
+	}
+
+	o.Start()
+	if o.IsPaused() {
+		t.Error("orchestrator should not be paused after Start()")
+	}
+
+	o.Pause()
+	if !o.IsPaused() {
+		t.Error("orchestrator should be paused after Pause()")
+	}
+}
+
+func TestOrchestratorIsProcessing(t *testing.T) {
+	o := &Orchestrator{}
+
+	if o.IsProcessing() {
+		t.Error("new orchestrator should not be processing")
+	}
+
+	o.mu.Lock()
+	o.processing = true
+	o.mu.Unlock()
+
+	if !o.IsProcessing() {
+		t.Error("orchestrator should be processing")
+	}
+}
+
+func TestOrchestratorCurrentTask(t *testing.T) {
+	o := &Orchestrator{}
+
+	if o.CurrentTask() != nil {
+		t.Error("new orchestrator should have nil current task")
+	}
+
+	task := &Task{
+		Issue:  github.Issue{Number: 42, Title: "Test"},
+		Status: StatusCoding,
+	}
+
+	o.mu.Lock()
+	o.currentTask = task
+	o.mu.Unlock()
+
+	got := o.CurrentTask()
+	if got == nil {
+		t.Fatal("expected non-nil current task")
+	}
+	if got.Issue.Number != 42 {
+		t.Errorf("CurrentTask().Issue.Number = %d, want 42", got.Issue.Number)
+	}
+}
+
+func TestOrchestratorStop(t *testing.T) {
+	o := &Orchestrator{running: true}
+
+	o.Stop()
+
+	o.mu.Lock()
+	running := o.running
+	o.mu.Unlock()
+
+	if running {
+		t.Error("orchestrator should not be running after Stop()")
+	}
+}
+
+func TestOrchestratorRunContextCancel(t *testing.T) {
+	o := &Orchestrator{paused: true}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- o.Run(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Errorf("Run() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run() did not return after context cancel")
+	}
+}
+
+func TestOrchestratorRunStop(t *testing.T) {
+	o := &Orchestrator{paused: true}
+
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- o.Run(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	o.Stop()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run() error = %v, want nil", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run() did not return after Stop()")
+	}
+}
+
+func TestHasLabel(t *testing.T) {
+	issue := github.Issue{
+		Labels: []struct {
+			Name string `json:"name"`
+		}{
+			{Name: "in-progress"},
+			{Name: "bug"},
+		},
+	}
+
+	if !hasLabel(issue, "in-progress") {
+		t.Error("expected hasLabel to find 'in-progress'")
+	}
+	if !hasLabel(issue, "bug") {
+		t.Error("expected hasLabel to find 'bug'")
+	}
+	if hasLabel(issue, "feature") {
+		t.Error("expected hasLabel to not find 'feature'")
+	}
+}
+
+func TestHasLabelEmpty(t *testing.T) {
+	issue := github.Issue{}
+	if hasLabel(issue, "any") {
+		t.Error("expected hasLabel to return false for empty labels")
+	}
+}

--- a/internal/mvp/task_test.go
+++ b/internal/mvp/task_test.go
@@ -1,0 +1,99 @@
+package mvp
+
+import (
+	"testing"
+
+	"github.com/crazy-goat/one-dev-army/internal/github"
+)
+
+func TestTaskStatusConstants(t *testing.T) {
+	statuses := []TaskStatus{
+		StatusPending,
+		StatusAnalyzing,
+		StatusPlanning,
+		StatusCoding,
+		StatusTesting,
+		StatusCreatingPR,
+		StatusDone,
+		StatusFailed,
+	}
+
+	expected := []string{
+		"pending",
+		"analyzing",
+		"planning",
+		"coding",
+		"testing",
+		"creating_pr",
+		"done",
+		"failed",
+	}
+
+	if len(statuses) != len(expected) {
+		t.Fatalf("expected %d statuses, got %d", len(expected), len(statuses))
+	}
+
+	for i, s := range statuses {
+		if string(s) != expected[i] {
+			t.Errorf("status[%d] = %q, want %q", i, s, expected[i])
+		}
+	}
+}
+
+func TestTaskZeroValue(t *testing.T) {
+	var task Task
+	if task.Status != "" {
+		t.Errorf("zero-value Status = %q, want empty", task.Status)
+	}
+	if task.Result != nil {
+		t.Error("zero-value Result should be nil")
+	}
+	if task.Branch != "" {
+		t.Errorf("zero-value Branch = %q, want empty", task.Branch)
+	}
+	if task.Worktree != "" {
+		t.Errorf("zero-value Worktree = %q, want empty", task.Worktree)
+	}
+}
+
+func TestTaskWithIssue(t *testing.T) {
+	issue := github.Issue{
+		Number: 42,
+		Title:  "Add feature X",
+		Body:   "Description of feature X",
+		State:  "open",
+	}
+
+	task := Task{
+		Issue:     issue,
+		Milestone: "Sprint 1",
+		Status:    StatusPending,
+	}
+
+	if task.Issue.Number != 42 {
+		t.Errorf("Issue.Number = %d, want 42", task.Issue.Number)
+	}
+	if task.Milestone != "Sprint 1" {
+		t.Errorf("Milestone = %q, want %q", task.Milestone, "Sprint 1")
+	}
+	if task.Status != StatusPending {
+		t.Errorf("Status = %q, want %q", task.Status, StatusPending)
+	}
+}
+
+func TestTaskResult(t *testing.T) {
+	result := &TaskResult{
+		PRURL:   "https://github.com/owner/repo/pull/1",
+		Summary: "Implemented feature X",
+	}
+
+	if result.PRURL != "https://github.com/owner/repo/pull/1" {
+		t.Errorf("PRURL = %q, want PR URL", result.PRURL)
+	}
+	if result.Error != nil {
+		t.Error("Error should be nil for successful result")
+	}
+	if result.Summary != "Implemented feature X" {
+		t.Errorf("Summary = %q, want %q", result.Summary, "Implemented feature X")
+	}
+}

--- a/internal/mvp/worker_test.go
+++ b/internal/mvp/worker_test.go
@@ -1,0 +1,119 @@
+package mvp
+
+import (
+	"testing"
+
+	"github.com/crazy-goat/one-dev-army/internal/opencode"
+)
+
+func TestSlug(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Add feature X", "add-feature-x"},
+		{"Fix bug #123", "fix-bug-123"},
+		{"UPPERCASE TITLE", "uppercase-title"},
+		{"  spaces  around  ", "spaces-around"},
+		{"special!@#$%chars", "special-chars"},
+		{"", ""},
+		{"a", "a"},
+		{"already-slugged", "already-slugged"},
+		{"This is a very long title that should be truncated to forty characters maximum", "this-is-a-very-long-title-that-should-be"},
+		{"Trailing-dash-at-exactly-forty-characters", "trailing-dash-at-exactly-forty-character"},
+		{"dots.and.periods", "dots-and-periods"},
+		{"multiple---dashes", "multiple-dashes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := slug(tt.input)
+			if got != tt.want {
+				t.Errorf("slug(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugMaxLength(t *testing.T) {
+	long := "abcdefghijklmnopqrstuvwxyz-abcdefghijklmnopqrstuvwxyz"
+	got := slug(long)
+	if len(got) > 40 {
+		t.Errorf("slug length = %d, want <= 40", len(got))
+	}
+}
+
+func TestSlugNoTrailingDash(t *testing.T) {
+	input := "this title is exactly forty one chars long"
+	got := slug(input)
+	if len(got) > 0 && got[len(got)-1] == '-' {
+		t.Errorf("slug(%q) = %q, ends with dash", input, got)
+	}
+}
+
+func TestExtractText(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *opencode.Message
+		want string
+	}{
+		{
+			name: "nil message",
+			msg:  nil,
+			want: "",
+		},
+		{
+			name: "empty parts",
+			msg:  &opencode.Message{},
+			want: "",
+		},
+		{
+			name: "single text part",
+			msg: &opencode.Message{
+				Parts: []opencode.Part{
+					{Type: "text", Text: "hello world"},
+				},
+			},
+			want: "hello world",
+		},
+		{
+			name: "multiple text parts",
+			msg: &opencode.Message{
+				Parts: []opencode.Part{
+					{Type: "text", Text: "part1"},
+					{Type: "text", Text: "part2"},
+				},
+			},
+			want: "part1part2",
+		},
+		{
+			name: "mixed part types",
+			msg: &opencode.Message{
+				Parts: []opencode.Part{
+					{Type: "text", Text: "hello"},
+					{Type: "tool_use", Text: "ignored"},
+					{Type: "text", Text: " world"},
+				},
+			},
+			want: "hello world",
+		},
+		{
+			name: "no text parts",
+			msg: &opencode.Message{
+				Parts: []opencode.Part{
+					{Type: "tool_use", Text: "ignored"},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractText(tt.msg)
+			if got != tt.want {
+				t.Errorf("extractText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Unit tests for MVP Task types: status constants, zero values, issue wiring, result struct (#44)
- Unit tests for Worker slug function: edge cases, max length, trailing dash (#46)
- Unit tests for Worker extractText helper: nil, empty, single, multiple, mixed parts (#45)
- Unit tests for Orchestrator: start/pause/stop state, processing flag, current task, context cancellation, graceful stop, hasLabel helper (#48)

All 16 tests pass. Covers tickets #44, #45, #46, #48.

Closes #44, #45, #46, #48