### PR TITLE
Implement Step 1: Idea input with LLM refinement

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -646,9 +646,11 @@ func (s *Server) handleWizardNew(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		Type      string
 		SessionID string
+		IdeaText  string
 	}{
 		Type:      wizardType,
 		SessionID: session.ID,
+		IdeaText:  session.IdeaText,
 	}
 
 	s.render(w, "wizard_new.html", data)
@@ -663,9 +665,21 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 
 	sessionID := r.FormValue("session_id")
 	idea := r.FormValue("idea")
+	refinedText := r.FormValue("refined_text")
 
-	if sessionID == "" || idea == "" {
-		http.Error(w, "missing session_id or idea", http.StatusBadRequest)
+	if sessionID == "" {
+		http.Error(w, "missing session_id", http.StatusBadRequest)
+		return
+	}
+
+	// Use refined_text if provided (for iterations), otherwise use idea
+	inputText := idea
+	if refinedText != "" {
+		inputText = refinedText
+	}
+
+	if inputText == "" {
+		http.Error(w, "missing idea or refined_text", http.StatusBadRequest)
 		return
 	}
 
@@ -675,25 +689,30 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Store the idea
-	session.IdeaText = idea
+	// Store the idea (only on first iteration)
+	if idea != "" {
+		session.IdeaText = idea
+	}
 	session.SetStep(WizardStepRefine)
-	session.AddLog("user", idea)
+	session.AddLog("user", inputText)
 
 	// If no opencode client, return mock response for testing
 	if s.oc == nil {
-		mockRefined := "Refined: " + idea + "\n\nThis feature would allow users to authenticate securely."
+		iteration := session.RefinementIteration
+		mockRefined := fmt.Sprintf("Refined (iteration %d): %s\n\nThis feature would allow users to authenticate securely.", iteration+1, inputText)
 		session.SetRefinedDescription(mockRefined)
 		session.AddLog("assistant", mockRefined)
 
 		data := struct {
-			SessionID          string
-			Type               string
-			RefinedDescription string
+			SessionID           string
+			Type                string
+			RefinedDescription  string
+			RefinementIteration int
 		}{
-			SessionID:          session.ID,
-			Type:               string(session.Type),
-			RefinedDescription: mockRefined,
+			SessionID:           session.ID,
+			Type:                string(session.Type),
+			RefinedDescription:  mockRefined,
+			RefinementIteration: session.RefinementIteration,
 		}
 
 		s.render(w, "wizard_refine.html", data)
@@ -709,8 +728,8 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build refinement prompt
-	prompt := buildRefinementPrompt(session.Type, idea)
-	session.AddLog("system", "Sending refinement request to LLM")
+	prompt := buildRefinementPrompt(session.Type, inputText)
+	session.AddLog("system", "Sending refinement request to LLM (iteration "+fmt.Sprintf("%d", session.RefinementIteration+1)+")")
 
 	// Send message to LLM with timeout
 	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
@@ -739,13 +758,15 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	s.oc.DeleteSession(llmSession.ID)
 
 	data := struct {
-		SessionID          string
-		Type               string
-		RefinedDescription string
+		SessionID           string
+		Type                string
+		RefinedDescription  string
+		RefinementIteration int
 	}{
-		SessionID:          session.ID,
-		Type:               string(session.Type),
-		RefinedDescription: refinedDesc,
+		SessionID:           session.ID,
+		Type:                string(session.Type),
+		RefinedDescription:  refinedDesc,
+		RefinementIteration: session.RefinementIteration,
 	}
 
 	s.render(w, "wizard_refine.html", data)

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -667,3 +667,153 @@ func TestMiddlewareChain(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 }
+
+// TestHandleWizardRefine_MultipleIterations tests that refined text can be re-refined
+func TestHandleWizardRefine_MultipleIterations(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session
+	session, _ := srv.wizardStore.Create("feature")
+
+	// First refinement with initial idea
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+	formData.Set("idea", "Create a login page")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Fatalf("First refinement failed: expected status 200 or 500, got %d", rec.Code)
+	}
+
+	// Verify first refinement worked
+	session, _ = srv.wizardStore.Get(session.ID)
+	if session.RefinementIteration != 1 {
+		t.Errorf("Expected iteration 1 after first refinement, got %d", session.RefinementIteration)
+	}
+	if session.IdeaText != "Create a login page" {
+		t.Errorf("Expected idea text to be preserved, got %q", session.IdeaText)
+	}
+
+	// Second refinement with refined_text (iteration)
+	firstRefined := session.RefinedDescription
+	formData = url.Values{}
+	formData.Set("session_id", session.ID)
+	formData.Set("refined_text", firstRefined)
+
+	req = httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Fatalf("Second refinement failed: expected status 200 or 500, got %d", rec.Code)
+	}
+
+	// Verify second refinement worked
+	session, _ = srv.wizardStore.Get(session.ID)
+	if session.RefinementIteration != 2 {
+		t.Errorf("Expected iteration 2 after second refinement, got %d", session.RefinementIteration)
+	}
+	if session.IdeaText != "Create a login page" {
+		t.Errorf("Expected original idea text to be preserved, got %q", session.IdeaText)
+	}
+
+	// Verify logs were added for both iterations
+	logs := session.GetLogs()
+	if len(logs) < 4 { // Should have: user (idea), system, assistant, user (refined), system, assistant
+		t.Errorf("Expected at least 4 log entries, got %d", len(logs))
+	}
+}
+
+// TestHandleWizardRefine_RefinedTextOnly tests refinement with only refined_text (no idea)
+func TestHandleWizardRefine_RefinedTextOnly(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session with existing idea
+	session, _ := srv.wizardStore.Create("feature")
+	session.IdeaText = "Original idea"
+
+	// Refinement with only refined_text
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+	formData.Set("refined_text", "Already refined description")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 200 or 500, got %d", rec.Code)
+	}
+
+	// Verify original idea is preserved
+	session, _ = srv.wizardStore.Get(session.ID)
+	if session.IdeaText != "Original idea" {
+		t.Errorf("Expected original idea to be preserved, got %q", session.IdeaText)
+	}
+}
+
+// TestHandleWizardRefine_MissingSessionID tests error handling for missing session_id
+func TestHandleWizardRefine_MissingSessionID(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test with missing session_id but with idea
+	formData := url.Values{}
+	formData.Set("idea", "Some idea")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for missing session_id, got %d", rec.Code)
+	}
+}
+
+// TestHandleWizardRefine_MissingBothIdeaAndRefinedText tests error handling when both idea and refined_text are missing
+func TestHandleWizardRefine_MissingBothIdeaAndRefinedText(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session
+	session, _ := srv.wizardStore.Create("feature")
+
+	// Test with session_id but no idea or refined_text
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for missing idea and refined_text, got %d", rec.Code)
+	}
+}

