### PR TITLE
Implement Step 1: Idea input with LLM refinement

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -888,6 +888,125 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	s.render(w, "wizard_refine.html", data)
 }
 
+// handleWizardRefineAgain re-refines the existing description using LLM
+func (s *Server) handleWizardRefineAgain(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form data. Please try again.", http.StatusBadRequest)
+		return
+	}
+
+	sessionID := r.FormValue("session_id")
+	if sessionID == "" {
+		http.Error(w, "Session ID is required.", http.StatusBadRequest)
+		return
+	}
+
+	session, ok := s.wizardStore.Get(sessionID)
+	if !ok {
+		http.Error(w, "Session not found. Please start over.", http.StatusNotFound)
+		return
+	}
+
+	// Get the current refined description to use as input
+	currentDescription := session.RefinedDescription
+	if currentDescription == "" {
+		// Fall back to idea text if no refined description exists
+		currentDescription = session.IdeaText
+	}
+
+	if currentDescription == "" {
+		http.Error(w, "No description available to refine. Please go back and enter an idea.", http.StatusBadRequest)
+		return
+	}
+
+	session.AddLog("user", "Requesting further refinement")
+
+	// If no opencode client, return mock response for testing
+	if s.oc == nil {
+		mockRefined := "Further refined: " + currentDescription + "\n\nThis version includes additional clarity and technical details."
+		session.SetRefinedDescription(mockRefined)
+		session.AddLog("assistant", mockRefined)
+
+		data := struct {
+			SessionID          string
+			Type               string
+			RefinedDescription string
+			Error              string
+		}{
+			SessionID:          session.ID,
+			Type:               string(session.Type),
+			RefinedDescription: mockRefined,
+		}
+
+		s.render(w, "wizard_refine.html", data)
+		return
+	}
+
+	// Create LLM session for refinement
+	llmSession, err := s.oc.CreateSession("Wizard Refinement - Iteration")
+	if err != nil {
+		log.Printf("[Wizard] Error creating LLM session: %v", err)
+		http.Error(w, "Unable to connect to AI service. Please try again in a moment.", http.StatusServiceUnavailable)
+		return
+	}
+	defer func() {
+		if err := s.oc.DeleteSession(llmSession.ID); err != nil {
+			log.Printf("[Wizard] Error deleting LLM session %s: %v", llmSession.ID, err)
+		}
+	}()
+
+	// Build refinement prompt with codebase context
+	codebaseContext := GetCodebaseContext()
+	prompt := BuildRefinementPrompt(session.Type, currentDescription, codebaseContext)
+	session.AddLog("system", "Sending refinement request to LLM (iteration)")
+
+	// Send message to LLM with timeout
+	ctx, cancel := context.WithTimeout(r.Context(), LLMRequestTimeout)
+	defer cancel()
+
+	model := opencode.ParseModelRef(DefaultLLMModel)
+	var output strings.Builder
+	response, err := s.oc.SendMessageStream(ctx, llmSession.ID, prompt, model, &output)
+	if err != nil {
+		log.Printf("[Wizard] Error from LLM: %v", err)
+		session.AddLog("system", "LLM error: "+err.Error())
+
+		// Determine appropriate error message based on error type
+		statusCode := http.StatusInternalServerError
+		errorMsg := "Failed to refine description. Please try again."
+
+		if ctx.Err() == context.DeadlineExceeded {
+			statusCode = http.StatusGatewayTimeout
+			errorMsg = "The AI service is taking too long to respond. Please try again."
+		}
+
+		http.Error(w, errorMsg, statusCode)
+		return
+	}
+
+	// Extract refined description from response
+	var refinedDesc string
+	if len(response.Parts) > 0 {
+		refinedDesc = response.Parts[0].Text
+	}
+
+	session.SetRefinedDescription(refinedDesc)
+	session.AddLog("assistant", refinedDesc)
+
+	data := struct {
+		SessionID          string
+		Type               string
+		RefinedDescription string
+		Error              string
+	}{
+		SessionID:          session.ID,
+		Type:               string(session.Type),
+		RefinedDescription: refinedDesc,
+	}
+
+	s.render(w, "wizard_refine.html", data)
+}
+
 // handleWizardBreakdown sends description to LLM and returns task list
 func (s *Server) handleWizardBreakdown(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -737,3 +737,119 @@ func TestLayoutNavigationButtons(t *testing.T) {
 		t.Error("layout template missing nav-actions container div")
 	}
 }
