### PR TITLE
Feature Creation Wizard: interactive modal for creating features and bugs from the dashboard

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -607,7 +607,7 @@ func (s *Server) handleTaskDetail(w http.ResponseWriter, r *http.Request) {
 
 	isActive := false
 	status := ""
-	issueTitle := fmt.Sprintf("#%d", issueNum)
+	issueTitle := ""
 	if s.orchestrator != nil {
 		if task := s.orchestrator.CurrentTask(); task != nil && task.Issue.Number == issueNum {
 			isActive = true
@@ -616,7 +616,12 @@ func (s *Server) handleTaskDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if issueTitle == fmt.Sprintf("#%d", issueNum) && len(steps) > 0 {
+	if issueTitle == "" && s.gh != nil {
+		if issue, err := s.gh.GetIssue(issueNum); err == nil {
+			issueTitle = issue.Title
+		}
+	}
+	if issueTitle == "" {
 		issueTitle = fmt.Sprintf("Issue #%d", issueNum)
 	}
 
@@ -790,9 +795,21 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 
 	sessionID := r.FormValue("session_id")
 	idea := r.FormValue("idea")
+	currentDesc := r.FormValue("current_description")
 
-	if sessionID == "" || idea == "" {
-		http.Error(w, "missing session_id or idea", http.StatusBadRequest)
+	if sessionID == "" {
+		http.Error(w, "missing session_id", http.StatusBadRequest)
+		return
+	}
+
+	// Use current_description if provided (re-refinement), otherwise use idea
+	inputText := currentDesc
+	if inputText == "" {
+		inputText = idea
+	}
+
+	if inputText == "" {
+		http.Error(w, "missing idea or current_description", http.StatusBadRequest)
 		return
 	}
 
@@ -802,21 +819,23 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate idea length to prevent abuse
+	// Validate input length to prevent abuse
 	const maxIdeaLength = 10000
-	if len(idea) > maxIdeaLength {
-		http.Error(w, "idea exceeds maximum length of 10000 characters", http.StatusBadRequest)
+	if len(inputText) > maxIdeaLength {
+		http.Error(w, "input exceeds maximum length of 10000 characters", http.StatusBadRequest)
 		return
 	}
 
-	// Store the idea using thread-safe setter
-	session.SetIdeaText(idea)
+	// Store the idea using thread-safe setter (only if it's a new idea, not re-refinement)
+	if idea != "" {
+		session.SetIdeaText(idea)
+	}
 	session.SetStep(WizardStepRefine)
-	session.AddLog("user", idea)
+	session.AddLog("user", inputText)
 
 	// If no opencode client, return mock response for testing
 	if s.oc == nil {
-		mockRefined := "Refined: " + idea + "\n\nThis feature would allow users to authenticate securely."
+		mockRefined := "Refined: " + inputText + "\n\nThis feature would allow users to authenticate securely."
 		session.SetRefinedDescription(mockRefined)
 		session.AddLog("assistant", mockRefined)
 
@@ -838,7 +857,8 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	llmSession, err := s.oc.CreateSession("Wizard Refinement")
 	if err != nil {
 		log.Printf("[Wizard] Error creating LLM session: %v", err)
-		http.Error(w, "failed to create LLM session", http.StatusInternalServerError)
+		session.AddLog("system", "Error: Failed to create LLM session - "+err.Error())
+		s.renderError(w, "Failed to connect to AI service. Please try again.", session.ID, string(session.Type))
 		return
 	}
 	defer func() {
@@ -849,7 +869,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 
 	// Build refinement prompt with codebase context
 	codebaseContext := GetCodebaseContext()
-	prompt := BuildRefinementPrompt(session.Type, idea, codebaseContext)
+	prompt := BuildRefinementPrompt(session.Type, inputText, codebaseContext)
 	session.AddLog("system", "Sending refinement request to LLM")
 
 	// Send message to LLM with timeout
@@ -862,7 +882,15 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("[Wizard] Error from LLM: %v", err)
 		session.AddLog("system", "LLM error: "+err.Error())
-		http.Error(w, "failed to refine idea", http.StatusInternalServerError)
+
+		errorMsg := "Failed to refine idea. "
+		if ctx.Err() == context.DeadlineExceeded {
+			errorMsg += "The AI service timed out. Please try again with a shorter description."
+		} else {
+			errorMsg += "Please check your connection and try again."
+		}
+
+		s.renderError(w, errorMsg, session.ID, string(session.Type))
 		return
 	}
 
@@ -886,6 +914,22 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.render(w, "wizard_refine.html", data)
+}
+
+// renderError renders an error message in the wizard modal
+func (s *Server) renderError(w http.ResponseWriter, errorMsg, sessionID, wizardType string) {
+	data := struct {
+		SessionID string
+		Type      string
+		Error     string
+	}{
+		SessionID: sessionID,
+		Type:      wizardType,
+		Error:     errorMsg,
+	}
+
+	w.WriteHeader(http.StatusOK) // Return 200 so HTMX displays the content
+	s.render(w, "wizard_error.html", data)
 }
 
 // handleWizardBreakdown sends description to LLM and returns task list

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -124,6 +124,71 @@ func TestHandleWizardRefine_MissingIdea(t *testing.T) {
 	}
 }
 
+func TestHandleWizardRefine_WithCurrentDescription(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Create a session first
+	session, _ := srv.wizardStore.Create("feature")
+
+	// Test re-refinement with current_description (no idea provided)
+	form := url.Values{}
+	form.Set("session_id", session.ID)
+	form.Set("current_description", "Previous refined description")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	// Should return 200 OK (or 500 if template missing)
+	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 200 or 500, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// If successful, verify the response contains the re-refined text
+	if rec.Code == http.StatusOK {
+		body := rec.Body.String()
+		if !strings.Contains(body, "Refined: Previous refined description") {
+			t.Errorf("expected response to contain re-refined text, got: %s", body)
+		}
+
+		// Verify session was updated
+		updatedSession, _ := srv.wizardStore.Get(session.ID)
+		if !strings.Contains(updatedSession.RefinedDescription, "Previous refined description") {
+			t.Errorf("expected session to store re-refined description")
+		}
+	}
+}
+
+func TestHandleWizardRefine_ErrorRendering(t *testing.T) {
+	srv := &Server{
+		tmpls:       make(map[string]*template.Template),
+		wizardStore: NewWizardSessionStore(),
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test with invalid session - should return error template
+	form := url.Values{}
+	form.Set("session_id", "invalid-session")
+	form.Set("idea", "test idea")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	// Should return 400 Bad Request for invalid session
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400 for invalid session, got %d", rec.Code)
+	}
+}
+
 func TestHandleWizardBreakdown(t *testing.T) {
 	srv := &Server{
 		tmpls:       make(map[string]*template.Template),

--- a/internal/dashboard/templates/wizard_error.html
+++ b/internal/dashboard/templates/wizard_error.html
@@ -1,0 +1,31 @@
+<div class="wizard-step">
+  <h2>Error</h2>
+  
+  <div class="error-container" style="padding: 1.5rem; background: var(--surface); border-radius: 8px; border: 1px solid var(--error); margin: 1rem 0;">
+    <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 1rem;">
+      <span style="font-size: 1.5rem;">⚠️</span>
+      <strong style="color: var(--error);">Something went wrong</strong>
+    </div>
+    <p style="color: var(--text); margin: 0;">{{.Error}}</p>
+  </div>
+  
+  <div class="form-actions">
+    <button type="button" class="btn" onclick="closeWizardModal()">Cancel</button>
+    <div class="nav-buttons">
+      <button type="button" class="btn" hx-get="/wizard/new?type={{.Type}}&amp;session_id={{.SessionID}}" hx-target="#wizard-modal-content">
+        ← Back
+      </button>
+      <button type="button" class="btn btn-primary" hx-get="/wizard/new?type={{.Type}}&amp;session_id={{.SessionID}}" hx-target="#wizard-modal-content">
+        Try Again
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+.wizard-step { max-width: 800px; margin: 0 auto; }
+.form-actions { display: flex; justify-content: space-between; gap: 0.5rem; margin-top: 1.5rem; }
+.nav-buttons { display: flex; gap: 0.5rem; }
+.btn-primary { background: var(--accent); color: white; border: none; }
+.btn-primary:hover { background: var(--accent-hover); }
+</style>

--- a/internal/dashboard/templates/wizard_new.html
+++ b/internal/dashboard/templates/wizard_new.html
@@ -2,7 +2,7 @@
 <div class="wizard-step-content">
   <h1>Create New {{if eq .Type "bug"}}Bug Report{{else}}Feature{{end}}</h1>
   
-  <form hx-post="/wizard/refine" hx-target="#wizard-modal-content" hx-swap="innerHTML">
+  <form hx-post="/wizard/refine" hx-target="#wizard-modal-content" hx-swap="innerHTML" hx-disabled-elt="button[type='submit']">
     <input type="hidden" name="session_id" value="{{.SessionID}}">
     <input type="hidden" name="wizard_type" value="{{.Type}}">
     
@@ -20,7 +20,7 @@
     </div>
   </form>
   
-  <div id="wizard-logs" style="margin-top: 1rem;"></div>
+  <div id="wizard-logs" hx-get="/wizard/logs/{{.SessionID}}" hx-trigger="every 3s" hx-swap="innerHTML" style="margin-top: 1rem; max-height: 200px; overflow-y: auto; border: 1px solid var(--border); border-radius: 6px; padding: 0.5rem; background: var(--surface);"></div>
 </div>
 
 <style>

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -17,7 +17,7 @@
         <button type="button" class="btn" hx-get="/wizard/new?type={{.Type}}&amp;session_id={{.SessionID}}" hx-target="#wizard-modal-content">
           ← Back
         </button>
-        <button type="button" class="btn btn-secondary" hx-post="/wizard/refine-again" hx-target="#wizard-modal-content" hx-disabled-elt="button[type='submit']">
+        <button type="button" class="btn btn-secondary" hx-post="/wizard/refine" hx-target="#wizard-modal-content" hx-disabled-elt="button[type='submit']" hx-vals='{"current_description": "{{.RefinedDescription}}"}'>
           <span class="spinner" style="display:none;">⏳</span>
           <span class="label">Refine Again</span>
         </button>

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -40,6 +40,18 @@ func (i Issue) GetLabelNames() []string {
 	return names
 }
 
+func (c *Client) GetIssue(number int) (*Issue, error) {
+	out, err := c.gh("issue", "view", strconv.Itoa(number), "--json", "number,title,body,state,labels,assignees")
+	if err != nil {
+		return nil, fmt.Errorf("getting issue #%d: %w", number, err)
+	}
+	var issue Issue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return nil, fmt.Errorf("parsing issue #%d: %w", number, err)
+	}
+	return &issue, nil
+}
+
 func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
 	args := []string{"issue", "create", "--title", title, "--body", body}
 	for _, l := range labels {


### PR DESCRIPTION
Closes #15

## Summary

Add a multi-step wizard (modal) to the dashboard top bar that allows users to create new features or bug reports. The wizard guides the user through three phases:

1. **Idea Input & Refinement** — User enters a simple idea (e.g. "add a button here"). An LLM refines it into a technical description using codebase context. User can refine multiple times until satisfied.
2. **Task Breakdown** — LLM splits the accepted description into small, technical tasks with acceptance criteria (no implementation details). Each task gets a proposed priority (`priority:high/medium/low`) and complexity (`size:S/M/L/XL`).
3. **Confirmation & Creation** — Upon acceptance, GitHub issues are created: one business-level epic issue linking to all technical sub-tasks. Tasks are NOT assigned to any sprint — they wait for the next planning session.

## Technical Approach

- HTMX-based modal overlay on the dashboard
- LLM calls via OpenCode API with log polling (every 1s) for user visibility
- New backend endpoints for each wizard step
- New labels: `priority:high`, `priority:medium`, `priority:low`, `epic`
- Epic issue body contains links to all child tasks
- Child task bodies reference the parent epic

## Sub-tasks

- [ ] #16 — Add 'New Feature' and 'New Bug' buttons to dashboard top navigation bar
- [ ] #17 — Implement wizard modal shell with step navigation (HTMX)
- [ ] #18 — Implement Step 1: Idea input with LLM refinement
- [ ] #19 — Implement LLM log viewer with HTMX polling
- [ ] #20 — Implement Step 2: LLM task breakdown with priority and complexity
- [ ] #21 — Implement Step 3: Create GitHub issues (epic + sub-tasks)
- [ ] #22 — Add backend endpoints for wizard API
- [ ] #23 — Design LLM prompts for idea refinement and task breakdown
- [ ] #24 — Ensure priority labels exist on startup