### PR TITLE
Design LLM prompts for idea refinement and task breakdown

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -708,8 +708,9 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build refinement prompt
-	prompt := buildRefinementPrompt(session.Type, idea)
+	// Build refinement prompt with codebase context
+	codebaseContext := GetCodebaseContext()
+	prompt := BuildRefinementPrompt(session.Type, idea, codebaseContext)
 	session.AddLog("system", "Sending refinement request to LLM")
 
 	// Send message to LLM with timeout
@@ -749,39 +750,6 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.render(w, "wizard_refine.html", data)
-}
-
-// buildRefinementPrompt creates the prompt for idea refinement
-func buildRefinementPrompt(wizardType WizardType, idea string) string {
-	if wizardType == WizardTypeBug {
-		return fmt.Sprintf(`You are a technical product manager helping to refine a bug report.
-
-Original bug description:
-%s
-
-Please refine this bug report to include:
-1. Clear description of the issue
-2. Steps to reproduce
-3. Expected vs actual behavior
-4. Impact/severity assessment
-5. Any additional context that would help developers
-
-Return a well-structured, professional bug description.`, idea)
-	}
-
-	return fmt.Sprintf(`You are a technical product manager helping to refine a feature idea.
-
-Original idea:
-%s
-
-Please refine this feature description to include:
-1. Clear problem statement
-2. Target users/personas
-3. Proposed solution overview
-4. Key acceptance criteria
-5. Any technical considerations or constraints
-
-Return a well-structured, professional feature description suitable for a GitHub issue.`, idea)
 }
 
 // handleWizardBreakdown sends description to LLM and returns task list