--- a/internal/dashboard/templates/wizard_new.html
+++ b/internal/dashboard/templates/wizard_new.html
@@ -8,19 +8,19 @@
     
     <div class="form-group">
       <label for="idea">Describe your {{if eq .Type "bug"}}bug{{else}}feature idea{{end}}:</label>
-      <textarea id="idea" name="idea" rows="6" placeholder="{{if eq .Type "bug"}}Describe the bug, steps to reproduce, and expected behavior...{{else}}Describe the feature, who it's for, and what problem it solves...{{end}}" required></textarea>
+      <textarea id="idea" name="idea" rows="6" placeholder="{{if eq .Type "bug"}}Describe the bug, steps to reproduce, and expected behavior...{{else}}Describe the feature, who it's for, and what problem it solves...{{end}}" required>{{.IdeaText}}</textarea>
     </div>
     
     <div class="form-actions">
       <button type="button" class="btn" onclick="closeWizardModal()">Cancel</button>
-      <button type="submit" class="btn btn-primary">
+      <button type="submit" class="btn btn-primary" id="refine-btn">
         <span class="spinner" style="display:none;">⏳</span>
         <span class="label">Refine with AI</span>
       </button>
     </div>
   </form>
   
-  <div id="wizard-logs" style="margin-top: 1rem;"></div>
+  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
 </div>
 
 <style>
