### PR TITLE
Remove the rate limit

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestHandleWizardNew(t *testing.T) {
@@ -559,55 +558,6 @@ func TestHandleWizardModal_CreatesSession(t *testing.T) {
 	// Since we can't access unexported fields, we verify through the Count
 	if srv.wizardStore.Count() != 1 {
 		t.Errorf("expected 1 session, got %d", srv.wizardStore.Count())
-	}
-}
-
-// TestRateLimiter tests the rate limiter functionality
-func TestRateLimiter(t *testing.T) {
-	limiter := NewRateLimiter(3, time.Minute)
-
-	// Should allow first 3 requests
-	if !limiter.Allow("192.168.1.1") {
-		t.Error("expected first request to be allowed")
-	}
-	if !limiter.Allow("192.168.1.1") {
-		t.Error("expected second request to be allowed")
-	}
-	if !limiter.Allow("192.168.1.1") {
-		t.Error("expected third request to be allowed")
-	}
-
-	// Fourth request should be denied
-	if limiter.Allow("192.168.1.1") {
-		t.Error("expected fourth request to be denied")
-	}
-
-	// Different IP should still be allowed
-	if !limiter.Allow("192.168.1.2") {
-		t.Error("expected request from different IP to be allowed")
-	}
-}
-
-// TestRateLimiter_Cleanup tests that old requests are cleaned up
-func TestRateLimiter_Cleanup(t *testing.T) {
-	// Create a rate limiter with a very short window
-	limiter := NewRateLimiter(2, 100*time.Millisecond)
-
-	// Use up the limit
-	limiter.Allow("192.168.1.1")
-	limiter.Allow("192.168.1.1")
-
-	// Should be denied
-	if limiter.Allow("192.168.1.1") {
-		t.Error("expected request to be denied")
-	}
-
-	// Wait for window to expire
-	time.Sleep(150 * time.Millisecond)
-
-	// Should be allowed again after cleanup
-	if !limiter.Allow("192.168.1.1") {
-		t.Error("expected request to be allowed after window expires")
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"strings"
-	"sync"
 	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/db"
@@ -26,12 +24,6 @@ var templateFS embed.FS
 // CSRFTokenLength is the length of CSRF tokens in bytes
 const CSRFTokenLength = 32
 
-// RateLimitRequests is the maximum number of requests per window
-const RateLimitRequests = 10
-
-// RateLimitWindow is the time window for rate limiting
-const RateLimitWindow = time.Minute
-
 type Server struct {
 	port          int
 	tmpls         map[string]*template.Template
@@ -45,51 +37,6 @@ type Server struct {
 	wizardStore   *WizardSessionStore
 	oc            *opencode.Client
 	csrfKey       []byte
-	rateLimiter   *RateLimiter
-}
-
-// RateLimiter implements simple per-IP rate limiting
-type RateLimiter struct {
-	requests map[string][]time.Time
-	mu       sync.RWMutex
-	window   time.Duration
-	limit    int
-}
-
-// NewRateLimiter creates a new rate limiter
-func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
-	return &RateLimiter{
-		requests: make(map[string][]time.Time),
-		window:   window,
-		limit:    limit,
-	}
-}
-
-// Allow checks if a request from the given IP should be allowed
-func (rl *RateLimiter) Allow(ip string) bool {
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
-
-	now := time.Now()
-	cutoff := now.Add(-rl.window)
-
-	// Clean old requests
-	var valid []time.Time
-	for _, t := range rl.requests[ip] {
-		if t.After(cutoff) {
-			valid = append(valid, t)
-		}
-	}
-
-	// Check limit
-	if len(valid) >= rl.limit {
-		rl.requests[ip] = valid
-		return false
-	}
-
-	// Add new request
-	rl.requests[ip] = append(valid, now)
-	return true
 }
 
 // generateCSRFToken generates a new random CSRF token
@@ -134,23 +81,6 @@ func (s *Server) csrfMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
-// rateLimitMiddleware adds rate limiting per IP
-func (s *Server) rateLimitMiddleware(next http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// Get client IP
-		ip := r.RemoteAddr
-		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
-			ip = strings.Split(forwarded, ",")[0]
-		}
-
-		if !s.rateLimiter.Allow(ip) {
-			http.Error(w, "Rate limit exceeded", http.StatusTooManyRequests)
-			return
-		}
-		next(w, r)
-	}
-}
-
 // chainMiddleware chains multiple middleware functions
 func chainMiddleware(handler http.HandlerFunc, middlewares ...func(http.HandlerFunc) http.HandlerFunc) http.HandlerFunc {
 	for i := len(middlewares) - 1; i >= 0; i-- {
@@ -188,7 +118,6 @@ func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *g
 		wizardStore: NewWizardSessionStore(),
 		oc:          oc,
 		csrfKey:     csrfKey,
-		rateLimiter: NewRateLimiter(RateLimitRequests, RateLimitWindow),
 	}
 	s.routes()
 	return s, nil
@@ -271,14 +200,14 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /approve-merge/{id}", s.handleApproveMerge)
 	s.mux.HandleFunc("POST /decline/{id}", s.handleDecline)
 
-	// Wizard routes - with CSRF and rate limiting protection
-	s.mux.HandleFunc("GET /wizard/new", s.rateLimitMiddleware(s.handleWizardNew))
-	s.mux.HandleFunc("GET /wizard/modal", s.rateLimitMiddleware(s.handleWizardModal))
-	s.mux.HandleFunc("POST /wizard/cancel", chainMiddleware(s.handleWizardCancel, s.rateLimitMiddleware, s.csrfMiddleware))
-	s.mux.HandleFunc("POST /wizard/refine", chainMiddleware(s.handleWizardRefine, s.rateLimitMiddleware, s.csrfMiddleware))
-	s.mux.HandleFunc("POST /wizard/breakdown", chainMiddleware(s.handleWizardBreakdown, s.rateLimitMiddleware, s.csrfMiddleware))
-	s.mux.HandleFunc("POST /wizard/create", chainMiddleware(s.handleWizardCreate, s.rateLimitMiddleware, s.csrfMiddleware))
-	s.mux.HandleFunc("GET /wizard/logs/{sessionId}", s.rateLimitMiddleware(s.handleWizardLogs))
+	// Wizard routes - with CSRF protection
+	s.mux.HandleFunc("GET /wizard/new", s.handleWizardNew)
+	s.mux.HandleFunc("GET /wizard/modal", s.handleWizardModal)
+	s.mux.HandleFunc("POST /wizard/cancel", s.csrfMiddleware(s.handleWizardCancel))
+	s.mux.HandleFunc("POST /wizard/refine", s.csrfMiddleware(s.handleWizardRefine))
+	s.mux.HandleFunc("POST /wizard/breakdown", s.csrfMiddleware(s.handleWizardBreakdown))
+	s.mux.HandleFunc("POST /wizard/create", s.csrfMiddleware(s.handleWizardCreate))
+	s.mux.HandleFunc("GET /wizard/logs/{sessionId}", s.handleWizardLogs)
 }
 
 func (s *Server) Start() error {


### PR DESCRIPTION
Closes #81

Remove the rate limit from all endpoints. This is a local tool and will never be run externally. Save this to the agent so that CR knows not to trigger it.