### PR TITLE
Implement Step 3: Create GitHub issues (epic + sub-tasks)

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1008,7 +1008,7 @@ Return ONLY a JSON array in this exact format:
 No markdown, no explanation, just the JSON array.`, wizardType, description)
 }
 
-// handleWizardCreate creates GitHub issues and returns confirmation
+// handleWizardCreate creates GitHub issues with epic + sub-task structure
 func (s *Server) handleWizardCreate(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "invalid form data", http.StatusBadRequest)
@@ -1033,77 +1033,178 @@ func (s *Server) handleWizardCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	session.SetStep(WizardStepCreate)
-	session.AddLog("system", fmt.Sprintf("Creating %d GitHub issues", len(session.Tasks)))
+	session.AddLog("system", fmt.Sprintf("Creating epic + %d sub-tasks", len(session.Tasks)))
 
 	// If no GitHub client, return mock confirmation for testing
 	if s.gh == nil {
-		mockIssues := []struct {
-			Number int
-			Title  string
-			URL    string
-		}{
-			{Number: 101, Title: session.Tasks[0].Title, URL: "https://github.com/test/issues/101"},
-			{Number: 102, Title: session.Tasks[1].Title, URL: "https://github.com/test/issues/102"},
+		mockEpic := CreatedIssue{
+			Number:  100,
+			Title:   session.RefinedDescription,
+			URL:     "https://github.com/test/issues/100",
+			IsEpic:  true,
+			Success: true,
 		}
-		session.AddLog("system", "Mock: Created 2 issues")
+		mockSubTasks := []CreatedIssue{
+			{Number: 101, Title: session.Tasks[0].Title, URL: "https://github.com/test/issues/101", IsEpic: false, Success: true},
+			{Number: 102, Title: session.Tasks[1].Title, URL: "https://github.com/test/issues/102", IsEpic: false, Success: true},
+		}
+		session.SetCreatedIssues(append([]CreatedIssue{mockEpic}, mockSubTasks...))
+		session.SetEpicNumber(100)
+		session.AddLog("system", "Mock: Created epic #100 with 2 sub-tasks")
 
 		data := struct {
-			CreatedIssues []struct {
-				Number int
-				Title  string
-				URL    string
-			}
+			Epic      CreatedIssue
+			SubTasks  []CreatedIssue
+			HasErrors bool
 		}{
-			CreatedIssues: mockIssues,
+			Epic:      mockEpic,
+			SubTasks:  mockSubTasks,
+			HasErrors: false,
 		}
 
-		// Clean up session after mock creation to free memory
 		s.wizardStore.Delete(sessionID)
-
 		s.render(w, "wizard_create.html", data)
 		return
 	}
 
-	// Create GitHub issues for each task
-	type createdIssue struct {
-		Number int
-		Title  string
-		URL    string
+	// Step 1: Create Epic First (abort on failure)
+	epicLabels := []string{"epic"}
+	if session.Type == WizardTypeFeature {
+		epicLabels = append(epicLabels, "enhancement")
+	} else if session.Type == WizardTypeBug {
+		epicLabels = append(epicLabels, "bug")
 	}
-	var createdIssues []createdIssue
 
+	epicBody := fmt.Sprintf("## Summary\n\n%s\n\n## Sub-tasks\n\n*Sub-tasks will be linked here after creation.*",
+		session.RefinedDescription)
+
+	epicNum, err := s.gh.CreateIssue(session.RefinedDescription, epicBody, epicLabels)
+	if err != nil {
+		log.Printf("[Wizard] Error creating epic: %v", err)
+		session.AddLog("system", fmt.Sprintf("Error creating epic: %v", err))
+		http.Error(w, fmt.Sprintf("Failed to create epic: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	session.SetEpicNumber(epicNum)
+	epicIssue := CreatedIssue{
+		Number:  epicNum,
+		Title:   session.RefinedDescription,
+		URL:     fmt.Sprintf("https://github.com/%s/issues/%d", s.gh.Repo, epicNum),
+		IsEpic:  true,
+		Success: true,
+	}
+	session.AddCreatedIssue(epicIssue)
+	session.AddLog("system", fmt.Sprintf("Created epic #%d", epicNum))
+
+	// Step 2: Create Sub-tasks (continue on individual failures)
+	var subTaskLinks []string
 	for _, task := range session.Tasks {
-		// Build issue body
-		body := fmt.Sprintf("## Description\n\n%s\n\n## Priority\n%s\n\n## Complexity\n%s",
+		// Map priority to label
+		priorityLabel := ""
+		switch strings.ToLower(task.Priority) {
+		case "critical", "high":
+			priorityLabel = "priority:high"
+		case "medium":
+			priorityLabel = "priority:medium"
+		case "low":
+			priorityLabel = "priority:low"
+		}
+
+		// Map complexity to size label
+		sizeLabel := ""
+		switch strings.ToUpper(task.Complexity) {
+		case "S":
+			sizeLabel = "size:S"
+		case "M":
+			sizeLabel = "size:M"
+		case "L":
+			sizeLabel = "size:L"
+		case "XL":
+			sizeLabel = "size:XL"
+		}
+
+		// Build labels array
+		labels := []string{"wizard"}
+		if priorityLabel != "" {
+			labels = append(labels, priorityLabel)
+		}
+		if sizeLabel != "" {
+			labels = append(labels, sizeLabel)
+		}
+
+		// Build sub-task body with parent reference
+		body := fmt.Sprintf("## Description\n\n%s\n\n---\n\n**Parent Epic:** #%d\n**Priority:** %s\n**Complexity:** %s",
 			task.Description,
+			epicNum,
 			task.Priority,
 			task.Complexity,
 		)
 
-		// Create the issue
-		issueNum, err := s.gh.CreateIssue(task.Title, body, []string{"wizard"})
+		// Create the sub-task issue
+		issueNum, err := s.gh.CreateIssue(task.Title, body, labels)
 		if err != nil {
-			log.Printf("[Wizard] Error creating issue for task %q: %v", task.Title, err)
-			session.AddLog("system", fmt.Sprintf("Error creating issue: %v", err))
+			log.Printf("[Wizard] Error creating sub-task %q: %v", task.Title, err)
+			session.AddLog("system", fmt.Sprintf("Error creating sub-task %q: %v", task.Title, err))
+			session.AddCreatedIssue(CreatedIssue{
+				Title:   task.Title,
+				IsEpic:  false,
+				Success: false,
+				Error:   err.Error(),
+			})
 			continue
 		}
 
-		createdIssues = append(createdIssues, createdIssue{
-			Number: issueNum,
-			Title:  task.Title,
-			URL:    fmt.Sprintf("https://github.com/%s/issues/%d", s.gh.Repo, issueNum),
-		})
+		issueURL := fmt.Sprintf("https://github.com/%s/issues/%d", s.gh.Repo, issueNum)
+		subTaskLinks = append(subTaskLinks, fmt.Sprintf("- #%d: %s", issueNum, task.Title))
 
-		session.AddLog("system", fmt.Sprintf("Created issue #%d: %s", issueNum, task.Title))
+		session.AddCreatedIssue(CreatedIssue{
+			Number:  issueNum,
+			Title:   task.Title,
+			URL:     issueURL,
+			IsEpic:  false,
+			Success: true,
+		})
+		session.AddLog("system", fmt.Sprintf("Created sub-task #%d: %s", issueNum, task.Title))
+	}
+
+	// Step 3: Update Epic Body with sub-task links
+	if len(subTaskLinks) > 0 {
+		updatedEpicBody := fmt.Sprintf("## Summary\n\n%s\n\n## Sub-tasks\n\n%s",
+			session.RefinedDescription,
+			strings.Join(subTaskLinks, "\n"),
+		)
+		if err := s.gh.UpdateIssueBody(epicNum, updatedEpicBody); err != nil {
+			log.Printf("[Wizard] Error updating epic body: %v", err)
+			session.AddLog("system", fmt.Sprintf("Error updating epic body: %v", err))
+		} else {
+			session.AddLog("system", fmt.Sprintf("Updated epic #%d with %d sub-task links", epicNum, len(subTaskLinks)))
+		}
+	}
+
+	// Prepare data for template
+	var subTasks []CreatedIssue
+	hasErrors := false
+	for _, issue := range session.CreatedIssues {
+		if !issue.IsEpic {
+			subTasks = append(subTasks, issue)
+			if !issue.Success {
+				hasErrors = true
+			}
+		}
 	}
 
 	data := struct {
-		CreatedIssues []createdIssue
+		Epic      CreatedIssue
+		SubTasks  []CreatedIssue
+		HasErrors bool
 	}{
-		CreatedIssues: createdIssues,
+		Epic:      epicIssue,
+		SubTasks:  subTasks,
+		HasErrors: hasErrors,
 	}
 
-	// Clean up session after successful creation to free memory
+	// Clean up session after creation to free memory
 	s.wizardStore.Delete(sessionID)
 
 	s.render(w, "wizard_create.html", data)

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 	"net/http/httptest"
@@ -735,5 +736,273 @@ func TestLayoutNavigationButtons(t *testing.T) {
 	// Check for nav-actions container
 	if !strings.Contains(output, "nav-actions") {
 		t.Error("layout template missing nav-actions container div")
+	}
+}
+
+// TestHandleWizardCreate_EpicFirst verifies that epic is created before sub-tasks
+func TestHandleWizardCreate_EpicFirst(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+		gh:          nil,
+	}
+	defer srv.wizardStore.Stop()
+
+	session, _ := srv.wizardStore.Create("feature")
+	session.SetRefinedDescription("Test Epic")
+	session.SetTasks([]WizardTask{
+		{Title: "Sub-task 1", Description: "Description 1", Priority: "high", Complexity: "M"},
+		{Title: "Sub-task 2", Description: "Description 2", Priority: "medium", Complexity: "S"},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/create", strings.NewReader("session_id="+session.ID))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardCreate(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 200 or 500, got %d", rec.Code)
+	}
+}
+
+// TestHandleWizardCreate_LabelMapping tests priority and complexity label conversion
+func TestHandleWizardCreate_LabelMapping(t *testing.T) {
+	testCases := []struct {
+		name       string
+		priority   string
+		complexity string
+		wantLabels []string
+	}{
+		{
+			name:       "critical priority + XL size",
+			priority:   "critical",
+			complexity: "XL",
+			wantLabels: []string{"wizard", "priority:high", "size:XL"},
+		},
+		{
+			name:       "high priority + L size",
+			priority:   "high",
+			complexity: "L",
+			wantLabels: []string{"wizard", "priority:high", "size:L"},
+		},
+		{
+			name:       "medium priority + M size",
+			priority:   "medium",
+			complexity: "M",
+			wantLabels: []string{"wizard", "priority:medium", "size:M"},
+		},
+		{
+			name:       "low priority + S size",
+			priority:   "low",
+			complexity: "S",
+			wantLabels: []string{"wizard", "priority:low", "size:S"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Verify label mapping logic is correct
+			var labels []string
+			labels = append(labels, "wizard")
+
+			switch tc.priority {
+			case "critical", "high":
+				labels = append(labels, "priority:high")
+			case "medium":
+				labels = append(labels, "priority:medium")
+			case "low":
+				labels = append(labels, "priority:low")
+			}
+
+			switch tc.complexity {
+			case "S":
+				labels = append(labels, "size:S")
+			case "M":
+				labels = append(labels, "size:M")
+			case "L":
+				labels = append(labels, "size:L")
+			case "XL":
+				labels = append(labels, "size:XL")
+			}
+
+			if len(labels) != len(tc.wantLabels) {
+				t.Errorf("expected %d labels, got %d: %v", len(tc.wantLabels), len(labels), labels)
+			}
+			for i, label := range labels {
+				if label != tc.wantLabels[i] {
+					t.Errorf("expected label %d to be %q, got %q", i, tc.wantLabels[i], label)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleWizardCreate_EpicLabels tests epic label assignment based on type
+func TestHandleWizardCreate_EpicLabels(t *testing.T) {
+	testCases := []struct {
+		name       string
+		wizardType string
+		wantLabels []string
+	}{
+		{
+			name:       "feature type",
+			wizardType: "feature",
+			wantLabels: []string{"epic", "enhancement"},
+		},
+		{
+			name:       "bug type",
+			wizardType: "bug",
+			wantLabels: []string{"epic", "bug"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Verify epic label logic
+			var epicLabels []string
+			epicLabels = append(epicLabels, "epic")
+			if tc.wizardType == "feature" {
+				epicLabels = append(epicLabels, "enhancement")
+			} else if tc.wizardType == "bug" {
+				epicLabels = append(epicLabels, "bug")
+			}
+
+			if len(epicLabels) != len(tc.wantLabels) {
+				t.Errorf("expected %d epic labels, got %d: %v", len(tc.wantLabels), len(epicLabels), epicLabels)
+			}
+			for i, label := range epicLabels {
+				if label != tc.wantLabels[i] {
+					t.Errorf("expected epic label %d to be %q, got %q", i, tc.wantLabels[i], label)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleWizardCreate_MissingSession tests error when session is missing
+func TestHandleWizardCreate_MissingSession(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/create", strings.NewReader("session_id=invalid"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardCreate(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for invalid session, got %d", rec.Code)
+	}
+}
+
+// TestHandleWizardCreate_MissingSessionID tests error when session_id is missing
+func TestHandleWizardCreate_MissingSessionID(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/create", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardCreate(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for missing session_id, got %d", rec.Code)
+	}
+}
+
+// TestCreatedIssue_Tracking tests the CreatedIssue struct and tracking methods
+func TestCreatedIssue_Tracking(t *testing.T) {
+	store := NewWizardSessionStore()
+	defer store.Stop()
+
+	session, _ := store.Create("feature")
+
+	// Test AddCreatedIssue
+	epic := CreatedIssue{
+		Number:  100,
+		Title:   "Test Epic",
+		URL:     "https://github.com/test/issues/100",
+		IsEpic:  true,
+		Success: true,
+	}
+	session.AddCreatedIssue(epic)
+
+	if len(session.CreatedIssues) != 1 {
+		t.Errorf("expected 1 created issue, got %d", len(session.CreatedIssues))
+	}
+
+	// Test SetCreatedIssues
+	subTasks := []CreatedIssue{
+		{Number: 101, Title: "Task 1", IsEpic: false, Success: true},
+		{Number: 102, Title: "Task 2", IsEpic: false, Success: true},
+	}
+	session.SetCreatedIssues(subTasks)
+
+	if len(session.CreatedIssues) != 2 {
+		t.Errorf("expected 2 created issues after SetCreatedIssues, got %d", len(session.CreatedIssues))
+	}
+
+	// Test SetEpicNumber
+	session.SetEpicNumber(100)
+	if session.EpicNumber != 100 {
+		t.Errorf("expected epic number 100, got %d", session.EpicNumber)
+	}
+}
+
+// TestHandleWizardCreate_EpicBodyFormat tests the epic body format
+func TestHandleWizardCreate_EpicBodyFormat(t *testing.T) {
+	refinedDesc := "Test Epic Description"
+	expectedBody := "## Summary\n\nTest Epic Description\n\n## Sub-tasks\n\n*Sub-tasks will be linked here after creation.*"
+
+	// Verify the initial epic body format
+	body := fmt.Sprintf("## Summary\n\n%s\n\n## Sub-tasks\n\n*Sub-tasks will be linked here after creation.*",
+		refinedDesc)
+
+	if body != expectedBody {
+		t.Errorf("epic body format mismatch\nexpected: %s\ngot: %s", expectedBody, body)
+	}
+
+	// Verify the updated epic body format with sub-tasks
+	subTaskLinks := []string{"- #101: Task 1", "- #102: Task 2"}
+	updatedBody := fmt.Sprintf("## Summary\n\n%s\n\n## Sub-tasks\n\n%s",
+		refinedDesc,
+		strings.Join(subTaskLinks, "\n"),
+	)
+
+	expectedUpdatedBody := "## Summary\n\nTest Epic Description\n\n## Sub-tasks\n\n- #101: Task 1\n- #102: Task 2"
+	if updatedBody != expectedUpdatedBody {
+		t.Errorf("updated epic body format mismatch\nexpected: %s\ngot: %s", expectedUpdatedBody, updatedBody)
+	}
+}
+
+// TestHandleWizardCreate_SubTaskBodyFormat tests the sub-task body format
+func TestHandleWizardCreate_SubTaskBodyFormat(t *testing.T) {
+	task := WizardTask{
+		Title:       "Test Task",
+		Description: "Test Description",
+		Priority:    "high",
+		Complexity:  "M",
+	}
+	epicNum := 100
+
+	expectedBody := "## Description\n\nTest Description\n\n---\n\n**Parent Epic:** #100\n**Priority:** high\n**Complexity:** M"
+
+	body := fmt.Sprintf("## Description\n\n%s\n\n---\n\n**Parent Epic:** #%d\n**Priority:** %s\n**Complexity:** %s",
+		task.Description,
+		epicNum,
+		task.Priority,
+		task.Complexity,
+	)
+
+	if body != expectedBody {
+		t.Errorf("sub-task body format mismatch\nexpected: %s\ngot: %s", expectedBody, body)
 	}
 }

--- a/internal/dashboard/templates/wizard_create.html
+++ b/internal/dashboard/templates/wizard_create.html
@@ -1,17 +1,43 @@
 <div class="wizard-step">
   <h2>✅ Issues Created Successfully</h2>
   
-  <p class="subtitle">The following GitHub issues have been created:</p>
+  {{if .HasErrors}}
+  <div class="error-banner">
+    <strong>⚠️ Some sub-tasks failed to create.</strong> Check the list below for details.
+  </div>
+  {{end}}
   
-  <div class="issue-list">
-    {{range .CreatedIssues}}
-    <div class="issue-card">
-      <a href="{{.URL}}" target="_blank" class="issue-link">
-        <span class="issue-number">#{{.Number}}</span>
-        <span class="issue-title">{{.Title}}</span>
+  <div class="epic-section">
+    <h3>📋 Epic</h3>
+    <div class="issue-card epic-card">
+      <a href="{{.Epic.URL}}" target="_blank" class="issue-link">
+        <span class="issue-number">#{{.Epic.Number}}</span>
+        <span class="issue-title">{{.Epic.Title}}</span>
+        <span class="issue-badge epic-badge">EPIC</span>
       </a>
     </div>
-    {{end}}
+  </div>
+  
+  <div class="subtasks-section">
+    <h3>📝 Sub-tasks ({{len .SubTasks}})</h3>
+    <div class="issue-list">
+      {{range .SubTasks}}
+      <div class="issue-card {{if not .Success}}issue-failed{{end}}">
+        {{if .Success}}
+        <a href="{{.URL}}" target="_blank" class="issue-link">
+          <span class="issue-number">#{{.Number}}</span>
+          <span class="issue-title">{{.Title}}</span>
+        </a>
+        {{else}}
+        <div class="issue-link failed">
+          <span class="issue-number">❌</span>
+          <span class="issue-title">{{.Title}}</span>
+          <span class="error-text">{{.Error}}</span>
+        </div>
+        {{end}}
+      </div>
+      {{end}}
+    </div>
   </div>
   
   <div class="form-actions">
@@ -25,24 +51,80 @@
 <style>
 .wizard-step { max-width: 800px; margin: 0 auto; }
 .subtitle { color: var(--muted); margin-bottom: 1rem; }
+
+.error-banner {
+  background: #fee;
+  border: 1px solid #fcc;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  color: #c33;
+}
+
+.epic-section { margin-bottom: 1.5rem; }
+.epic-section h3 { margin-bottom: 0.5rem; color: var(--text); }
+
+.subtasks-section h3 { margin-bottom: 0.5rem; color: var(--text); }
+
 .issue-list { display: flex; flex-direction: column; gap: 0.5rem; margin: 1rem 0; }
+
 .issue-card {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 6px;
   padding: 0.75rem 1rem;
 }
+
+.epic-card {
+  background: linear-gradient(135deg, var(--surface) 0%, rgba(99, 102, 241, 0.1) 100%);
+  border-color: var(--accent);
+  border-width: 2px;
+}
+
+.issue-failed {
+  background: #fee;
+  border-color: #fcc;
+}
+
 .issue-link {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  text-decoration: none;
 }
+
+.issue-link.failed {
+  color: #c33;
+}
+
 .issue-number {
   color: var(--accent);
   font-weight: 600;
+  min-width: 3rem;
 }
+
 .issue-title {
   color: var(--text);
+  flex: 1;
 }
+
+.issue-badge {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+.epic-badge {
+  background: var(--accent);
+  color: white;
+}
+
+.error-text {
+  font-size: 0.875rem;
+  color: #c33;
+  margin-left: auto;
+}
+
 .form-actions { display: flex; justify-content: space-between; gap: 0.5rem; margin-top: 1.5rem; }
 </style>

--- a/internal/dashboard/wizard.go
+++ b/internal/dashboard/wizard.go
@@ -63,18 +63,30 @@ type WizardTask struct {
 	Complexity  string `json:"complexity"` // "S", "M", "L", "XL"
 }
 
+// CreatedIssue tracks a GitHub issue created by the wizard
+type CreatedIssue struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	IsEpic  bool   `json:"is_epic"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
 // WizardSession holds the state for a single wizard instance
 type WizardSession struct {
-	ID                 string        `json:"id"`
-	Type               WizardType    `json:"type"`
-	CurrentStep        WizardStep    `json:"current_step"`
-	IdeaText           string        `json:"idea_text"`
-	RefinedDescription string        `json:"refined_description"`
-	Tasks              []WizardTask  `json:"tasks"`
-	LLMLogs            []LLMLogEntry `json:"llm_logs"`
-	CreatedAt          time.Time     `json:"created_at"`
-	UpdatedAt          time.Time     `json:"updated_at"`
-	mu                 sync.RWMutex  `json:"-"`
+	ID                 string         `json:"id"`
+	Type               WizardType     `json:"type"`
+	CurrentStep        WizardStep     `json:"current_step"`
+	IdeaText           string         `json:"idea_text"`
+	RefinedDescription string         `json:"refined_description"`
+	Tasks              []WizardTask   `json:"tasks"`
+	CreatedIssues      []CreatedIssue `json:"created_issues"`
+	EpicNumber         int            `json:"epic_number"`
+	LLMLogs            []LLMLogEntry  `json:"llm_logs"`
+	CreatedAt          time.Time      `json:"created_at"`
+	UpdatedAt          time.Time      `json:"updated_at"`
+	mu                 sync.RWMutex   `json:"-"`
 }
 
 // AddLog adds a new log entry to the session (thread-safe)