@@ -45,5 +45,6 @@
 .form-actions { display: flex; justify-content: space-between; gap: 0.5rem; margin-top: 1.5rem; }
 .htmx-request .spinner { display: inline !important; }
 .htmx-request .label { display: none; }
+.htmx-request .btn { opacity: 0.7; pointer-events: none; }
 </style>
 {{end}}

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -1,26 +1,30 @@
 <div class="wizard-step">
-  <h2>Refined Description</h2>
+  <h2>Refined Description {{if gt .RefinementIteration 0}}(Iteration {{.RefinementIteration}}){{end}}</h2>
   
   <div class="refined-content">
     <p class="description">{{.RefinedDescription}}</p>
   </div>
   
-  <form hx-post="/wizard/breakdown" hx-target="#wizard-modal-content" hx-swap="innerHTML">
-    <input type="hidden" name="session_id" value="{{.SessionID}}">
-    
-    <div class="form-actions">
-      <button type="button" class="btn" onclick="closeWizardModal()">Cancel</button>
-      <div class="nav-buttons">
-        <button type="button" class="btn" hx-get="/wizard/new?type={{.Type}}&amp;session_id={{.SessionID}}" hx-target="#wizard-modal-content">
-          ← Back
-        </button>
-        <button type="submit" class="btn btn-primary">
+  <div class="form-actions">
+    <button type="button" class="btn" onclick="closeWizardModal()">Cancel</button>
+    <div class="nav-buttons">
+      <form hx-post="/wizard/refine" hx-target="#wizard-modal-content" hx-swap="innerHTML" style="display: inline;">
+        <input type="hidden" name="session_id" value="{{.SessionID}}">
+        <input type="hidden" name="refined_text" value="{{.RefinedDescription}}">
+        <button type="submit" class="btn" id="refine-again-btn">
           <span class="spinner" style="display:none;">⏳</span>
-          <span class="label">Break Down into Tasks</span>
+          <span class="label">↻ Refine Again</span>
         </button>
-      </div>
+      </form>
+      <form hx-post="/wizard/breakdown" hx-target="#wizard-modal-content" hx-swap="innerHTML" style="display: inline;">
+        <input type="hidden" name="session_id" value="{{.SessionID}}">
+        <button type="submit" class="btn btn-primary" id="accept-continue-btn">
+          <span class="spinner" style="display:none;">⏳</span>
+          <span class="label">Accept & Continue →</span>
+        </button>
+      </form>
     </div>
-  </form>
+  </div>
   
   <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
 </div>
@@ -43,4 +47,5 @@
 .nav-buttons { display: flex; gap: 0.5rem; }
 .htmx-request .spinner { display: inline !important; }
 .htmx-request .label { display: none; }
+.htmx-request .btn { opacity: 0.7; pointer-events: none; }
 </style>

