### PR TITLE
Implement LLM log viewer with HTMX polling

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1032,6 +1032,12 @@ func (s *Server) handleWizardLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If session is complete, return 204 No Content to stop HTMX polling
+	if session.IsComplete() {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	logs := session.GetLogs()
 
 	data := struct {

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -263,6 +263,18 @@ func TestHandleWizardLogs(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404 for invalid session, got %d", rec.Code)
 	}
+
+	// Test polling stops when session is complete (returns 204 No Content)
+	session.SetStep(WizardStepDone)
+	req = httptest.NewRequest(http.MethodGet, "/wizard/logs/"+session.ID, nil)
+	req.SetPathValue("sessionId", session.ID)
+	rec = httptest.NewRecorder()
+
+	srv.handleWizardLogs(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected status 204 when session is complete, got %d", rec.Code)
+	}
 }
 
 // TestFullWizardFlow tests the complete wizard flow end-to-end

--- a/internal/dashboard/templates/wizard_breakdown.html
+++ b/internal/dashboard/templates/wizard_breakdown.html
@@ -35,7 +35,7 @@
     </div>
   </form>
   
-  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
+  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" hx-on::after-swap="this.scrollTop = this.scrollHeight" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
 </div>
 
 <style>

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -22,7 +22,7 @@
     </div>
   </form>
   
-  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
+  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" hx-on::after-swap="this.scrollTop = this.scrollHeight" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
 </div>
 
 <style>

--- a/internal/dashboard/wizard.go
+++ b/internal/dashboard/wizard.go
@@ -121,6 +121,13 @@ func (s *WizardSession) GetLogs() []LLMLogEntry {
 	return logs
 }
 
+// IsComplete returns true if the wizard session is done (thread-safe)
+func (s *WizardSession) IsComplete() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.CurrentStep == WizardStepDone
+}
+
 // WizardSessionStore manages all active wizard sessions in memory
 type WizardSessionStore struct {
 	sessions map[string]*WizardSession


### PR DESCRIPTION
Closes #19

## Parent Epic
Part of #15 — Feature Creation Wizard

## Description

Create a log viewer component that shows LLM processing output in real-time. Uses HTMX polling (every 1s) to fetch latest log entries from a backend endpoint. This component is reused in Step 1 (refinement) and Step 2 (task breakdown).

## Acceptance Criteria

- [ ] Log viewer panel displays LLM output as it is generated
- [ ] Polling interval is ~1 second (`hx-trigger="every 1s"`)
- [ ] Log panel auto-scrolls to the bottom as new content arrives
- [ ] Log panel is visually distinct (monospace font, terminal-like appearance)
- [ ] Polling stops automatically when LLM processing is complete
- [ ] Backend endpoint stores and serves log entries per wizard session
- [ ] Log viewer is a reusable template partial used in both Step 1 and Step 2