@@ -119,6 +131,30 @@ func (s *WizardSession) SetIdeaText(idea string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.IdeaText = idea
+	s.UpdatedAt = time.Now()
+}
+
+// SetCreatedIssues updates the created issues list (thread-safe)
+func (s *WizardSession) SetCreatedIssues(issues []CreatedIssue) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.CreatedIssues = issues
+	s.UpdatedAt = time.Now()
+}
+
+// AddCreatedIssue appends a single created issue (thread-safe)
+func (s *WizardSession) AddCreatedIssue(issue CreatedIssue) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.CreatedIssues = append(s.CreatedIssues, issue)
+	s.UpdatedAt = time.Now()
+}
+
+// SetEpicNumber sets the epic issue number (thread-safe)
+func (s *WizardSession) SetEpicNumber(num int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.EpicNumber = num
 	s.UpdatedAt = time.Now()
 }
 

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -238,6 +238,15 @@ func (c *Client) CloseIssue(issueNum int) error {
 	return nil
 }
 
+// UpdateIssueBody updates the body of an existing issue
+func (c *Client) UpdateIssueBody(issueNum int, body string) error {
+	_, err := c.gh("issue", "edit", strconv.Itoa(issueNum), "--body", body)
+	if err != nil {
+		return fmt.Errorf("updating body of issue #%d: %w", issueNum, err)
+	}
+	return nil
+}
+
 func (c *Client) ListOpenIssues() ([]Issue, error) {
 	args := []string{"issue", "list", "--state", "open", "--json", "number,title,body,state,assignees,labels", "--limit", "500"}
 	var issues []Issue


### PR DESCRIPTION
Closes #21

## Parent Epic
Part of #15 — Feature Creation Wizard

## Description

Implement the final step of the wizard. Upon user acceptance, create all GitHub issues: one business-level epic issue and individual technical sub-task issues. The epic body links to all sub-tasks. Each sub-task body references the parent epic. Issues are created without a milestone (they wait for the next sprint planning).

## Acceptance Criteria

- [ ] One epic issue is created with label `epic` and `enhancement` (or `bug` based on wizard type)
- [ ] Epic issue body contains a summary and links to all sub-task issues
- [ ] Individual technical issues are created with:
  - Appropriate priority label (`priority:high/medium/low`)
  - Appropriate size label (`size:S/M/L/XL`)
  - Reference to parent epic in the body
- [ ] No milestone is assigned to any created issue
- [ ] Confirmation view shows all created issues with links to GitHub
- [ ] Errors during issue creation are handled gracefully (partial creation recovery)
- [ ] Modal can be closed after confirmation