--- a/internal/dashboard/wizard.go
+++ b/internal/dashboard/wizard.go
@@ -62,16 +62,17 @@ type WizardTask struct {
 
 // WizardSession holds the state for a single wizard instance
 type WizardSession struct {
-	ID                 string        `json:"id"`
-	Type               WizardType    `json:"type"`
-	CurrentStep        WizardStep    `json:"current_step"`
-	IdeaText           string        `json:"idea_text"`
-	RefinedDescription string        `json:"refined_description"`
-	Tasks              []WizardTask  `json:"tasks"`
-	LLMLogs            []LLMLogEntry `json:"llm_logs"`
-	CreatedAt          time.Time     `json:"created_at"`
-	UpdatedAt          time.Time     `json:"updated_at"`
-	mu                 sync.RWMutex  `json:"-"`
+	ID                  string        `json:"id"`
+	Type                WizardType    `json:"type"`
+	CurrentStep         WizardStep    `json:"current_step"`
+	IdeaText            string        `json:"idea_text"`
+	RefinedDescription  string        `json:"refined_description"`
+	RefinementIteration int           `json:"refinement_iteration"`
+	Tasks               []WizardTask  `json:"tasks"`
+	LLMLogs             []LLMLogEntry `json:"llm_logs"`
+	CreatedAt           time.Time     `json:"created_at"`
+	UpdatedAt           time.Time     `json:"updated_at"`
+	mu                  sync.RWMutex  `json:"-"`
 }
 
 // AddLog adds a new log entry to the session (thread-safe)
@@ -100,6 +101,7 @@ func (s *WizardSession) SetRefinedDescription(desc string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.RefinedDescription = desc
+	s.RefinementIteration++
 	s.UpdatedAt = time.Now()
 }
 

--- a/internal/dashboard/wizard_test.go
+++ b/internal/dashboard/wizard_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -184,6 +185,15 @@ func TestWizardSession_SetRefinedDescription(t *testing.T) {
 	session.SetRefinedDescription("Refined description")
 	if session.RefinedDescription != "Refined description" {
 		t.Errorf("expected refined description, got %q", session.RefinedDescription)
+	}
+	if session.RefinementIteration != 1 {
+		t.Errorf("expected refinement iteration 1, got %d", session.RefinementIteration)
+	}
+
+	// Second refinement should increment counter
+	session.SetRefinedDescription("Further refined description")
+	if session.RefinementIteration != 2 {
+		t.Errorf("expected refinement iteration 2, got %d", session.RefinementIteration)
 	}
 }
 
@@ -393,6 +403,51 @@ func TestValidWizardTypes(t *testing.T) {
 	}
 	if ValidWizardTypes["invalid"] {
 		t.Error("'invalid' should not be a valid wizard type")
+	}
+}
+
+func TestWizardSession_RefinementIteration(t *testing.T) {
+	session := &WizardSession{
+		ID:   "test-id",
+		Type: "feature",
+	}
+
+	// Initially should be 0
+	if session.RefinementIteration != 0 {
+		t.Errorf("expected initial iteration 0, got %d", session.RefinementIteration)
+	}
+
+	// Increment through refinements
+	for i := 1; i <= 5; i++ {
+		session.SetRefinedDescription(fmt.Sprintf("Refined version %d", i))
+		if session.RefinementIteration != i {
+			t.Errorf("expected iteration %d, got %d", i, session.RefinementIteration)
+		}
+	}
+}
+
+func TestWizardSession_ConcurrentRefinement(t *testing.T) {
+	session := &WizardSession{
+		ID:   "test-id",
+		Type: "feature",
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrent refinements
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			session.SetRefinedDescription(fmt.Sprintf("Refined %d", i))
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Should have exactly 100 iterations
+	if session.RefinementIteration != 100 {
+		t.Errorf("expected 100 refinement iterations, got %d", session.RefinementIteration)
 	}
 }
 


### PR DESCRIPTION
Closes #18

## Parent Epic
Part of #15 — Feature Creation Wizard

## Description

Implement the first step of the wizard where the user enters their idea in a textarea. A "Refine" button sends the idea to the LLM (via OpenCode API) which generates a more technical description using codebase context. The user can click "Refine" multiple times. When satisfied, they click "Accept & Continue" to proceed to Step 2.

## Acceptance Criteria

- [ ] Textarea for user to input their idea (plain text)
- [ ] "Refine" button triggers an LLM call via OpenCode API
- [ ] LLM receives the user's idea and generates a technical description
- [ ] Refined description is displayed below/replacing the original input
- [ ] User can click "Refine" multiple times to iterate
- [ ] "Accept & Continue" button proceeds to Step 2 with the accepted description
- [ ] While LLM is processing, a log panel shows LLM output (see #19)
- [ ] Refine button is disabled while LLM is processing
- [ ] Error states are handled gracefully (LLM timeout, connection failure)