@@ -851,7 +819,7 @@ func (s *Server) handleWizardBreakdown(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build breakdown prompt with JSON schema requirement
-	prompt := buildBreakdownPrompt(session.Type, session.RefinedDescription)
+	prompt := BuildBreakdownPrompt(session.Type, session.RefinedDescription)
 	session.AddLog("system", "Sending breakdown request to LLM")
 
 	// Send message to LLM with timeout

--- a/internal/dashboard/prompts.go
+++ b/internal/dashboard/prompts.go
@@ -1,0 +1,148 @@
+package dashboard
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Prompt templates for the Feature/Bug Creation Wizard
+// These prompts are designed to work with LLMs to refine ideas and break them down into tasks
+
+// RefinementPromptTemplate is the base template for idea refinement
+// It instructs the LLM to analyze the idea in the context of the existing codebase
+const RefinementPromptTemplate = `You are a technical product manager helping to refine a %s.
+
+Analyze the following in the context of the existing codebase:
+
+=== EXISTING CODEBASE CONTEXT ===
+%s
+=== END CODEBASE CONTEXT ===
+
+Original %s:
+%s
+
+Please refine this %s to include:
+1. Clear %s
+2. %s
+3. %s
+4. %s
+5. %s
+6. Analysis of how this fits with existing codebase patterns and architecture
+
+IMPORTANT: Consider the codebase context above when refining. Look for:
+- Existing similar features or patterns you should follow
+- Technical constraints or requirements from the current stack
+- Integration points with existing code
+- Consistency with current architecture
+
+Return a well-structured, professional %s suitable for a GitHub issue.`
+
+// BreakdownPromptTemplate is the base template for task breakdown
+// It instructs the LLM to break down a technical description into actionable tasks
+const BreakdownPromptTemplate = `You are a technical project manager breaking down work into GitHub issues.
+
+%s description:
+%s
+
+Break this down into 3-7 specific, actionable tasks. For each task provide:
+- title: concise task title (max 80 chars)
+- description: detailed description that MUST include clear acceptance criteria (what "done" looks like)
+- priority: one of [low, medium, high, critical]
+- complexity: one of [S, M, L, XL] (S=1-2 hours, M=half day, L=1-2 days, XL=3+ days)
+
+CRITICAL CONSTRAINTS:
+1. DO NOT include implementation details, code snippets, or specific technical solutions in the description
+2. Focus on WHAT needs to be done and the acceptance criteria, NOT HOW to do it
+3. The description should be understandable by any team member, not just developers
+4. Each task description MUST end with a "Acceptance Criteria:" section listing 2-4 specific, verifiable criteria
+
+Return ONLY a JSON array in this exact format:
+[
+  {
+    "title": "Task title",
+    "description": "Task description with clear acceptance criteria at the end.\n\nAcceptance Criteria:\n- Criterion 1\n- Criterion 2\n- Criterion 3",
+    "priority": "high",
+    "complexity": "M"
+  }
+]
+
+No markdown, no explanation, just the JSON array.`
+
+// BuildRefinementPrompt creates the prompt for idea refinement with codebase context
+// wizardType: the type of wizard (feature or bug)
+// idea: the original user idea
+// codebaseContext: information about the existing codebase (file structure, key files, etc.)
+func BuildRefinementPrompt(wizardType WizardType, idea string, codebaseContext string) string {
+	if codebaseContext == "" {
+		codebaseContext = "No codebase context provided."
+	}
+
+	if wizardType == WizardTypeBug {
+		return fmt.Sprintf(RefinementPromptTemplate,
+			"bug report",                  // %s - role context
+			codebaseContext,               // %s - codebase context
+			"bug description",             // %s - original type
+			idea,                          // %s - original content
+			"bug report",                  // %s - output type
+			"description of the issue",    // %s - point 1
+			"Steps to reproduce",          // %s - point 2
+			"Expected vs actual behavior", // %s - point 3
+			"Impact/severity assessment",  // %s - point 4
+			"Any additional context that would help developers", // %s - point 5
+			"bug report", // %s - final output type
+		)
+	}
+
+	return fmt.Sprintf(RefinementPromptTemplate,
+		"feature idea",               // %s - role context
+		codebaseContext,              // %s - codebase context
+		"idea",                       // %s - original type
+		idea,                         // %s - original content
+		"feature description",        // %s - output type
+		"problem statement",          // %s - point 1
+		"Target users/personas",      // %s - point 2
+		"Proposed solution overview", // %s - point 3
+		"Key acceptance criteria",    // %s - point 4
+		"Technical considerations or constraints", // %s - point 5
+		"feature description",                     // %s - final output type
+	)
+}
+
+// BuildBreakdownPrompt creates the prompt for task breakdown
+// wizardType: the type of wizard (feature or bug)
+// description: the refined technical description
+func BuildBreakdownPrompt(wizardType WizardType, description string) string {
+	var typeLabel string
+	if wizardType == WizardTypeBug {
+		typeLabel = "Bug fix"
+	} else {
+		typeLabel = "Feature"
+	}
+
+	return fmt.Sprintf(BreakdownPromptTemplate, typeLabel, description)
+}
+
+// GetCodebaseContext gathers context about the existing codebase
+// This is a placeholder implementation that can be enhanced to:
+// - Read key configuration files (package.json, go.mod, etc.)
+// - Get file structure from git
+// - Analyze existing patterns in the codebase
+// Returns a string summarizing the codebase context
+func GetCodebaseContext() string {
+	// For now, return a minimal context
+	// In a full implementation, this could:
+	// 1. Run git ls-files to get file structure
+	// 2. Read key config files (go.mod, package.json, etc.)
+	// 3. Sample existing code patterns
+	// 4. Limit to top N files to avoid token limits
+
+	var context strings.Builder
+	context.WriteString("Project Structure:\n")
+	context.WriteString("- Go-based backend service\n")
+	context.WriteString("- Uses standard project layout (internal/, cmd/, etc.)\n")
+	context.WriteString("- Dashboard package for web UI and wizard functionality\n")
+	context.WriteString("- GitHub integration for issue management\n")
+	context.WriteString("- LLM integration via OpenCode API\n")
+
+	return context.String()
+}

--- a/internal/dashboard/wizard_test.go
+++ b/internal/dashboard/wizard_test.go
@@ -282,27 +282,51 @@ func TestParseTaskJSON_MultipleTasks(t *testing.T) {
 }
 
 func TestBuildRefinementPrompt_Feature(t *testing.T) {
-	prompt := buildRefinementPrompt(WizardTypeFeature, "Create a login page")
+	codebaseContext := "Project uses Go with standard layout"
+	prompt := BuildRefinementPrompt(WizardTypeFeature, "Create a login page", codebaseContext)
 	if !strings.Contains(prompt, "feature idea") {
 		t.Error("expected prompt to mention 'feature idea'")
 	}
 	if !strings.Contains(prompt, "Create a login page") {
 		t.Error("expected prompt to contain the original idea")
 	}
+	if !strings.Contains(prompt, codebaseContext) {
+		t.Error("expected prompt to contain codebase context")
+	}
+	if !strings.Contains(prompt, "EXISTING CODEBASE CONTEXT") {
+		t.Error("expected prompt to contain codebase context section header")
+	}
+	if !strings.Contains(prompt, "how this fits with existing codebase patterns") {
+		t.Error("expected prompt to instruct analyzing codebase patterns")
+	}
 }
 
 func TestBuildRefinementPrompt_Bug(t *testing.T) {
-	prompt := buildRefinementPrompt(WizardTypeBug, "Login is broken")
+	codebaseContext := "Project uses Go with standard layout"
+	prompt := BuildRefinementPrompt(WizardTypeBug, "Login is broken", codebaseContext)
 	if !strings.Contains(prompt, "bug report") {
 		t.Error("expected prompt to mention 'bug report'")
 	}
 	if !strings.Contains(prompt, "Steps to reproduce") {
 		t.Error("expected prompt to ask for steps to reproduce")
 	}
+	if !strings.Contains(prompt, codebaseContext) {
+		t.Error("expected prompt to contain codebase context")
+	}
+	if !strings.Contains(prompt, "EXISTING CODEBASE CONTEXT") {
+		t.Error("expected prompt to contain codebase context section header")
+	}
+}
+
+func TestBuildRefinementPrompt_EmptyCodebaseContext(t *testing.T) {
+	prompt := BuildRefinementPrompt(WizardTypeFeature, "Create a login page", "")
+	if !strings.Contains(prompt, "No codebase context provided") {
+		t.Error("expected prompt to handle empty codebase context gracefully")
+	}
 }
 
 func TestBuildBreakdownPrompt(t *testing.T) {
-	prompt := buildBreakdownPrompt(WizardTypeFeature, "A feature description")
+	prompt := BuildBreakdownPrompt(WizardTypeFeature, "A feature description")
 	if !strings.Contains(prompt, "JSON array") {
 		t.Error("expected prompt to mention JSON array")
 	}
@@ -311,6 +335,96 @@ func TestBuildBreakdownPrompt(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "A feature description") {
 		t.Error("expected prompt to contain the description")
+	}
+	if !strings.Contains(prompt, "DO NOT include implementation details") {
+		t.Error("expected prompt to explicitly forbid implementation details")
+	}
+	if !strings.Contains(prompt, "Acceptance Criteria:") {
+		t.Error("expected prompt to require acceptance criteria")
+	}
+	if !strings.Contains(prompt, "WHAT needs to be done") {
+		t.Error("expected prompt to focus on WHAT not HOW")
+	}
+}
+
+func TestBuildBreakdownPrompt_BugType(t *testing.T) {
+	prompt := BuildBreakdownPrompt(WizardTypeBug, "A bug description")
+	if !strings.Contains(prompt, "Bug fix description") {
+		t.Error("expected prompt to use 'Bug fix' label for bug type")
+	}
+	if !strings.Contains(prompt, "DO NOT include implementation details") {
+		t.Error("expected prompt to explicitly forbid implementation details")
+	}
+}
+
+func TestBuildBreakdownPrompt_ForbidsImplementationDetails(t *testing.T) {
+	prompt := BuildBreakdownPrompt(WizardTypeFeature, "Some feature")
+
+	// Check for explicit prohibition
+	if !strings.Contains(prompt, "DO NOT include implementation details") {
+		t.Error("expected prompt to explicitly forbid implementation details")
+	}
+	if !strings.Contains(prompt, "code snippets") {
+		t.Error("expected prompt to forbid code snippets")
+	}
+	if !strings.Contains(prompt, "specific technical solutions") {
+		t.Error("expected prompt to forbid specific technical solutions")
+	}
+
+	// Check for focus on WHAT not HOW
+	if !strings.Contains(prompt, "WHAT needs to be done") {
+		t.Error("expected prompt to focus on WHAT")
+	}
+	if !strings.Contains(prompt, "NOT HOW to do it") {
+		t.Error("expected prompt to explicitly say NOT HOW")
+	}
+}
+
+func TestBuildBreakdownPrompt_RequiresAcceptanceCriteria(t *testing.T) {
+	prompt := BuildBreakdownPrompt(WizardTypeFeature, "Some feature")
+
+	if !strings.Contains(prompt, "Acceptance Criteria:") {
+		t.Error("expected prompt to require acceptance criteria section")
+	}
+	if !strings.Contains(prompt, "MUST include clear acceptance criteria") {
+		t.Error("expected prompt to require acceptance criteria in description")
+	}
+	if !strings.Contains(prompt, "what \"done\" looks like") {
+		t.Error("expected prompt to define what done looks like")
+	}
+}
+
+func TestBuildBreakdownPrompt_ValidJSONStructure(t *testing.T) {
+	prompt := BuildBreakdownPrompt(WizardTypeFeature, "Some feature")
+
+	// Check for JSON format requirements
+	if !strings.Contains(prompt, "Return ONLY a JSON array") {
+		t.Error("expected prompt to require JSON array output")
+	}
+	if !strings.Contains(prompt, `"title"`) {
+		t.Error("expected prompt to specify title field in JSON")
+	}
+	if !strings.Contains(prompt, `"description"`) {
+		t.Error("expected prompt to specify description field in JSON")
+	}
+	if !strings.Contains(prompt, `"priority"`) {
+		t.Error("expected prompt to specify priority field in JSON")
+	}
+	if !strings.Contains(prompt, `"complexity"`) {
+		t.Error("expected prompt to specify complexity field in JSON")
+	}
+	if !strings.Contains(prompt, "No markdown, no explanation, just the JSON array") {
+		t.Error("expected prompt to forbid markdown and explanations")
+	}
+}
+
+func TestGetCodebaseContext(t *testing.T) {
+	context := GetCodebaseContext()
+	if context == "" {
+		t.Error("expected non-empty codebase context")
+	}
+	if !strings.Contains(context, "Project Structure") {
+		t.Error("expected context to mention project structure")
 	}
 }
 


### PR DESCRIPTION
Closes #23

## Parent Epic
Part of #15 — Feature Creation Wizard

## Description

Design and implement the LLM prompts used in the wizard. Two prompts are needed: one for refining a user's idea into a technical description (Step 1), and one for breaking down a description into technical tasks (Step 2). Prompts should instruct the LLM to use codebase context, avoid implementation details in tasks, and return structured output (JSON).

## Acceptance Criteria

- [ ] Refinement prompt takes user idea and produces a technical description
- [ ] Refinement prompt instructs LLM to consider codebase context
- [ ] Breakdown prompt takes a technical description and produces a list of tasks
- [ ] Each task in breakdown output includes: title, description with acceptance criteria, priority, complexity
- [ ] Breakdown prompt explicitly forbids implementation details in tasks
- [ ] Output format is structured (JSON) for reliable parsing
- [ ] Prompts are defined as constants/templates in a dedicated file
- [ ] Both prompts include the wizard type (feature vs bug) for context