### PR TITLE
Merge feature/bug wizard into single entry point with type selector

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -792,16 +792,8 @@ func (s *Server) handleTaskStream(w http.ResponseWriter, r *http.Request) {
 
 // handleWizardNew returns the initial wizard modal form
 func (s *Server) handleWizardNew(w http.ResponseWriter, r *http.Request) {
-	// Get wizard type from query param (default to feature)
+	// Get wizard type from query param
 	wizardType := r.URL.Query().Get("type")
-
-	// Validate wizard type
-	if wizardType == "" {
-		wizardType = "feature"
-	} else if wizardType != "feature" && wizardType != "bug" {
-		http.Error(w, "invalid wizard type: must be 'feature' or 'bug'", http.StatusBadRequest)
-		return
-	}
 
 	// Check for page mode
 	isPage := r.URL.Query().Get("page") == "1"
@@ -817,8 +809,12 @@ func (s *Server) handleWizardNew(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Create new session if not found
-	if session == nil {
+	// If no type param or invalid type, and no session, show type selector
+	isValidType := wizardType == "feature" || wizardType == "bug"
+	needsTypeSelection := (wizardType == "" || !isValidType) && session == nil
+
+	// Create new session if valid type is provided and no session exists
+	if !needsTypeSelection && session == nil {
 		var err error
 		session, err = s.wizardStore.Create(wizardType)
 		if err != nil {
@@ -828,17 +824,25 @@ func (s *Server) handleWizardNew(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Type              string
-		SessionID         string
-		IsPage            bool
-		CurrentStep       int
-		ShowBreakdownStep bool
+		Type               string
+		SessionID          string
+		IsPage             bool
+		CurrentStep        int
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
-		Type:              wizardType,
-		SessionID:         session.ID,
-		IsPage:            isPage,
-		CurrentStep:       1,
-		ShowBreakdownStep: wizardType == "feature" && !session.SkipBreakdown,
+		Type:               wizardType,
+		SessionID:          "",
+		IsPage:             isPage,
+		CurrentStep:        1,
+		ShowBreakdownStep:  false,
+		NeedsTypeSelection: needsTypeSelection,
+	}
+
+	if session != nil {
+		data.SessionID = session.ID
+		data.Type = string(session.Type)
+		data.ShowBreakdownStep = session.Type == WizardTypeFeature && !session.SkipBreakdown
 	}
 
 	s.renderFragment(w, "wizard_new.html", data)
@@ -918,6 +922,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 			SkipBreakdown      bool
 			CurrentStep        int
 			ShowBreakdownStep  bool
+			NeedsTypeSelection bool
 		}{
 			SessionID:          session.ID,
 			Type:               string(session.Type),
@@ -926,6 +931,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 			SkipBreakdown:      session.SkipBreakdown,
 			CurrentStep:        2,
 			ShowBreakdownStep:  session.Type == WizardTypeFeature && !session.SkipBreakdown,
+			NeedsTypeSelection: false,
 		}
 
 		s.renderFragment(w, "wizard_refine.html", data)
@@ -998,6 +1004,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		SkipBreakdown      bool
 		CurrentStep        int
 		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
 		SessionID:          session.ID,
 		Type:               string(session.Type),
@@ -1006,6 +1013,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		SkipBreakdown:      session.SkipBreakdown,
 		CurrentStep:        2,
 		ShowBreakdownStep:  session.Type == WizardTypeFeature && !session.SkipBreakdown,
+		NeedsTypeSelection: false,
 	}
 
 	s.renderFragment(w, "wizard_refine.html", data)
@@ -1079,19 +1087,21 @@ func (s *Server) handleWizardBreakdown(w http.ResponseWriter, r *http.Request) {
 		session.AddLog("assistant", "Generated 2 tasks")
 
 		data := struct {
-			SessionID         string
-			Tasks             []WizardTask
-			IsPage            bool
-			SprintName        string
-			CurrentStep       int
-			ShowBreakdownStep bool
+			SessionID          string
+			Tasks              []WizardTask
+			IsPage             bool
+			SprintName         string
+			CurrentStep        int
+			ShowBreakdownStep  bool
+			NeedsTypeSelection bool
 		}{
-			SessionID:         session.ID,
-			Tasks:             mockTasks,
-			IsPage:            isPage,
-			SprintName:        s.activeSprintName(),
-			CurrentStep:       3,
-			ShowBreakdownStep: true,
+			SessionID:          session.ID,
+			Tasks:              mockTasks,
+			IsPage:             isPage,
+			SprintName:         s.activeSprintName(),
+			CurrentStep:        3,
+			ShowBreakdownStep:  true,
+			NeedsTypeSelection: false,
 		}
 
 		s.renderFragment(w, "wizard_breakdown.html", data)
@@ -1139,19 +1149,21 @@ func (s *Server) handleWizardBreakdown(w http.ResponseWriter, r *http.Request) {
 	session.AddLog("assistant", fmt.Sprintf("Generated %d tasks", len(tasks)))
 
 	data := struct {
-		SessionID         string
-		Tasks             []WizardTask
-		IsPage            bool
-		SprintName        string
-		CurrentStep       int
-		ShowBreakdownStep bool
+		SessionID          string
+		Tasks              []WizardTask
+		IsPage             bool
+		SprintName         string
+		CurrentStep        int
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
-		SessionID:         session.ID,
-		Tasks:             tasks,
-		IsPage:            isPage,
-		SprintName:        s.activeSprintName(),
-		CurrentStep:       3,
-		ShowBreakdownStep: true,
+		SessionID:          session.ID,
+		Tasks:              tasks,
+		IsPage:             isPage,
+		SprintName:         s.activeSprintName(),
+		CurrentStep:        3,
+		ShowBreakdownStep:  true,
+		NeedsTypeSelection: false,
 	}
 
 	s.renderFragment(w, "wizard_breakdown.html", data)
@@ -1251,21 +1263,23 @@ func (s *Server) handleWizardCreate(w http.ResponseWriter, r *http.Request) {
 		session.AddLog("system", "Mock: Created epic #100 with 2 sub-tasks")
 
 		data := struct {
-			Epic              CreatedIssue
-			SubTasks          []CreatedIssue
-			HasErrors         bool
-			IsPage            bool
-			IsSingleIssue     bool
-			CurrentStep       int
-			ShowBreakdownStep bool
+			Epic               CreatedIssue
+			SubTasks           []CreatedIssue
+			HasErrors          bool
+			IsPage             bool
+			IsSingleIssue      bool
+			CurrentStep        int
+			ShowBreakdownStep  bool
+			NeedsTypeSelection bool
 		}{
-			Epic:              mockEpic,
-			SubTasks:          mockSubTasks,
-			HasErrors:         false,
-			IsPage:            isPage,
-			IsSingleIssue:     false,
-			CurrentStep:       4,
-			ShowBreakdownStep: !session.SkipBreakdown,
+			Epic:               mockEpic,
+			SubTasks:           mockSubTasks,
+			HasErrors:          false,
+			IsPage:             isPage,
+			IsSingleIssue:      false,
+			CurrentStep:        4,
+			ShowBreakdownStep:  !session.SkipBreakdown,
+			NeedsTypeSelection: false,
 		}
 
 		s.wizardStore.Delete(sessionID)
@@ -1429,21 +1443,23 @@ func (s *Server) handleWizardCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := struct {
-		Epic              CreatedIssue
-		SubTasks          []CreatedIssue
-		HasErrors         bool
-		IsPage            bool
-		IsSingleIssue     bool
-		CurrentStep       int
-		ShowBreakdownStep bool
+		Epic               CreatedIssue
+		SubTasks           []CreatedIssue
+		HasErrors          bool
+		IsPage             bool
+		IsSingleIssue      bool
+		CurrentStep        int
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
-		Epic:              epicIssue,
-		SubTasks:          subTasks,
-		HasErrors:         hasErrors,
-		IsPage:            isPage,
-		IsSingleIssue:     false,
-		CurrentStep:       4,
-		ShowBreakdownStep: !session.SkipBreakdown,
+		Epic:               epicIssue,
+		SubTasks:           subTasks,
+		HasErrors:          hasErrors,
+		IsPage:             isPage,
+		IsSingleIssue:      false,
+		CurrentStep:        4,
+		ShowBreakdownStep:  !session.SkipBreakdown,
+		NeedsTypeSelection: false,
 	}
 
 	// Clean up session after creation to free memory
@@ -1478,21 +1494,23 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 		session.AddLog("system", "Mock: Created single issue #100")
 
 		data := struct {
-			Epic              CreatedIssue
-			SubTasks          []CreatedIssue
-			HasErrors         bool
-			IsPage            bool
-			IsSingleIssue     bool
-			CurrentStep       int
-			ShowBreakdownStep bool
+			Epic               CreatedIssue
+			SubTasks           []CreatedIssue
+			HasErrors          bool
+			IsPage             bool
+			IsSingleIssue      bool
+			CurrentStep        int
+			ShowBreakdownStep  bool
+			NeedsTypeSelection bool
 		}{
-			Epic:              mockIssue,
-			SubTasks:          []CreatedIssue{},
-			HasErrors:         false,
-			IsPage:            isPage,
-			IsSingleIssue:     true,
-			CurrentStep:       4,
-			ShowBreakdownStep: false,
+			Epic:               mockIssue,
+			SubTasks:           []CreatedIssue{},
+			HasErrors:          false,
+			IsPage:             isPage,
+			IsSingleIssue:      true,
+			CurrentStep:        4,
+			ShowBreakdownStep:  false,
+			NeedsTypeSelection: false,
 		}
 
 		s.wizardStore.Delete(session.ID)
@@ -1549,21 +1567,23 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 	}
 
 	data := struct {
-		Epic              CreatedIssue
-		SubTasks          []CreatedIssue
-		HasErrors         bool
-		IsPage            bool
-		IsSingleIssue     bool
-		CurrentStep       int
-		ShowBreakdownStep bool
+		Epic               CreatedIssue
+		SubTasks           []CreatedIssue
+		HasErrors          bool
+		IsPage             bool
+		IsSingleIssue      bool
+		CurrentStep        int
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
-		Epic:              issue,
-		SubTasks:          []CreatedIssue{},
-		HasErrors:         false,
-		IsPage:            isPage,
-		IsSingleIssue:     true,
-		CurrentStep:       4,
-		ShowBreakdownStep: false,
+		Epic:               issue,
+		SubTasks:           []CreatedIssue{},
+		HasErrors:          false,
+		IsPage:             isPage,
+		IsSingleIssue:      true,
+		CurrentStep:        4,
+		ShowBreakdownStep:  false,
+		NeedsTypeSelection: false,
 	}
 
 	// Clean up session after creation to free memory
@@ -1607,33 +1627,56 @@ func (s *Server) handleWizardLogs(w http.ResponseWriter, r *http.Request) {
 
 // handleWizardPage returns the full wizard page (not modal)
 func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
-	// Get wizard type from query param (default to feature)
+	// Get wizard type from query param
 	wizardType := r.URL.Query().Get("type")
-	if wizardType != "bug" {
-		wizardType = "feature"
+
+	// Check for existing session ID (for back navigation)
+	sessionID := r.URL.Query().Get("session_id")
+	var session *WizardSession
+
+	if sessionID != "" {
+		// Try to get existing session
+		if existing, ok := s.wizardStore.Get(sessionID); ok {
+			session = existing
+		}
 	}
 
-	// Create new session
-	session, err := s.wizardStore.Create(wizardType)
-	if err != nil {
-		http.Error(w, "invalid wizard type", http.StatusBadRequest)
-		return
+	// If no type param or invalid type, and no session, show type selector
+	isValidType := wizardType == "feature" || wizardType == "bug"
+	needsTypeSelection := (wizardType == "" || !isValidType) && session == nil
+
+	// Create new session if valid type is provided and no session exists
+	if !needsTypeSelection && session == nil {
+		var err error
+		session, err = s.wizardStore.Create(wizardType)
+		if err != nil {
+			http.Error(w, "invalid wizard type", http.StatusBadRequest)
+			return
+		}
 	}
 
 	data := struct {
-		Active            string
-		Type              string
-		SessionID         string
-		CurrentStep       int
-		IsPage            bool
-		ShowBreakdownStep bool
+		Active             string
+		Type               string
+		SessionID          string
+		CurrentStep        int
+		IsPage             bool
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
-		Active:            "wizard",
-		Type:              wizardType,
-		SessionID:         session.ID,
-		CurrentStep:       1,
-		IsPage:            true,
-		ShowBreakdownStep: wizardType == "feature" && !session.SkipBreakdown,
+		Active:             "wizard",
+		Type:               wizardType,
+		SessionID:          "",
+		CurrentStep:        1,
+		IsPage:             true,
+		ShowBreakdownStep:  false,
+		NeedsTypeSelection: needsTypeSelection,
+	}
+
+	if session != nil {
+		data.SessionID = session.ID
+		data.Type = string(session.Type)
+		data.ShowBreakdownStep = session.Type == WizardTypeFeature && !session.SkipBreakdown
 	}
 
 	s.render(w, "wizard_page.html", data)
@@ -1641,29 +1684,52 @@ func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
 
 // handleWizardModal returns the full modal shell with step 1 loaded
 func (s *Server) handleWizardModal(w http.ResponseWriter, r *http.Request) {
-	// Get wizard type from query param (default to feature)
+	// Get wizard type from query param
 	wizardType := r.URL.Query().Get("type")
-	if wizardType != "bug" {
-		wizardType = "feature"
+
+	// Check for existing session ID (for back navigation)
+	sessionID := r.URL.Query().Get("session_id")
+	var session *WizardSession
+
+	if sessionID != "" {
+		// Try to get existing session
+		if existing, ok := s.wizardStore.Get(sessionID); ok {
+			session = existing
+		}
 	}
 
-	// Create new session
-	session, err := s.wizardStore.Create(wizardType)
-	if err != nil {
-		http.Error(w, "invalid wizard type", http.StatusBadRequest)
-		return
+	// If no type param or invalid type, and no session, show type selector
+	isValidType := wizardType == "feature" || wizardType == "bug"
+	needsTypeSelection := (wizardType == "" || !isValidType) && session == nil
+
+	// Create new session if valid type is provided and no session exists
+	if !needsTypeSelection && session == nil {
+		var err error
+		session, err = s.wizardStore.Create(wizardType)
+		if err != nil {
+			http.Error(w, "invalid wizard type", http.StatusBadRequest)
+			return
+		}
 	}
 
 	data := struct {
-		Type              string
-		SessionID         string
-		CurrentStep       int
-		ShowBreakdownStep bool
+		Type               string
+		SessionID          string
+		CurrentStep        int
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
 	}{
-		Type:              wizardType,
-		SessionID:         session.ID,
-		CurrentStep:       1,
-		ShowBreakdownStep: wizardType == "feature" && !session.SkipBreakdown,
+		Type:               wizardType,
+		SessionID:          "",
+		CurrentStep:        1,
+		ShowBreakdownStep:  false,
+		NeedsTypeSelection: needsTypeSelection,
+	}
+
+	if session != nil {
+		data.SessionID = session.ID
+		data.Type = string(session.Type)
+		data.ShowBreakdownStep = session.Type == WizardTypeFeature && !session.SkipBreakdown
 	}
 
 	s.renderFragment(w, "wizard_modal.html", data)
@@ -1681,4 +1747,36 @@ func (s *Server) handleWizardCancel(w http.ResponseWriter, r *http.Request) {
 		s.wizardStore.Delete(sessionID)
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+// handleWizardSelectType handles type selection and creates a session
+func (s *Server) handleWizardSelectType(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	wizardType := r.FormValue("wizard_type")
+	if wizardType != "feature" && wizardType != "bug" {
+		http.Error(w, "invalid wizard type: must be 'feature' or 'bug'", http.StatusBadRequest)
+		return
+	}
+
+	// Create new session with selected type
+	session, err := s.wizardStore.Create(wizardType)
+	if err != nil {
+		http.Error(w, "failed to create session", http.StatusInternalServerError)
+		return
+	}
+
+	// Check for page mode
+	isPage := r.FormValue("page") == "1" || r.URL.Query().Get("page") == "1"
+
+	// Redirect to idea input step
+	redirectURL := "/wizard/new?session_id=" + session.ID
+	if isPage {
+		redirectURL += "&page=1"
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 }

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -274,9 +274,10 @@ func TestHandleWizardNew_InvalidType(t *testing.T) {
 
 	srv.handleWizardNew(rec, req)
 
-	// Should return 400 Bad Request for invalid type
-	if rec.Code != http.StatusBadRequest {
-		t.Errorf("expected status 400 for invalid type, got %d", rec.Code)
+	// With new implementation, invalid type defaults to showing type selector
+	// No session should be created
+	if srv.wizardStore.Count() != 0 {
+		t.Errorf("expected 0 sessions for invalid type (type selector shown), got %d", srv.wizardStore.Count())
 	}
 }
 
@@ -805,15 +806,15 @@ func TestHandleWizardPage(t *testing.T) {
 		t.Errorf("expected 2 sessions, got %d", srv.wizardStore.Count())
 	}
 
-	// Test default type (should default to feature)
+	// Test default type (no type param - should show type selector, not create session)
 	req = httptest.NewRequest(http.MethodGet, "/wizard", nil)
 	rec = httptest.NewRecorder()
 
 	srv.handleWizardPage(rec, req)
 
-	// Should have 3 sessions now
-	if srv.wizardStore.Count() != 3 {
-		t.Errorf("expected 3 sessions, got %d", srv.wizardStore.Count())
+	// Should still have 2 sessions (no new session created for type selector)
+	if srv.wizardStore.Count() != 2 {
+		t.Errorf("expected 2 sessions (type selector shown, no session created), got %d", srv.wizardStore.Count())
 	}
 }
 
@@ -916,7 +917,7 @@ func TestConcurrentHandlerAccess(t *testing.T) {
 	}
 }
 
-// TestHeaderButtons_FromBoard verifies header buttons are present on the board page
+// TestHeaderButtons_FromBoard verifies header button is present on the board page
 func TestHeaderButtons_FromBoard(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
@@ -932,22 +933,23 @@ func TestHeaderButtons_FromBoard(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify both header buttons are present with correct hrefs
-	if !strings.Contains(body, `href="/wizard?type=feature"`) {
-		t.Error("board page missing New Feature button with correct href")
+	// Verify single header button is present with correct href
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Error("board page missing New Issue button with correct href")
 	}
-	if !strings.Contains(body, `href="/wizard?type=bug"`) {
-		t.Error("board page missing New Bug button with correct href")
+	if !strings.Contains(body, "+ New Issue") {
+		t.Error("board page missing 'New Issue' button text")
 	}
-	if !strings.Contains(body, "+ New Feature") {
-		t.Error("board page missing 'New Feature' button text")
+	// Verify old buttons are NOT present
+	if strings.Contains(body, `href="/wizard?type=feature"`) {
+		t.Error("board page should not have old New Feature button")
 	}
-	if !strings.Contains(body, "+ New Bug") {
-		t.Error("board page missing 'New Bug' button text")
+	if strings.Contains(body, `href="/wizard?type=bug"`) {
+		t.Error("board page should not have old New Bug button")
 	}
 }
 
-// TestHeaderButtons_FromBacklog verifies header buttons are present on the backlog page
+// TestHeaderButtons_FromBacklog verifies header button is present on the backlog page
 func TestHeaderButtons_FromBacklog(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
@@ -963,22 +965,23 @@ func TestHeaderButtons_FromBacklog(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify both header buttons are present with correct hrefs
-	if !strings.Contains(body, `href="/wizard?type=feature"`) {
-		t.Error("backlog page missing New Feature button with correct href")
+	// Verify single header button is present with correct href
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Error("backlog page missing New Issue button with correct href")
 	}
-	if !strings.Contains(body, `href="/wizard?type=bug"`) {
-		t.Error("backlog page missing New Bug button with correct href")
+	if !strings.Contains(body, "+ New Issue") {
+		t.Error("backlog page missing 'New Issue' button text")
 	}
-	if !strings.Contains(body, "+ New Feature") {
-		t.Error("backlog page missing 'New Feature' button text")
+	// Verify old buttons are NOT present
+	if strings.Contains(body, `href="/wizard?type=feature"`) {
+		t.Error("backlog page should not have old New Feature button")
 	}
-	if !strings.Contains(body, "+ New Bug") {
-		t.Error("backlog page missing 'New Bug' button text")
+	if strings.Contains(body, `href="/wizard?type=bug"`) {
+		t.Error("backlog page should not have old New Bug button")
 	}
 }
 
-// TestHeaderButtons_FromCosts verifies header buttons are present on the costs page
+// TestHeaderButtons_FromCosts verifies header button is present on the costs page
 func TestHeaderButtons_FromCosts(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
@@ -994,22 +997,23 @@ func TestHeaderButtons_FromCosts(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify both header buttons are present with correct hrefs
-	if !strings.Contains(body, `href="/wizard?type=feature"`) {
-		t.Error("costs page missing New Feature button with correct href")
+	// Verify single header button is present with correct href
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Error("costs page missing New Issue button with correct href")
 	}
-	if !strings.Contains(body, `href="/wizard?type=bug"`) {
-		t.Error("costs page missing New Bug button with correct href")
+	if !strings.Contains(body, "+ New Issue") {
+		t.Error("costs page missing 'New Issue' button text")
 	}
-	if !strings.Contains(body, "+ New Feature") {
-		t.Error("costs page missing 'New Feature' button text")
+	// Verify old buttons are NOT present
+	if strings.Contains(body, `href="/wizard?type=feature"`) {
+		t.Error("costs page should not have old New Feature button")
 	}
-	if !strings.Contains(body, "+ New Bug") {
-		t.Error("costs page missing 'New Bug' button text")
+	if strings.Contains(body, `href="/wizard?type=bug"`) {
+		t.Error("costs page should not have old New Bug button")
 	}
 }
 
-// TestHeaderButtons_FromTask verifies header buttons are present on the task detail page
+// TestHeaderButtons_FromTask verifies header button is present on the task detail page
 func TestHeaderButtons_FromTask(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	// Keep store as nil - handler now handles nil store gracefully
@@ -1027,22 +1031,23 @@ func TestHeaderButtons_FromTask(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify both header buttons are present with correct hrefs
-	if !strings.Contains(body, `href="/wizard?type=feature"`) {
-		t.Error("task page missing New Feature button with correct href")
+	// Verify single header button is present with correct href
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Error("task page missing New Issue button with correct href")
 	}
-	if !strings.Contains(body, `href="/wizard?type=bug"`) {
-		t.Error("task page missing New Bug button with correct href")
+	if !strings.Contains(body, "+ New Issue") {
+		t.Error("task page missing 'New Issue' button text")
 	}
-	if !strings.Contains(body, "+ New Feature") {
-		t.Error("task page missing 'New Feature' button text")
+	// Verify old buttons are NOT present
+	if strings.Contains(body, `href="/wizard?type=feature"`) {
+		t.Error("task page should not have old New Feature button")
 	}
-	if !strings.Contains(body, "+ New Bug") {
-		t.Error("task page missing 'New Bug' button text")
+	if strings.Contains(body, `href="/wizard?type=bug"`) {
+		t.Error("task page should not have old New Bug button")
 	}
 }
 
-// TestHeaderButtons_FromWizard verifies header buttons are present on the wizard page itself
+// TestHeaderButtons_FromWizard verifies header button is present on the wizard page itself
 func TestHeaderButtons_FromWizard(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
@@ -1058,18 +1063,16 @@ func TestHeaderButtons_FromWizard(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify both header buttons are present with correct hrefs
-	if !strings.Contains(body, `href="/wizard?type=feature"`) {
-		t.Error("wizard page missing New Feature button with correct href")
+	// Verify single header button is present with correct href
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Error("wizard page missing New Issue button with correct href")
 	}
-	if !strings.Contains(body, `href="/wizard?type=bug"`) {
-		t.Error("wizard page missing New Bug button with correct href")
+	if !strings.Contains(body, "+ New Issue") {
+		t.Error("wizard page missing 'New Issue' button text")
 	}
-	if !strings.Contains(body, "+ New Feature") {
-		t.Error("wizard page missing 'New Feature' button text")
-	}
-	if !strings.Contains(body, "+ New Bug") {
-		t.Error("wizard page missing 'New Bug' button text")
+	// Verify old buttons are NOT present
+	if strings.Contains(body, `href="/wizard?type=feature"`) && !strings.Contains(body, `href="/wizard"`) {
+		t.Error("wizard page should not have separate New Feature button (should be unified)")
 	}
 }
 
@@ -1078,7 +1081,7 @@ func TestWizardFlow_FromBacklog(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
 
-	// Step 1: Verify backlog page renders with header buttons
+	// Step 1: Verify backlog page renders with unified header button
 	req := httptest.NewRequest(http.MethodGet, "/backlog", nil)
 	rec := httptest.NewRecorder()
 	srv.handleBacklog(rec, req)
@@ -1088,12 +1091,12 @@ func TestWizardFlow_FromBacklog(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, `href="/wizard?type=feature"`) {
-		t.Fatal("Step 1 failed: backlog page missing New Feature button")
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Fatal("Step 1 failed: backlog page missing New Issue button")
 	}
 
-	// Step 2: Click New Feature button - request wizard page
-	req = httptest.NewRequest(http.MethodGet, "/wizard?type=feature", nil)
+	// Step 2: Click New Issue button - request wizard page (shows type selector)
+	req = httptest.NewRequest(http.MethodGet, "/wizard", nil)
 	rec = httptest.NewRecorder()
 	srv.handleWizardPage(rec, req)
 
@@ -1101,18 +1104,37 @@ func TestWizardFlow_FromBacklog(t *testing.T) {
 		t.Fatalf("Step 2 failed: expected status 200, got %d", rec.Code)
 	}
 
-	// Verify session was created
-	if srv.wizardStore.Count() != 1 {
-		t.Fatalf("Step 2 failed: expected 1 session, got %d", srv.wizardStore.Count())
+	// No session yet - user needs to select type
+	if srv.wizardStore.Count() != 0 {
+		t.Fatalf("Step 2 failed: expected 0 sessions (type selector shown), got %d", srv.wizardStore.Count())
 	}
 
-	// Get the session ID by creating a test session and getting its ID
-	// Since we can't access internal map directly, we'll create a test session
-	testSession, _ := srv.wizardStore.Create("feature")
-	sessionID := testSession.ID
-
-	// Step 3: Submit idea for refinement
+	// Step 3: Select feature type via POST to select-type endpoint
 	formData := url.Values{}
+	formData.Set("wizard_type", "feature")
+	req = httptest.NewRequest(http.MethodPost, "/wizard/select-type", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	srv.handleWizardSelectType(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("Step 3 failed: expected redirect (303), got %d", rec.Code)
+	}
+
+	// Now session should be created
+	if srv.wizardStore.Count() != 1 {
+		t.Fatalf("Step 3 failed: expected 1 session after type selection, got %d", srv.wizardStore.Count())
+	}
+
+	// Get the session ID from the redirect URL
+	redirectURL := rec.Header().Get("Location")
+	var sessionID string
+	if strings.Contains(redirectURL, "session_id=") {
+		sessionID = strings.Split(strings.Split(redirectURL, "session_id=")[1], "&")[0]
+	}
+
+	// Step 4: Submit idea for refinement
+	formData = url.Values{}
 	formData.Set("session_id", sessionID)
 	formData.Set("idea", "Create a user dashboard with analytics")
 
@@ -1122,10 +1144,10 @@ func TestWizardFlow_FromBacklog(t *testing.T) {
 	srv.handleWizardRefine(rec, req)
 
 	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Fatalf("Step 3 failed: expected status 200 or 500, got %d", rec.Code)
+		t.Fatalf("Step 4 failed: expected status 200 or 500, got %d", rec.Code)
 	}
 
-	// Step 4: Request breakdown
+	// Step 5: Request breakdown
 	formData = url.Values{}
 	formData.Set("session_id", sessionID)
 
@@ -1135,10 +1157,10 @@ func TestWizardFlow_FromBacklog(t *testing.T) {
 	srv.handleWizardBreakdown(rec, req)
 
 	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Fatalf("Step 4 failed: expected status 200 or 500, got %d", rec.Code)
+		t.Fatalf("Step 5 failed: expected status 200 or 500, got %d", rec.Code)
 	}
 
-	// Step 5: Create issues
+	// Step 6: Create issues
 	formData = url.Values{}
 	formData.Set("session_id", sessionID)
 
@@ -1148,7 +1170,7 @@ func TestWizardFlow_FromBacklog(t *testing.T) {
 	srv.handleWizardCreate(rec, req)
 
 	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Fatalf("Step 5 failed: expected status 200 or 500, got %d", rec.Code)
+		t.Fatalf("Step 6 failed: expected status 200 or 500, got %d", rec.Code)
 	}
 
 	t.Log("Wizard flow from backlog completed successfully")
@@ -1159,7 +1181,7 @@ func TestWizardFlow_FromCosts(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
 
-	// Step 1: Verify costs page renders with header buttons
+	// Step 1: Verify costs page renders with unified header button
 	req := httptest.NewRequest(http.MethodGet, "/costs", nil)
 	rec := httptest.NewRecorder()
 	srv.handleCosts(rec, req)
@@ -1169,12 +1191,12 @@ func TestWizardFlow_FromCosts(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, `href="/wizard?type=bug"`) {
-		t.Fatal("Step 1 failed: costs page missing New Bug button")
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Fatal("Step 1 failed: costs page missing New Issue button")
 	}
 
-	// Step 2: Click New Bug button - request wizard page
-	req = httptest.NewRequest(http.MethodGet, "/wizard?type=bug", nil)
+	// Step 2: Click New Issue button - request wizard page (shows type selector)
+	req = httptest.NewRequest(http.MethodGet, "/wizard", nil)
 	rec = httptest.NewRecorder()
 	srv.handleWizardPage(rec, req)
 
@@ -1182,22 +1204,43 @@ func TestWizardFlow_FromCosts(t *testing.T) {
 		t.Fatalf("Step 2 failed: expected status 200, got %d", rec.Code)
 	}
 
-	// Verify session was created
-	if srv.wizardStore.Count() != 1 {
-		t.Fatalf("Step 2 failed: expected 1 session, got %d", srv.wizardStore.Count())
+	// No session yet - user needs to select type
+	if srv.wizardStore.Count() != 0 {
+		t.Fatalf("Step 2 failed: expected 0 sessions (type selector shown), got %d", srv.wizardStore.Count())
 	}
 
-	// Get the session ID by creating a test session
-	testSession, _ := srv.wizardStore.Create("bug")
-	sessionID := testSession.ID
+	// Step 3: Select bug type via POST to select-type endpoint
+	formData := url.Values{}
+	formData.Set("wizard_type", "bug")
+	req = httptest.NewRequest(http.MethodPost, "/wizard/select-type", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	srv.handleWizardSelectType(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("Step 3 failed: expected redirect (303), got %d", rec.Code)
+	}
+
+	// Now session should be created
+	if srv.wizardStore.Count() != 1 {
+		t.Fatalf("Step 3 failed: expected 1 session after type selection, got %d", srv.wizardStore.Count())
+	}
+
+	// Get the session ID from the redirect URL
+	redirectURL := rec.Header().Get("Location")
+	var sessionID string
+	if strings.Contains(redirectURL, "session_id=") {
+		sessionID = strings.Split(strings.Split(redirectURL, "session_id=")[1], "&")[0]
+	}
 
 	// Verify it's a bug type
-	if testSession.Type != "bug" {
-		t.Fatalf("Step 2 failed: expected session type 'bug', got %q", testSession.Type)
+	session, _ := srv.wizardStore.Get(sessionID)
+	if session == nil || session.Type != "bug" {
+		t.Fatalf("Step 3 failed: expected session type 'bug', got %v", session)
 	}
 
-	// Step 3: Submit bug description for refinement
-	formData := url.Values{}
+	// Step 4: Submit bug description for refinement
+	formData = url.Values{}
 	formData.Set("session_id", sessionID)
 	formData.Set("idea", "Fix login page validation error")
 
@@ -1207,10 +1250,10 @@ func TestWizardFlow_FromCosts(t *testing.T) {
 	srv.handleWizardRefine(rec, req)
 
 	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Fatalf("Step 3 failed: expected status 200 or 500, got %d", rec.Code)
+		t.Fatalf("Step 4 failed: expected status 200 or 500, got %d", rec.Code)
 	}
 
-	// Step 4: Request breakdown
+	// Step 5: Request breakdown
 	formData = url.Values{}
 	formData.Set("session_id", sessionID)
 
@@ -1220,10 +1263,10 @@ func TestWizardFlow_FromCosts(t *testing.T) {
 	srv.handleWizardBreakdown(rec, req)
 
 	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Fatalf("Step 4 failed: expected status 200 or 500, got %d", rec.Code)
+		t.Fatalf("Step 5 failed: expected status 200 or 500, got %d", rec.Code)
 	}
 
-	// Step 5: Create issues
+	// Step 6: Create issues
 	formData = url.Values{}
 	formData.Set("session_id", sessionID)
 
@@ -1233,7 +1276,7 @@ func TestWizardFlow_FromCosts(t *testing.T) {
 	srv.handleWizardCreate(rec, req)
 
 	if rec.Code != http.StatusOK && rec.Code != http.StatusInternalServerError {
-		t.Fatalf("Step 5 failed: expected status 200 or 500, got %d", rec.Code)
+		t.Fatalf("Step 6 failed: expected status 200 or 500, got %d", rec.Code)
 	}
 
 	t.Log("Wizard flow from costs completed successfully")
@@ -1317,28 +1360,25 @@ func TestLayoutNavigationButtons(t *testing.T) {
 
 	output := buf.String()
 
-	// Check for New Feature button as a link (changed from HTMX to regular links)
-	if !strings.Contains(output, `href="/wizard?type=feature"`) {
-		t.Error("layout template missing New Feature button with correct href attribute")
+	// Check for New Issue button as a link (unified entry point)
+	if !strings.Contains(output, `href="/wizard"`) {
+		t.Error("layout template missing New Issue button with correct href attribute")
 	}
-	if !strings.Contains(output, "+ New Feature") {
-		t.Error("layout template missing 'New Feature' button text")
-	}
-
-	// Check for New Bug button as a link (changed from HTMX to regular links)
-	if !strings.Contains(output, `href="/wizard?type=bug"`) {
-		t.Error("layout template missing New Bug button with correct href attribute")
-	}
-	if !strings.Contains(output, "+ New Bug") {
-		t.Error("layout template missing 'New Bug' button text")
+	if !strings.Contains(output, "+ New Issue") {
+		t.Error("layout template missing 'New Issue' button text")
 	}
 
-	// Check for correct CSS classes
-	if !strings.Contains(output, "btn btn-success") {
-		t.Error("layout template missing btn-success class on New Feature button")
+	// Verify old buttons are NOT present
+	if strings.Contains(output, `href="/wizard?type=feature"`) {
+		t.Error("layout template should not have old New Feature button href")
 	}
-	if !strings.Contains(output, "btn btn-danger") {
-		t.Error("layout template missing btn-danger class on New Bug button")
+	if strings.Contains(output, `href="/wizard?type=bug"`) {
+		t.Error("layout template should not have old New Bug button href")
+	}
+
+	// Check for correct CSS class on unified button
+	if !strings.Contains(output, "btn btn-primary") {
+		t.Error("layout template missing btn-primary class on New Issue button")
 	}
 
 	// Check for nav-actions container
@@ -1617,10 +1657,7 @@ func TestHandleWizardCreate_SubTaskBodyFormat(t *testing.T) {
 
 // TestWizardFlow_ValidationErrors tests all validation scenarios in sequence
 func TestWizardFlow_ValidationErrors(t *testing.T) {
-	srv := &Server{
-		tmpls:       make(map[string]*template.Template),
-		wizardStore: NewWizardSessionStore(),
-	}
+	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
 
 	tests := []struct {
@@ -1637,8 +1674,8 @@ func TestWizardFlow_ValidationErrors(t *testing.T) {
 				return req, httptest.NewRecorder()
 			},
 			handler:    srv.handleWizardNew,
-			wantStatus: http.StatusBadRequest,
-			wantError:  "Invalid wizard type",
+			wantStatus: http.StatusOK,       // New behavior: shows type selector instead of error
+			wantError:  "Select Issue Type", // Type selector UI is shown
 		},
 		{
 			name: "missing session_id on refine",
@@ -2214,7 +2251,7 @@ func TestHandleWizardCreate_SkipsBreakdownWhenFlagSet(t *testing.T) {
 	}
 }
 
-// TestBoardLayout_AfterButtonRemoval verifies board renders without duplicate buttons in board-actions
+// TestBoardLayout_AfterButtonRemoval verifies board renders with unified New Issue button in header
 func TestBoardLayout_AfterButtonRemoval(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
@@ -2230,21 +2267,22 @@ func TestBoardLayout_AfterButtonRemoval(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify NO duplicate +Feature or +Bug buttons in board-actions section
-	// These should only exist in the header navigation (layout.html)
-	if strings.Contains(body, "+ Feature") && !strings.Contains(body, "+ New Feature") {
-		t.Error("board page contains duplicate '+ Feature' button in board-actions - should only be in header")
-	}
-	if strings.Contains(body, "+ Bug") && !strings.Contains(body, "+ New Bug") {
-		t.Error("board page contains duplicate '+ Bug' button in board-actions - should only be in header")
+	// Verify unified "+ New Issue" button is present in header navigation
+	if !strings.Contains(body, "+ New Issue") {
+		t.Error("board page missing '+ New Issue' button in header navigation")
 	}
 
-	// Verify header buttons ARE present (from layout.html)
-	if !strings.Contains(body, "+ New Feature") {
-		t.Error("board page missing '+ New Feature' button in header navigation")
+	// Verify old separate buttons are NOT present
+	if strings.Contains(body, "+ New Feature") {
+		t.Error("board page should not have old '+ New Feature' button")
 	}
-	if !strings.Contains(body, "+ New Bug") {
-		t.Error("board page missing '+ New Bug' button in header navigation")
+	if strings.Contains(body, "+ New Bug") {
+		t.Error("board page should not have old '+ New Bug' button")
+	}
+
+	// Verify the unified button links to /wizard (without type param)
+	if !strings.Contains(body, `href="/wizard"`) {
+		t.Error("board page New Issue button should link to /wizard")
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -152,6 +152,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /wizard", s.handleWizardPage)
 	s.mux.HandleFunc("GET /wizard/new", s.handleWizardNew)
 	s.mux.HandleFunc("GET /wizard/modal", s.handleWizardModal)
+	s.mux.HandleFunc("POST /wizard/select-type", s.handleWizardSelectType)
 	s.mux.HandleFunc("POST /wizard/cancel", s.handleWizardCancel)
 	s.mux.HandleFunc("POST /wizard/refine", s.handleWizardRefine)
 	s.mux.HandleFunc("POST /wizard/breakdown", s.handleWizardBreakdown)

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -40,8 +40,7 @@ h2{font-size:1.1rem;margin-bottom:.75rem;color:var(--muted)}
     <a href="/costs" {{if eq .Active "costs"}}class="active"{{end}}>Costs</a>
   </div>
   <div class="nav-actions">
-    <a href="/wizard?type=feature" class="btn btn-success">+ New Feature</a>
-    <a href="/wizard?type=bug" class="btn btn-danger">+ New Bug</a>
+    <a href="/wizard" class="btn btn-primary">+ New Issue</a>
   </div>
 </nav>
 <div class="container">

--- a/internal/dashboard/templates/wizard_new.html
+++ b/internal/dashboard/templates/wizard_new.html
@@ -1,5 +1,44 @@
 {{define "wizard-step-content"}}
 <div class="wizard-step-content">
+  {{if .NeedsTypeSelection}}
+  <h1>Select Issue Type</h1>
+  
+  <form hx-post="/wizard/select-type{{if .IsPage}}?page=1{{end}}" hx-target="#wizard-content" hx-swap="innerHTML" hx-disabled-elt="button[type='submit']">
+    {{if .IsPage}}<input type="hidden" name="page" value="1">{{end}}
+    
+    <div class="type-selector">
+      <label class="type-card feature-card">
+        <input type="radio" name="wizard_type" value="feature" required>
+        <div class="type-card-content">
+          <div class="type-icon">✨</div>
+          <div class="type-title">Feature</div>
+          <div class="type-description">New functionality or enhancement</div>
+        </div>
+      </label>
+      
+      <label class="type-card bug-card">
+        <input type="radio" name="wizard_type" value="bug" required>
+        <div class="type-card-content">
+          <div class="type-icon">🐛</div>
+          <div class="type-title">Bug</div>
+          <div class="type-description">Something is not working correctly</div>
+        </div>
+      </label>
+    </div>
+    
+    <div class="form-actions">
+      {{if .IsPage}}
+      <a href="/" class="btn">Cancel</a>
+      {{else}}
+      <button type="button" class="btn" onclick="closeWizardModal()">Cancel</button>
+      {{end}}
+      <button type="submit" class="btn btn-primary">
+        <span class="spinner" style="display:none;">⏳</span>
+        <span class="label">Continue</span>
+      </button>
+    </div>
+  </form>
+  {{else}}
   <h1>Create New {{if eq .Type "bug"}}Bug Report{{else}}Feature{{end}}</h1>
   
   <form hx-post="/wizard/refine{{if .IsPage}}?page=1{{end}}" hx-target="#wizard-content" hx-swap="innerHTML" hx-disabled-elt="button[type='submit']">
@@ -24,6 +63,7 @@
       </button>
     </div>
   </form>
+  {{end}}
 </div>
 
 <style>
@@ -48,6 +88,61 @@
 .form-actions { display: flex; justify-content: space-between; gap: 0.5rem; margin-top: 1.5rem; }
 .htmx-request .spinner { display: inline !important; }
 .htmx-request .label { display: none; }
+
+/* Type selector styles */
+.type-selector {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+.type-card {
+  cursor: pointer;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  text-align: center;
+  transition: all 0.2s;
+  background: var(--surface);
+}
+.type-card:hover {
+  border-color: var(--accent);
+}
+.type-card input[type="radio"] {
+  display: none;
+}
+.type-card input[type="radio"]:checked + .type-card-content {
+  color: var(--accent);
+}
+.type-card:has(input[type="radio"]:checked) {
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+}
+.type-card.feature-card:has(input[type="radio"]:checked) {
+  border-color: var(--accent);
+  background: rgba(88, 166, 255, 0.1);
+}
+.type-card.bug-card:has(input[type="radio"]:checked) {
+  border-color: var(--red);
+  background: rgba(248, 81, 73, 0.1);
+}
+.type-card.bug-card:hover {
+  border-color: var(--red);
+}
+.type-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+.type-title {
+  font-weight: 600;
+  font-size: 1.1rem;
+  margin-bottom: 0.25rem;
+  color: var(--text);
+}
+.type-description {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
 </style>
 {{end}}
 

--- a/internal/dashboard/templates/wizard_steps.html
+++ b/internal/dashboard/templates/wizard_steps.html
@@ -1,5 +1,39 @@
 {{define "wizard-steps"}}
 <div class="step-indicator" id="wizard-step-indicator" hx-swap-oob="true">
+  {{if .NeedsTypeSelection}}
+  <div class="step {{if eq .CurrentStep 1}}active{{end}} {{if gt .CurrentStep 1}}completed{{end}}">
+    <span class="step-number">1</span>
+    <span class="step-label">Type</span>
+  </div>
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 2}}active{{end}} {{if gt .CurrentStep 2}}completed{{end}}">
+    <span class="step-number">2</span>
+    <span class="step-label">Idea</span>
+  </div>
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 3}}active{{end}} {{if gt .CurrentStep 3}}completed{{end}}">
+    <span class="step-number">3</span>
+    <span class="step-label">Refine</span>
+  </div>
+  {{if .ShowBreakdownStep}}
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 4}}active{{end}} {{if gt .CurrentStep 4}}completed{{end}}">
+    <span class="step-number">4</span>
+    <span class="step-label">Breakdown</span>
+  </div>
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 5}}active{{end}}">
+    <span class="step-number">5</span>
+    <span class="step-label">Create</span>
+  </div>
+  {{else}}
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 4}}active{{end}}">
+    <span class="step-number">4</span>
+    <span class="step-label">Create</span>
+  </div>
+  {{end}}
+  {{else}}
   <div class="step {{if eq .CurrentStep 1}}active{{end}} {{if gt .CurrentStep 1}}completed{{end}}">
     <span class="step-number">1</span>
     <span class="step-label">Idea</span>
@@ -26,6 +60,7 @@
     <span class="step-number">3</span>
     <span class="step-label">Create</span>
   </div>
+  {{end}}
   {{end}}
 </div>
 {{end}}


### PR DESCRIPTION
Closes #134

## Summary

Replace the two separate "+ New Feature" and "+ New Bug" buttons with a single "+ New Issue" button. The wizard's first step becomes a type selector (Feature / Bug) before proceeding to the idea input.

## Current flow

```
Header: [+ New Feature] [+ New Bug]  →  /wizard?type=feature  or  /wizard?type=bug
Step 1: Idea input (type already decided)
```

## Target flow

```
Header: [+ New Issue]  →  /wizard
Step 1: Type selection (Feature / Bug cards)
Step 2: Idea input
```

## Requirements

- Single "New Issue" button in navigation header
- Step 1: type selector with visual cards (feature=blue/accent, bug=red)
- Direct links with `?type=feature` or `?type=bug` skip type selection (backward compat)
- Selected type stored in session, used throughout the flow
- Step indicator adjusts accordingly

## Files to change

| File | Change |
|------|--------|
| `layout.html` | Replace two buttons with single "+ New Issue" |
| `wizard_new.html` | Add type selector UI before idea textarea, or create new `wizard_type.html` step |
| `handlers.go` | Update `handleWizardPage`/`handleWizardNew` — show type selector when no `?type=` param |
| `wizard_page.html` | Update step indicator (5 steps or keep 4 with type as sub-step of step 1) |

## Notes

- `WizardType` enum and session management stay unchanged
- LLM prompts already handle both types — no changes needed
- Keep existing route `/wizard?type=X` for backward compatibility