### PR TITLE
Fix: wizard uses raw idea text instead of refined description for issue title

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1248,9 +1248,9 @@ func (s *Server) handleWizardCreate(w http.ResponseWriter, r *http.Request) {
 
 	// If no GitHub client, return mock confirmation for testing
 	if s.gh == nil {
-		mockTitle := session.IdeaText
+		mockTitle := session.RefinedDescription
 		if mockTitle == "" {
-			mockTitle = session.RefinedDescription
+			mockTitle = session.IdeaText
 		}
 		if len(mockTitle) > 200 {
 			mockTitle = mockTitle[:197] + "..."
@@ -1303,9 +1303,9 @@ func (s *Server) handleWizardCreate(w http.ResponseWriter, r *http.Request) {
 		epicLabels = append(epicLabels, "bug")
 	}
 
-	epicTitle := session.IdeaText
+	epicTitle := session.RefinedDescription
 	if epicTitle == "" {
-		epicTitle = session.RefinedDescription
+		epicTitle = session.IdeaText
 	}
 	// GitHub issue titles have a 256 character limit
 	if len(epicTitle) > 200 {
@@ -1484,9 +1484,9 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 
 	// If no GitHub client, return mock confirmation for testing
 	if s.gh == nil {
-		mockTitle := session.IdeaText
+		mockTitle := session.RefinedDescription
 		if mockTitle == "" {
-			mockTitle = session.RefinedDescription
+			mockTitle = session.IdeaText
 		}
 		if len(mockTitle) > 200 {
 			mockTitle = mockTitle[:197] + "..."
@@ -1534,10 +1534,10 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 		labels = append(labels, "bug")
 	}
 
-	// Build title from idea text (truncated to 200 chars)
-	title := session.IdeaText
+	// Build title from refined description (truncated to 200 chars)
+	title := session.RefinedDescription
 	if title == "" {
-		title = session.RefinedDescription
+		title = session.IdeaText
 	}
 	if len(title) > 200 {
 		title = title[:197] + "..."

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -509,6 +509,36 @@ func TestHandleWizardCreate(t *testing.T) {
 	}
 }
 
+// TestHandleWizardCreate_UsesRefinedDescriptionForTitle verifies that epic title uses refined description
+func TestHandleWizardCreate_UsesRefinedDescriptionForTitle(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	srv.gh = nil
+	defer srv.wizardStore.Stop()
+
+	session, _ := srv.wizardStore.Create("feature")
+	session.SetIdeaText("Raw user input")
+	session.SetRefinedDescription("LLM refined description")
+	session.SetTasks([]WizardTask{
+		{Title: "Task 1", Description: "Desc 1", Priority: "high", Complexity: "M"},
+		{Title: "Task 2", Description: "Desc 2", Priority: "medium", Complexity: "S"},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/create", strings.NewReader("session_id="+session.ID))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardCreate(rec, req)
+
+	// Verify response contains the refined description as title, not raw idea text
+	body := rec.Body.String()
+	if !strings.Contains(body, "LLM refined description") {
+		t.Errorf("expected response to contain refined description as title, got: %s", body)
+	}
+	if strings.Contains(body, "Raw user input") && !strings.Contains(body, "LLM refined description") {
+		t.Error("expected title to come from refined description, not raw idea text")
+	}
+}
+
 func TestHandleWizardCreate_NoTasks(t *testing.T) {
 	srv := &Server{
 		tmpls:       make(map[string]*template.Template),
@@ -2069,6 +2099,31 @@ func TestHandleWizardRefine_SkipBreakdown(t *testing.T) {
 	updatedSession3, _ := srv.wizardStore.Get(session3.ID)
 	if !updatedSession3.SkipBreakdown {
 		t.Error("expected SkipBreakdown to be true for bug type")
+	}
+}
+
+// TestHandleWizardCreateSingle_UsesRefinedDescriptionForTitle verifies single issue uses refined description
+func TestHandleWizardCreateSingle_UsesRefinedDescriptionForTitle(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	session, _ := srv.wizardStore.Create("feature")
+	session.SetIdeaText("Raw user input")
+	session.SetRefinedDescription("LLM refined description")
+	session.SetSkipBreakdown(true)
+
+	form := url.Values{}
+	form.Set("session_id", session.ID)
+
+	req := httptest.NewRequest(http.MethodPost, "/wizard/create", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardCreate(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "LLM refined description") {
+		t.Errorf("expected response to contain refined description as title, got: %s", body)
 	}
 }
 

--- a/internal/dashboard/prompts.go
+++ b/internal/dashboard/prompts.go
@@ -37,7 +37,9 @@ IMPORTANT: Consider the codebase context above when refining. Look for:
 
 Return a well-structured, professional %s suitable for a GitHub issue.
 
-CRITICAL: Return ONLY the markdown content. No introduction, no preamble, no conversational text, no "Let me summarize". Start directly with the structured content. No "Here's the refined description" or similar phrases. Just the content itself.`
+CRITICAL: Return ONLY the markdown content. No introduction, no preamble, no conversational text, no "Let me summarize". Start directly with the structured content. No "Here's the refined description" or similar phrases. Just the content itself.
+
+CRITICAL: Output MUST be in English regardless of input language.`
 
 // BreakdownPromptTemplate is the base template for task breakdown
 // It instructs the LLM to break down a technical description into actionable tasks

--- a/internal/dashboard/prompts_test.go
+++ b/internal/dashboard/prompts_test.go
@@ -1,0 +1,13 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRefinementPrompt_EnglishOnlyConstraint verifies prompt requires English output
+func TestRefinementPrompt_EnglishOnlyConstraint(t *testing.T) {
+	if !strings.Contains(RefinementPromptTemplate, "Output MUST be in English regardless of input language") {
+		t.Error("RefinementPromptTemplate must contain English-only constraint")
+	}
+}


### PR DESCRIPTION
Closes #128

## Summary

When creating GitHub issues, the wizard uses `session.IdeaText` (raw user input) as the issue title instead of `session.RefinedDescription` (LLM-refined output). The refined description should be primary, with idea text as fallback only.

Additionally, the LLM refinement prompt must enforce English-only output regardless of input language.

## Current behavior (bug)

```go
// handlers.go:1260-1263 and 1479-1483
epicTitle := session.IdeaText           // raw user input — WRONG
if epicTitle == "" {
    epicTitle = session.RefinedDescription  // fallback
}
```

## Expected behavior

```go
title := session.RefinedDescription     // refined output — CORRECT
if title == "" {
    title = session.IdeaText            // fallback only
}
```

## Files to change

| File | Change |
|------|--------|
| `handlers.go` | Swap priority in `handleWizardCreate` (line ~1260) and `handleWizardCreateSingle` (line ~1479) |
| `prompts.go` | Add to `RefinementPromptTemplate`: "Output MUST be in English regardless of input language" |

## Acceptance criteria

- [ ] Issue title comes from refined description, not raw idea text
- [ ] Both epic and single-issue creation paths are fixed
- [ ] LLM always returns English descriptions even when input is in another language
- [ ] Mock mode follows same logic