### PR TITLE
Move sprint assignment checkbox from Breakdown step to Refine step

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -905,6 +905,10 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		session.SetSkipBreakdown(true)
 	}
 
+	// Parse add_to_sprint checkbox
+	addToSprint := r.FormValue("add_to_sprint") == "1"
+	session.SetAddToSprint(addToSprint)
+
 	session.SetStep(WizardStepRefine)
 	session.AddLog("user", inputText)
 
@@ -920,6 +924,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 			RefinedDescription string
 			IsPage             bool
 			SkipBreakdown      bool
+			SprintName         string
 			CurrentStep        int
 			ShowBreakdownStep  bool
 			NeedsTypeSelection bool
@@ -929,6 +934,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 			RefinedDescription: mockRefined,
 			IsPage:             isPage,
 			SkipBreakdown:      session.SkipBreakdown,
+			SprintName:         s.activeSprintName(),
 			CurrentStep:        2,
 			ShowBreakdownStep:  session.Type == WizardTypeFeature && !session.SkipBreakdown,
 			NeedsTypeSelection: false,
@@ -1002,6 +1008,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		RefinedDescription string
 		IsPage             bool
 		SkipBreakdown      bool
+		SprintName         string
 		CurrentStep        int
 		ShowBreakdownStep  bool
 		NeedsTypeSelection bool
@@ -1011,6 +1018,7 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 		RefinedDescription: refinedDesc,
 		IsPage:             isPage,
 		SkipBreakdown:      session.SkipBreakdown,
+		SprintName:         s.activeSprintName(),
 		CurrentStep:        2,
 		ShowBreakdownStep:  session.Type == WizardTypeFeature && !session.SkipBreakdown,
 		NeedsTypeSelection: false,

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -2661,3 +2661,95 @@ func TestWizardStepIndicator_NoDuplicateInContent(t *testing.T) {
 		t.Errorf("step indicator appears %d times, should appear only once (no duplicates in content)", indicatorCount)
 	}
 }
+
+// TestHandleWizardRefine_ParsesAddToSprint verifies that the add_to_sprint form value is parsed and stored in session
+func TestHandleWizardRefine_ParsesAddToSprint(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create a session
+	session, _ := srv.wizardStore.Create("feature")
+
+	// Test with add_to_sprint checked
+	form := url.Values{}
+	form.Set("session_id", session.ID)
+	form.Set("idea", "Test feature idea")
+	form.Set("add_to_sprint", "1")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	// Verify session was updated
+	updated, ok := srv.wizardStore.Get(session.ID)
+	if !ok {
+		t.Fatal("expected to retrieve session")
+	}
+
+	if !updated.AddToSprint {
+		t.Errorf("expected AddToSprint to be true when checkbox is checked, got %v", updated.AddToSprint)
+	}
+
+	// Test with add_to_sprint unchecked
+	session2, _ := srv.wizardStore.Create("feature")
+	form2 := url.Values{}
+	form2.Set("session_id", session2.ID)
+	form2.Set("idea", "Another test idea")
+	// Don't set add_to_sprint
+
+	req2 := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(form2.Encode()))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec2 := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec2.Code)
+	}
+
+	updated2, ok := srv.wizardStore.Get(session2.ID)
+	if !ok {
+		t.Fatal("expected to retrieve session")
+	}
+
+	if updated2.AddToSprint {
+		t.Errorf("expected AddToSprint to be false when checkbox is unchecked, got %v", updated2.AddToSprint)
+	}
+}
+
+// TestHandleWizardRefine_SprintNameInTemplate verifies SprintName is passed to template when active sprint exists
+func TestHandleWizardRefine_SprintNameInTemplate(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create a session
+	session, _ := srv.wizardStore.Create("feature")
+
+	form := url.Values{}
+	form.Set("session_id", session.ID)
+	form.Set("idea", "Test feature idea")
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/refine", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardRefine(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Since there's no active sprint (gh is nil), SprintName should be empty
+	// and the sprint checkbox should NOT appear
+	if strings.Contains(body, `name="add_to_sprint"`) {
+		t.Error("sprint checkbox should NOT appear when there is no active sprint")
+	}
+}

--- a/internal/dashboard/templates/wizard_breakdown.html
+++ b/internal/dashboard/templates/wizard_breakdown.html
@@ -24,15 +24,6 @@
     <input type="hidden" name="session_id" value="{{.SessionID}}">
     {{if .IsPage}}<input type="hidden" name="page" value="1">{{end}}
     
-    {{if .SprintName}}
-    <div class="sprint-option">
-      <label class="sprint-checkbox">
-        <input type="checkbox" name="add_to_sprint" value="1" checked>
-        <span class="sprint-checkbox-label">Add to current sprint <strong>{{.SprintName}}</strong></span>
-      </label>
-    </div>
-    {{end}}
-    
     <div class="form-actions">
       {{if .IsPage}}
       <a href="/" class="btn">Cancel</a>

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -22,6 +22,15 @@
     </div>
     {{end}}
     
+    {{if .SprintName}}
+    <div class="form-group sprint-option">
+      <label class="sprint-checkbox">
+        <input type="checkbox" name="add_to_sprint" value="1" checked>
+        <span class="sprint-checkbox-label">Add to current sprint <strong>{{.SprintName}}</strong></span>
+      </label>
+    </div>
+    {{end}}
+    
     <div id="refine-error" class="error-message" style="display:none; color: var(--error); margin: 1rem 0;"></div>
     
     <div class="form-actions">

--- a/internal/dashboard/wizard_test.go
+++ b/internal/dashboard/wizard_test.go
@@ -536,3 +536,20 @@ func TestSessionConstants(t *testing.T) {
 		t.Errorf("expected SessionMaxAge to be 30 minutes, got %v", SessionMaxAge)
 	}
 }
+
+func TestWizardSession_SetAddToSprint(t *testing.T) {
+	session := &WizardSession{
+		ID:   "test-id",
+		Type: "feature",
+	}
+
+	session.SetAddToSprint(true)
+	if !session.AddToSprint {
+		t.Errorf("expected AddToSprint to be true, got %v", session.AddToSprint)
+	}
+
+	session.SetAddToSprint(false)
+	if session.AddToSprint {
+		t.Errorf("expected AddToSprint to be false, got %v", session.AddToSprint)
+	}
+}


### PR DESCRIPTION
Closes #129

## Summary

The "Add to current sprint" checkbox is in the Breakdown step, which bugs skip entirely (bugs always go Refine → Create). Move it to the Refine step so both features and bugs can be assigned to the active sprint.

## Current behavior

- Feature with breakdown: sees sprint checkbox in Breakdown step ✓
- Feature without breakdown: skips Breakdown → no sprint checkbox ✗
- Bug: always skips Breakdown → no sprint checkbox ✗

## Expected behavior

Sprint checkbox appears in the Refine step for all ticket types (feature and bug).

## Files to change

| File | Change |
|------|--------|
| `wizard_breakdown.html` | Remove sprint checkbox section |
| `wizard_refine.html` | Add sprint checkbox (same markup/styling) |
| `handlers.go` | Pass `SprintName` in `handleWizardRefine` data struct, parse `add_to_sprint` from refine form and store in session |

## Notes

- Checkbox only visible when active sprint exists (`SprintName != ""`)
- Default: checked (current behavior)
- `handleWizardCreate` / `handleWizardCreateSingle` already read `AddToSprint` from session — no changes needed there