### PR TITLE
Fix failing integration tests: add missing mock endpoint for structured code review

### DIFF
--- a/internal/mvp/integration_test.go
+++ b/internal/mvp/integration_test.go
@@ -174,6 +174,30 @@ func startMockOpencode(t *testing.T) (*httptest.Server, *requestLog) {
 			return
 		}
 
+		if strings.HasPrefix(r.URL.Path, "/session/") && strings.HasSuffix(r.URL.Path, "/message") && r.Method == http.MethodPost {
+			pathParts := strings.Split(strings.TrimPrefix(r.URL.Path, "/session/"), "/")
+			sessID := pathParts[0]
+
+			response := map[string]interface{}{
+				"info": map[string]interface{}{
+					"id":        "msg-cr-1",
+					"sessionID": sessID,
+					"role":      "assistant",
+					"structured": map[string]interface{}{
+						"approved":     true,
+						"already_done": false,
+						"issues":       []string{},
+						"suggestions":  []string{},
+						"verdict":      "Code looks good",
+					},
+				},
+				"parts": []interface{}{},
+			}
+
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+
 		if strings.HasPrefix(r.URL.Path, "/session/") && r.Method == http.MethodDelete {
 			w.WriteHeader(http.StatusNoContent)
 			return


### PR DESCRIPTION
Closes #137

## Summary

Three integration tests in `internal/mvp/integration_test.go` fail because the mock OpenCode server doesn't implement the `/session/{id}/message` endpoint used by `SendMessageStructured()` for code review.

## Failing tests

```
go test ./internal/mvp/... -v
```

- `TestWorkerProcessEndToEnd`
- `TestWorkerProcessStatusTransitions`
- `TestWorkerProcessTestFailure`

Error: `✗ FAILED code review: code review: structured message: status 404`

## Root cause

The mock server in `startMockOpencode()` handles:
- `/event` (SSE stream)
- `/session` (POST — create session)
- `/session/{id}/prompt_async` (POST — async prompts)
- `/session/{id}` (DELETE — delete session)

Missing: **`/session/{id}/message`** (POST — structured message for code review)

## Fix

Add `/session/{id}/message` handler to `startMockOpencode()` in `integration_test.go` that returns a mock code review response matching the expected JSON Schema:

```json
{
  "approved": true,
  "already_done": false,
  "issues": [],
  "suggestions": [],
  "verdict": "Code looks good"
}
```

The schema is defined in `internal/mvp/worker.go:370-380`.

## Files to change

| File | Change |
|------|--------|
| `internal/mvp/integration_test.go` | Add `/session/{id}/message` handler to mock server |

If any tests reference removed/obsolete code (e.g. old worktree APIs), delete them.

## Acceptance criteria

- [ ] `go test ./internal/mvp/...` passes
- [ ] `go test ./...` passes with no failures
- [ ] No obsolete/dead tests remain