### PR TITLE
Implement LLM log viewer with HTMX polling

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1239,6 +1239,14 @@ func (s *Server) handleWizardLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if the session has moved past the expected step
+	// If so, return 204 to stop HTMX polling
+	expectedStep := r.Header.Get("X-Expected-Step")
+	if expectedStep != "" && string(session.CurrentStep) != expectedStep {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
 	logs := session.GetLogs()
 
 	data := struct {

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -264,6 +264,31 @@ func TestHandleWizardLogs(t *testing.T) {
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status 404 for invalid session, got %d", rec.Code)
 	}
+
+	// Test with mismatched step - should return 204 to stop polling
+	session.SetStep(WizardStepBreakdown) // Move session to breakdown step
+	req = httptest.NewRequest(http.MethodGet, "/wizard/logs/"+session.ID, nil)
+	req.SetPathValue("sessionId", session.ID)
+	req.Header.Set("X-Expected-Step", "refine") // But expect refine step
+	rec = httptest.NewRecorder()
+
+	srv.handleWizardLogs(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected status 204 when step mismatch, got %d", rec.Code)
+	}
+
+	// Test with matching step - should return 200
+	req = httptest.NewRequest(http.MethodGet, "/wizard/logs/"+session.ID, nil)
+	req.SetPathValue("sessionId", session.ID)
+	req.Header.Set("X-Expected-Step", "breakdown") // Expect breakdown step
+	rec = httptest.NewRecorder()
+
+	srv.handleWizardLogs(rec, req)
+
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 200 or 500 when step matches, got %d", rec.Code)
+	}
 }
 
 // TestFullWizardFlow tests the complete wizard flow end-to-end

--- a/internal/dashboard/templates/wizard_breakdown.html
+++ b/internal/dashboard/templates/wizard_breakdown.html
@@ -35,7 +35,7 @@
     </div>
   </form>
   
-  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 3s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
+  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" hx-headers='{"X-Expected-Step": "breakdown"}' style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
 </div>
 
 <style>

--- a/internal/dashboard/templates/wizard_logs.html
+++ b/internal/dashboard/templates/wizard_logs.html
@@ -1,5 +1,5 @@
 {{if .Logs}}
-<div class="log-container">
+<div class="log-container" hx-on::after-swap="this.scrollTop = this.scrollHeight">
   {{range .Logs}}
   <div class="log-entry log-{{.Role}}">
     <span class="log-timestamp">{{.Timestamp.Format "15:04:05"}}</span>

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -29,7 +29,7 @@
     </div>
   </form>
   
-  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 3s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
+  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 1s" hx-swap="innerHTML" hx-headers='{"X-Expected-Step": "refine"}' style="margin-top: 1rem; max-height: 200px; overflow-y: auto;"></div>
 </div>
 
 <style>


### PR DESCRIPTION
Closes #19

## Parent Epic
Part of #15 — Feature Creation Wizard

## Description

Create a log viewer component that shows LLM processing output in real-time. Uses HTMX polling (every 1s) to fetch latest log entries from a backend endpoint. This component is reused in Step 1 (refinement) and Step 2 (task breakdown).

## Acceptance Criteria

- [ ] Log viewer panel displays LLM output as it is generated
- [ ] Polling interval is ~1 second (`hx-trigger="every 1s"`)
- [ ] Log panel auto-scrolls to the bottom as new content arrives
- [ ] Log panel is visually distinct (monospace font, terminal-like appearance)
- [ ] Polling stops automatically when LLM processing is complete
- [ ] Backend endpoint stores and serves log entries per wizard session
- [ ] Log viewer is a reusable template partial used in both Step 1 and Step 2