+
+func TestHandleWizardRefineAgain_Success(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session with refined description
+	session, _ := srv.wizardStore.Create("feature")
+	session.SetRefinedDescription("Initial refined description")
+
+	// Test with valid session
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine-again", strings.NewReader("session_id="+session.ID))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefineAgain(rec, req)
+
+	// Should accept the request (actual LLM call would need mocking)
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 200 or 500, got %d", rec.Code)
+	}
+
+	// Verify session still exists and has been updated
+	updated, ok := srv.wizardStore.Get(session.ID)
+	if !ok {
+		t.Error("session should still exist after refine-again")
+	}
+	if updated.RefinedDescription == "" {
+		t.Error("refined description should not be empty after refine-again")
+	}
+}
+
+func TestHandleWizardRefineAgain_NoSession(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test with invalid session
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine-again", strings.NewReader("session_id=invalid"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefineAgain(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("expected status 404 for invalid session, got %d", rec.Code)
+	}
+}
+
+func TestHandleWizardRefineAgain_NoDescription(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session without any description
+	session, _ := srv.wizardStore.Create("feature")
+	// Don't set any description
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine-again", strings.NewReader("session_id="+session.ID))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefineAgain(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for missing description, got %d", rec.Code)
+	}
+}
+
+func TestHandleWizardRefineAgain_FallbackToIdea(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session with only idea text (no refined description)
+	session, _ := srv.wizardStore.Create("feature")
+	session.SetIdeaText("My original idea")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine-again", strings.NewReader("session_id="+session.ID))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefineAgain(rec, req)
+
+	// Should work by falling back to idea text
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 200 or 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleWizardRefineAgain_MissingSessionID(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test with missing session_id
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine-again", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefineAgain(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for missing session_id, got %d", rec.Code)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -270,6 +270,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /wizard/modal", s.rateLimitMiddleware(s.handleWizardModal))
 	s.mux.HandleFunc("POST /wizard/cancel", chainMiddleware(s.handleWizardCancel, s.rateLimitMiddleware, s.csrfMiddleware))
 	s.mux.HandleFunc("POST /wizard/refine", chainMiddleware(s.handleWizardRefine, s.rateLimitMiddleware, s.csrfMiddleware))
+	s.mux.HandleFunc("POST /wizard/refine-again", chainMiddleware(s.handleWizardRefineAgain, s.rateLimitMiddleware, s.csrfMiddleware))
 	s.mux.HandleFunc("POST /wizard/breakdown", chainMiddleware(s.handleWizardBreakdown, s.rateLimitMiddleware, s.csrfMiddleware))
 	s.mux.HandleFunc("POST /wizard/create", chainMiddleware(s.handleWizardCreate, s.rateLimitMiddleware, s.csrfMiddleware))
 	s.mux.HandleFunc("GET /wizard/logs/{sessionId}", s.rateLimitMiddleware(s.handleWizardLogs))

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -17,7 +17,7 @@
         <button type="button" class="btn" hx-get="/wizard/new?type={{.Type}}&amp;session_id={{.SessionID}}" hx-target="#wizard-modal-content">
           ← Back
         </button>
-        <button type="button" class="btn btn-secondary" hx-post="/wizard/refine-again" hx-target="#wizard-modal-content" hx-disabled-elt="button[type='submit']">
+        <button type="button" class="btn btn-secondary" hx-post="/wizard/refine-again" hx-target="#wizard-modal-content" hx-disabled-elt="this">
           <span class="spinner" style="display:none;">⏳</span>
           <span class="label">Refine Again</span>
         </button>


### PR DESCRIPTION
Closes #18

## Parent Epic
Part of #15 — Feature Creation Wizard

## Description

Implement the first step of the wizard where the user enters their idea in a textarea. A "Refine" button sends the idea to the LLM (via OpenCode API) which generates a more technical description using codebase context. The user can click "Refine" multiple times. When satisfied, they click "Accept & Continue" to proceed to Step 2.

## Acceptance Criteria

- [ ] Textarea for user to input their idea (plain text)
- [ ] "Refine" button triggers an LLM call via OpenCode API
- [ ] LLM receives the user's idea and generates a technical description
- [ ] Refined description is displayed below/replacing the original input
- [ ] User can click "Refine" multiple times to iterate
- [ ] "Accept & Continue" button proceeds to Step 2 with the accepted description
- [ ] While LLM is processing, a log panel shows LLM output (see #19)
- [ ] Refine button is disabled while LLM is processing
- [ ] Error states are handled gracefully (LLM timeout, connection failure)