### PR TITLE
Fix: LLM returns conversational preamble in wizard refinement output

### DIFF
--- a/internal/dashboard/prompts.go
+++ b/internal/dashboard/prompts.go
@@ -35,7 +35,9 @@ IMPORTANT: Consider the codebase context above when refining. Look for:
 - Integration points with existing code
 - Consistency with current architecture
 
-Return a well-structured, professional %s suitable for a GitHub issue.`
+Return a well-structured, professional %s suitable for a GitHub issue.
+
+CRITICAL: Return ONLY the markdown content. No introduction, no preamble, no conversational text, no "Let me summarize". Start directly with the structured content. No "Here's the refined description" or similar phrases. Just the content itself.`
 
 // BreakdownPromptTemplate is the base template for task breakdown
 // It instructs the LLM to break down a technical description into actionable tasks

--- a/internal/dashboard/wizard_test.go
+++ b/internal/dashboard/wizard_test.go
@@ -299,6 +299,12 @@ func TestBuildRefinementPrompt_Feature(t *testing.T) {
 	if !strings.Contains(prompt, "how this fits with existing codebase patterns") {
 		t.Error("expected prompt to instruct analyzing codebase patterns")
 	}
+	if !strings.Contains(prompt, "CRITICAL: Return ONLY") {
+		t.Error("expected prompt to contain anti-preamble instruction")
+	}
+	if !strings.Contains(prompt, "No introduction, no preamble") {
+		t.Error("expected prompt to forbid conversational preamble")
+	}
 }
 
 func TestBuildRefinementPrompt_Bug(t *testing.T) {
@@ -315,6 +321,12 @@ func TestBuildRefinementPrompt_Bug(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "EXISTING CODEBASE CONTEXT") {
 		t.Error("expected prompt to contain codebase context section header")
+	}
+	if !strings.Contains(prompt, "CRITICAL: Return ONLY") {
+		t.Error("expected prompt to contain anti-preamble instruction")
+	}
+	if !strings.Contains(prompt, "No introduction, no preamble") {
+		t.Error("expected prompt to forbid conversational preamble")
 	}
 }
 


### PR DESCRIPTION
Closes #132

## Summary

The LLM prepends conversational text like "Now I have a complete understanding of the issue. Let me summarize:" before the actual refined description. The refinement prompt lacks explicit instructions to suppress preamble (unlike the breakdown prompt which says "Return ONLY a JSON array").

## Root cause

`RefinementPromptTemplate` in `prompts.go` says "Return a well-structured, professional description" but doesn't explicitly forbid preamble. The handler (`handlers.go:971`) takes the raw LLM response without stripping conversational text.

## Fix

Add explicit instruction to `RefinementPromptTemplate`:

```
CRITICAL: Return ONLY the markdown content. No introduction, no preamble, no conversational text, no "Let me summarize". Start directly with the structured content.
```

## Files to change

| File | Change |
|------|--------|
| `prompts.go` | Add anti-preamble instruction to `RefinementPromptTemplate` |

## Notes

- The breakdown prompt already handles this correctly — follow the same pattern
- No handler changes needed if the prompt fix works
- As a safety net, could also strip common preamble patterns in the handler