### PR TITLE
## Problem Statement
Currently, GitHub issues created through the system have excessively long titles that are difficult to scan, understand at a glance, and manage in issue lists. This reduces pro...

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1030,6 +1030,193 @@ func (s *Server) handleWizardRefine(w http.ResponseWriter, r *http.Request) {
 	s.renderFragment(w, "wizard_refine.html", data)
 }
 
+// handleWizardGenerateTitle generates or regenerates the issue title from technical planning
+func (s *Server) handleWizardGenerateTitle(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	sessionID := r.FormValue("session_id")
+	if sessionID == "" {
+		http.Error(w, "missing session_id", http.StatusBadRequest)
+		return
+	}
+
+	// Check for page mode
+	isPage := r.FormValue("page") == "1" || r.URL.Query().Get("page") == "1"
+
+	// Check if this is a regeneration request
+	regenerate := r.FormValue("regenerate") == "1"
+
+	session, ok := s.wizardStore.Get(sessionID)
+	if !ok {
+		http.Error(w, "session not found", http.StatusBadRequest)
+		return
+	}
+
+	// If user provided a custom title, store it
+	customTitle := r.FormValue("issue_title")
+	if customTitle != "" && !regenerate {
+		session.SetCustomTitle(customTitle)
+		session.SetUseCustomTitle(true)
+	}
+
+	session.SetStep(WizardStepTitle)
+
+	// If we already have a generated title and not regenerating, use it
+	if session.GeneratedTitle != "" && !regenerate {
+		title := session.GetFinalTitle()
+		s.renderTitlePage(w, session, title, isPage)
+		return
+	}
+
+	// Generate title using LLM
+	if s.oc == nil {
+		// Mock title generation for testing
+		mockTitle := generateMockTitle(session.Type, session.TechnicalPlanning)
+		session.SetGeneratedTitle(mockTitle)
+		session.AddLog("system", "Mock: Generated title: "+mockTitle)
+
+		title := session.GetFinalTitle()
+		s.renderTitlePage(w, session, title, isPage)
+		return
+	}
+
+	// Create LLM session for title generation
+	llmSession, err := s.oc.CreateSession("Wizard Title Generation")
+	if err != nil {
+		log.Printf("[Wizard] Error creating LLM session for title: %v", err)
+		session.AddLog("system", "Error: Failed to create LLM session for title - "+err.Error())
+		s.renderError(w, "Failed to connect to AI service for title generation. Please try again.", session.ID, string(session.Type), isPage)
+		return
+	}
+	defer func() {
+		if err := s.oc.DeleteSession(llmSession.ID); err != nil {
+			log.Printf("[Wizard] Error deleting LLM session %s: %v", llmSession.ID, err)
+		}
+	}()
+
+	// Build title generation prompt
+	prompt := BuildTitleGenerationPrompt(session.Type, session.TechnicalPlanning, session.Language)
+	session.AddLog("system", "Sending title generation request to LLM")
+
+	// Send message to LLM with timeout
+	ctx, cancel := context.WithTimeout(r.Context(), LLMRequestTimeout)
+	defer cancel()
+
+	model := opencode.ParseModelRef(s.wizardLLM)
+	var output strings.Builder
+	response, err := s.oc.SendMessageStream(ctx, llmSession.ID, prompt, model, &output)
+	if err != nil {
+		log.Printf("[Wizard] Error from LLM during title generation: %v", err)
+		session.AddLog("system", "LLM error during title generation: "+err.Error())
+
+		errorMsg := "Failed to generate title. "
+		if ctx.Err() == context.DeadlineExceeded {
+			errorMsg += "The AI service timed out. Please try again."
+		} else {
+			errorMsg += "Please check your connection and try again."
+		}
+
+		s.renderError(w, errorMsg, session.ID, string(session.Type), isPage)
+		return
+	}
+
+	// Extract title from response
+	var generatedTitle string
+	if len(response.Parts) > 0 {
+		generatedTitle = strings.TrimSpace(response.Parts[0].Text)
+	}
+
+	// Validate title
+	if generatedTitle == "" {
+		log.Printf("[Wizard] LLM returned empty title for session %s", session.ID)
+		session.AddLog("system", "Error: LLM returned empty title")
+		// Fallback to a default title based on type
+		if session.Type == WizardTypeBug {
+			generatedTitle = "[Bug] Fix issue"
+		} else {
+			generatedTitle = "[Feature] New feature"
+		}
+	}
+
+	// Ensure title has proper prefix
+	if !strings.HasPrefix(generatedTitle, "[Feature]") && !strings.HasPrefix(generatedTitle, "[Bug]") {
+		if session.Type == WizardTypeBug {
+			generatedTitle = "[Bug] " + generatedTitle
+		} else {
+			generatedTitle = "[Feature] " + generatedTitle
+		}
+	}
+
+	// Truncate if too long
+	if len(generatedTitle) > 80 {
+		generatedTitle = generatedTitle[:77] + "..."
+	}
+
+	session.SetGeneratedTitle(generatedTitle)
+	session.AddLog("assistant", "Generated title: "+generatedTitle)
+
+	title := session.GetFinalTitle()
+	s.renderTitlePage(w, session, title, isPage)
+}
+
+// renderTitlePage renders the title page with the given title
+func (s *Server) renderTitlePage(w http.ResponseWriter, session *WizardSession, title string, isPage bool) {
+	data := struct {
+		SessionID          string
+		Type               string
+		Title              string
+		IsPage             bool
+		SprintName         string
+		CurrentStep        int
+		ShowBreakdownStep  bool
+		NeedsTypeSelection bool
+	}{
+		SessionID:          session.ID,
+		Type:               string(session.Type),
+		Title:              title,
+		IsPage:             isPage,
+		SprintName:         s.activeSprintName(),
+		CurrentStep:        3, // Title is step 3
+		ShowBreakdownStep:  false,
+		NeedsTypeSelection: false,
+	}
+
+	s.renderFragment(w, "wizard_title.html", data)
+}
+
+// generateMockTitle generates a mock title for testing
+func generateMockTitle(wizardType WizardType, technicalPlanning string) string {
+	// Extract first line or first sentence for context
+	lines := strings.Split(technicalPlanning, "\n")
+	var context string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" && !strings.HasPrefix(trimmed, "#") && !strings.HasPrefix(trimmed, "-") {
+			context = trimmed
+			break
+		}
+	}
+
+	if context == "" {
+		context = "New implementation"
+	}
+
+	// Truncate context if too long
+	words := strings.Fields(context)
+	if len(words) > 5 {
+		words = words[:5]
+	}
+	context = strings.Join(words, " ")
+
+	if wizardType == WizardTypeBug {
+		return "[Bug] Fix " + context
+	}
+	return "[Feature] Add " + context
+}
+
 // renderError renders an error message in the wizard modal
 func (s *Server) renderError(w http.ResponseWriter, errorMsg, sessionID, wizardType string, isPage bool) {
 	data := struct {
@@ -1089,12 +1276,9 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 
 	// If no GitHub client, return mock confirmation for testing
 	if s.gh == nil {
-		mockTitle := session.TechnicalPlanning
+		mockTitle := session.GetFinalTitle()
 		if mockTitle == "" {
-			mockTitle = session.IdeaText
-		}
-		if len(mockTitle) > 200 {
-			mockTitle = mockTitle[:197] + "..."
+			mockTitle = generateMockTitle(session.Type, session.TechnicalPlanning)
 		}
 		mockIssue := CreatedIssue{
 			Number:  100,
@@ -1122,7 +1306,7 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 			HasErrors:          false,
 			IsPage:             isPage,
 			IsSingleIssue:      true,
-			CurrentStep:        3, // Step 3 is Create in new 3-step flow
+			CurrentStep:        4, // Step 4 is Create in new 4-step flow
 			ShowBreakdownStep:  false,
 			NeedsTypeSelection: false,
 			Type:               string(session.Type),
@@ -1141,13 +1325,16 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 		labels = append(labels, "bug")
 	}
 
-	// Build title from technical planning (truncated to 200 chars)
-	title := session.TechnicalPlanning
+	// Get title from session (either custom or generated)
+	title := session.GetFinalTitle()
 	if title == "" {
-		title = session.IdeaText
+		// Fallback: generate a simple title from technical planning
+		title = generateMockTitle(session.Type, session.TechnicalPlanning)
 	}
-	if len(title) > 200 {
-		title = title[:197] + "..."
+
+	// Validate title length (GitHub limit is 256, but we enforce 80)
+	if len(title) > 80 {
+		title = title[:77] + "..."
 	}
 
 	// Create the single issue
@@ -1197,7 +1384,7 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 		HasErrors:          false,
 		IsPage:             isPage,
 		IsSingleIssue:      true,
-		CurrentStep:        3, // Step 3 is Create in new 3-step flow
+		CurrentStep:        4, // Step 4 is Create in new 4-step flow
 		ShowBreakdownStep:  false,
 		NeedsTypeSelection: false,
 		Type:               string(session.Type),
@@ -1335,12 +1522,14 @@ func (s *Server) handleWizardModal(w http.ResponseWriter, r *http.Request) {
 		CurrentStep        int
 		ShowBreakdownStep  bool
 		NeedsTypeSelection bool
+		IsPage             bool
 	}{
 		Type:               wizardType,
 		SessionID:          "",
 		CurrentStep:        1,
 		ShowBreakdownStep:  false,
 		NeedsTypeSelection: needsTypeSelection,
+		IsPage:             false, // Modal is never page mode
 	}
 
 	if session != nil {

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -73,7 +73,7 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 	tmpls["wizard_modal.html"] = wizardModalTmpl
 
 	// Parse wizard partial templates (no layout)
-	wizardPartials := []string{"wizard_new.html", "wizard_refine.html", "wizard_create.html", "wizard_error.html", "wizard_logs.html"}
+	wizardPartials := []string{"wizard_new.html", "wizard_refine.html", "wizard_title.html", "wizard_create.html", "wizard_error.html", "wizard_logs.html"}
 	for _, page := range wizardPartials {
 		t, err := template.ParseFiles(
 			filepath.Join(templateDir, "wizard_steps.html"),
@@ -2696,5 +2696,251 @@ func TestHandleWizardRefine_AcceptsLanguageParameter(t *testing.T) {
 
 	if session.Language != "pl-PL" {
 		t.Errorf("Expected Language to be 'pl-PL', got %q", session.Language)
+	}
+}
+
+// TestHandleWizardGenerateTitle tests the title generation handler
+func TestHandleWizardGenerateTitle(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create a session first
+	session, err := srv.wizardStore.Create("feature")
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	// Set up technical planning
+	session.SetTechnicalPlanning("## Problem Statement\n\nAdd user authentication to the system.")
+
+	// Test title generation
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+
+	req := httptest.NewRequest("POST", "/wizard/title", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardGenerateTitle(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+
+	// Verify session has generated title
+	updatedSession, ok := srv.wizardStore.Get(session.ID)
+	if !ok {
+		t.Fatal("Session not found after title generation")
+	}
+
+	if updatedSession.GeneratedTitle == "" {
+		t.Error("Expected GeneratedTitle to be set")
+	}
+
+	// Verify title has proper prefix
+	if !strings.HasPrefix(updatedSession.GeneratedTitle, "[") {
+		t.Errorf("Expected title to have prefix, got: %s", updatedSession.GeneratedTitle)
+	}
+}
+
+// TestHandleWizardGenerateTitle_BugType tests title generation for bug type
+func TestHandleWizardGenerateTitle_BugType(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create a bug session
+	session, err := srv.wizardStore.Create("bug")
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	session.SetTechnicalPlanning("## Problem Statement\n\nFix login error when user enters wrong password.")
+
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+
+	req := httptest.NewRequest("POST", "/wizard/title", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardGenerateTitle(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+
+	updatedSession, ok := srv.wizardStore.Get(session.ID)
+	if !ok {
+		t.Fatal("Session not found")
+	}
+
+	// Bug titles should have [Bug] prefix
+	if !strings.HasPrefix(updatedSession.GeneratedTitle, "[Bug]") {
+		t.Errorf("Expected bug title to have [Bug] prefix, got: %s", updatedSession.GeneratedTitle)
+	}
+}
+
+// TestHandleWizardGenerateTitle_CustomTitle tests custom title override
+func TestHandleWizardGenerateTitle_CustomTitle(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	session, err := srv.wizardStore.Create("feature")
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	session.SetTechnicalPlanning("## Problem Statement\n\nAdd user authentication.")
+
+	// Submit custom title
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+	formData.Set("issue_title", "[Feature] Custom authentication title")
+
+	req := httptest.NewRequest("POST", "/wizard/title", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardGenerateTitle(rec, req)
+
+	updatedSession, ok := srv.wizardStore.Get(session.ID)
+	if !ok {
+		t.Fatal("Session not found")
+	}
+
+	if updatedSession.CustomTitle != "[Feature] Custom authentication title" {
+		t.Errorf("Expected CustomTitle to be set, got: %s", updatedSession.CustomTitle)
+	}
+
+	if !updatedSession.UseCustomTitle {
+		t.Error("Expected UseCustomTitle to be true")
+	}
+}
+
+// TestHandleWizardGenerateTitle_MissingSession tests error handling for missing session
+func TestHandleWizardGenerateTitle_MissingSession(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	formData := url.Values{}
+	formData.Set("session_id", "non-existent-session")
+
+	req := httptest.NewRequest("POST", "/wizard/title", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardGenerateTitle(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for missing session, got %d", rec.Code)
+	}
+}
+
+// TestHandleWizardGenerateTitle_MissingSessionID tests error handling for missing session_id
+func TestHandleWizardGenerateTitle_MissingSessionID(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest("POST", "/wizard/title", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardGenerateTitle(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for missing session_id, got %d", rec.Code)
+	}
+}
+
+// TestHandleWizardCreate_UsesSessionTitle tests that issue creation uses the session title
+func TestHandleWizardCreate_UsesSessionTitle(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create a session with technical planning and generated title
+	session, err := srv.wizardStore.Create("feature")
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	session.SetTechnicalPlanning("## Problem Statement\n\nAdd user authentication.")
+	session.SetGeneratedTitle("[Feature] Add user authentication system")
+	session.SetStep(WizardStepTitle)
+
+	// Create issue
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+
+	req := httptest.NewRequest("POST", "/wizard/create", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleWizardCreate(rec, req)
+
+	// Should return 200 OK (mock mode)
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", rec.Code)
+	}
+
+	// Verify the response contains the generated title
+	body := rec.Body.String()
+	if !strings.Contains(body, "[Feature] Add user authentication system") {
+		t.Errorf("Expected response to contain the generated title, got: %s", body)
+	}
+}
+
+// TestGenerateMockTitle tests the mock title generation function
+func TestGenerateMockTitle(t *testing.T) {
+	// Test feature type
+	planning := "## Problem Statement\n\nAdd user authentication to the system."
+	title := generateMockTitle(WizardTypeFeature, planning)
+
+	if !strings.HasPrefix(title, "[Feature]") {
+		t.Errorf("Expected feature title to have [Feature] prefix, got: %s", title)
+	}
+
+	// Test bug type
+	planning = "## Problem Statement\n\nFix login error when user enters wrong password."
+	title = generateMockTitle(WizardTypeBug, planning)
+
+	if !strings.HasPrefix(title, "[Bug]") {
+		t.Errorf("Expected bug title to have [Bug] prefix, got: %s", title)
+	}
+
+	// Test with empty planning
+	title = generateMockTitle(WizardTypeFeature, "")
+	if title == "" {
+		t.Error("Expected non-empty title even with empty planning")
+	}
+}
+
+// TestWizardRoutes_TitleRoute tests that the title route is registered
+func TestWizardRoutes_TitleRoute(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create a session
+	session, err := srv.wizardStore.Create("feature")
+	if err != nil {
+		t.Fatalf("Failed to create session: %v", err)
+	}
+
+	session.SetTechnicalPlanning("## Problem Statement\n\nAdd user authentication.")
+
+	// Test that the route exists and is accessible
+	formData := url.Values{}
+	formData.Set("session_id", session.ID)
+
+	req := httptest.NewRequest("POST", "/wizard/title", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	// The handler should exist and process the request
+	srv.handleWizardGenerateTitle(rec, req)
+
+	// Should not return 404
+	if rec.Code == http.StatusNotFound {
+		t.Error("Title route should be registered")
 	}
 }

--- a/internal/dashboard/prompts.go
+++ b/internal/dashboard/prompts.go
@@ -204,6 +204,30 @@ func BuildTechnicalPlanningPrompt(wizardType WizardType, idea string, codebaseCo
 	)
 }
 
+// BuildTitleGenerationPrompt creates the prompt for generating a concise issue title
+// wizardType: the type of wizard (feature or bug)
+// technicalPlanning: the technical planning content to base the title on
+// language: the output language (e.g., "en-US", "pl-PL")
+func BuildTitleGenerationPrompt(wizardType WizardType, technicalPlanning string, language string) string {
+	// Default to English if no language specified
+	if language == "" {
+		language = "en-US"
+	}
+
+	var typeLabel string
+	if wizardType == WizardTypeBug {
+		typeLabel = "Bug"
+	} else {
+		typeLabel = "Feature"
+	}
+
+	return fmt.Sprintf(TitleGenerationPromptTemplate,
+		language,
+		typeLabel,
+		technicalPlanning,
+	)
+}
+
 // GetCodebaseContext gathers context about the existing codebase
 // This is a placeholder implementation that can be enhanced to:
 // - Read key configuration files (package.json, go.mod, etc.)
@@ -228,6 +252,24 @@ func GetCodebaseContext() string {
 
 	return context.String()
 }
+
+// TitleGenerationPromptTemplate generates concise GitHub issue titles from technical planning
+// It instructs the LLM to create a short, scannable title with a type prefix
+const TitleGenerationPromptTemplate = `You are a GitHub issue title generator. Your ONLY output is a concise issue title.
+
+CRITICAL RULES:
+- Output ONLY the title text. Nothing else. No quotes, no explanation, no preamble.
+- Title MUST be 5-8 words, maximum 80 characters.
+- Title MUST start with [Feature] or [Bug] prefix based on the issue type.
+- Title should be scannable and descriptive.
+- Output MUST be in %s regardless of input language.
+
+Issue Type: %s
+
+Technical Planning:
+%s
+
+Generate a concise title:`
 
 // stripLLMPreamble removes conversational preamble that LLMs sometimes prepend
 // before the actual content. It looks for the first markdown heading or list item

--- a/internal/dashboard/prompts_test.go
+++ b/internal/dashboard/prompts_test.go
@@ -59,3 +59,69 @@ func TestBuildTechnicalPlanningPrompt_WithLanguage(t *testing.T) {
 		t.Errorf("Expected prompt to contain language instruction for en-US")
 	}
 }
+
+// TestBuildTitleGenerationPrompt verifies the title generation prompt structure
+func TestBuildTitleGenerationPrompt(t *testing.T) {
+	technicalPlanning := "## Problem Statement\n\nAdd user authentication to the system.\n\n## Architecture Overview\n\nKey components involved: auth service, user database."
+
+	prompt := BuildTitleGenerationPrompt(WizardTypeFeature, technicalPlanning, "en-US")
+
+	// Verify prompt contains required elements
+	if !strings.Contains(prompt, "Output ONLY the title text") {
+		t.Error("Title prompt missing 'Output ONLY the title text' instruction")
+	}
+	if !strings.Contains(prompt, "maximum 80 characters") {
+		t.Error("Title prompt missing max length constraint")
+	}
+	if !strings.Contains(prompt, "[Feature]") {
+		t.Error("Title prompt missing [Feature] prefix requirement")
+	}
+	if !strings.Contains(prompt, technicalPlanning) {
+		t.Error("Title prompt missing technical planning content")
+	}
+	if !strings.Contains(prompt, "Output MUST be in en-US") {
+		t.Error("Title prompt missing language constraint")
+	}
+}
+
+// TestBuildTitleGenerationPrompt_Bug verifies bug type title generation
+func TestBuildTitleGenerationPrompt_Bug(t *testing.T) {
+	technicalPlanning := "## Problem Statement\n\nFix login error when user enters wrong password."
+
+	prompt := BuildTitleGenerationPrompt(WizardTypeBug, technicalPlanning, "en-US")
+
+	if !strings.Contains(prompt, "[Bug]") {
+		t.Error("Bug title prompt should require [Bug] prefix")
+	}
+	if !strings.Contains(prompt, "Issue Type: Bug") {
+		t.Error("Bug title prompt should mention Bug type")
+	}
+}
+
+// TestBuildTitleGenerationPrompt_NonEnglish verifies non-English language handling
+func TestBuildTitleGenerationPrompt_NonEnglish(t *testing.T) {
+	technicalPlanning := "## Problem Statement\n\nAdd user authentication."
+
+	// Test with Polish
+	prompt := BuildTitleGenerationPrompt(WizardTypeFeature, technicalPlanning, "pl-PL")
+	if !strings.Contains(prompt, "Output MUST be in pl-PL") {
+		t.Error("Title prompt should support Polish language")
+	}
+
+	// Test with German
+	prompt = BuildTitleGenerationPrompt(WizardTypeFeature, technicalPlanning, "de-DE")
+	if !strings.Contains(prompt, "Output MUST be in de-DE") {
+		t.Error("Title prompt should support German language")
+	}
+}
+
+// TestBuildTitleGenerationPrompt_DefaultLanguage verifies default language is English
+func TestBuildTitleGenerationPrompt_DefaultLanguage(t *testing.T) {
+	technicalPlanning := "## Problem Statement\n\nAdd user authentication."
+
+	// Test with empty language - should default to en-US
+	prompt := BuildTitleGenerationPrompt(WizardTypeFeature, technicalPlanning, "")
+	if !strings.Contains(prompt, "Output MUST be in en-US") {
+		t.Error("Title prompt should default to en-US when language is empty")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -155,6 +155,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /wizard/select-type", s.handleWizardSelectType)
 	s.mux.HandleFunc("POST /wizard/cancel", s.handleWizardCancel)
 	s.mux.HandleFunc("POST /wizard/refine", s.handleWizardRefine)
+	s.mux.HandleFunc("POST /wizard/title", s.handleWizardGenerateTitle)
 	// REMOVED: s.mux.HandleFunc("POST /wizard/breakdown", s.handleWizardBreakdown)
 	s.mux.HandleFunc("POST /wizard/create", s.handleWizardCreate)
 	s.mux.HandleFunc("GET /wizard/logs/{sessionId}", s.handleWizardLogs)

--- a/internal/dashboard/templates/wizard_refine.html
+++ b/internal/dashboard/templates/wizard_refine.html
@@ -3,7 +3,7 @@
 <div class="wizard-step">
   <h2>Technical Planning</h2>
   
-  <form id="refine-form" hx-post="/wizard/create{{if .IsPage}}?page=1{{end}}" hx-target="#wizard-content" hx-swap="innerHTML" hx-disabled-elt="button[type='submit']" data-is-page="{{.IsPage}}">
+  <form id="refine-form" hx-post="/wizard/title{{if .IsPage}}?page=1{{end}}" hx-target="#wizard-content" hx-swap="innerHTML" hx-disabled-elt="button[type='submit']" data-is-page="{{.IsPage}}">
     <input type="hidden" name="session_id" value="{{.SessionID}}">
     {{if .IsPage}}<input type="hidden" name="page" value="1">{{end}}
     
@@ -44,7 +44,7 @@
         </button>
         <button type="submit" class="btn btn-primary">
           <span class="spinner" style="display:none;">⏳</span>
-          <span class="label">Accept &amp; Create Issue</span>
+          <span class="label">Accept &amp; Continue</span>
         </button>
       </div>
     </div>

--- a/internal/dashboard/templates/wizard_steps.html
+++ b/internal/dashboard/templates/wizard_steps.html
@@ -16,8 +16,13 @@
     <span class="step-label">Technical Planning</span>
   </div>
   <div class="step-connector"></div>
-  <div class="step {{if eq .CurrentStep 4}}active{{end}}">
+  <div class="step {{if eq .CurrentStep 4}}active{{end}} {{if gt .CurrentStep 4}}completed{{end}}">
     <span class="step-number">4</span>
+    <span class="step-label">Title</span>
+  </div>
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 5}}active{{end}}">
+    <span class="step-number">5</span>
     <span class="step-label">Create</span>
   </div>
   {{else}}
@@ -31,8 +36,13 @@
     <span class="step-label">Technical Planning</span>
   </div>
   <div class="step-connector"></div>
-  <div class="step {{if eq .CurrentStep 3}}active{{end}}">
+  <div class="step {{if eq .CurrentStep 3}}active{{end}} {{if gt .CurrentStep 3}}completed{{end}}">
     <span class="step-number">3</span>
+    <span class="step-label">Title</span>
+  </div>
+  <div class="step-connector"></div>
+  <div class="step {{if eq .CurrentStep 4}}active{{end}}">
+    <span class="step-number">4</span>
     <span class="step-label">Create</span>
   </div>
   {{end}}

--- a/internal/dashboard/templates/wizard_title.html
+++ b/internal/dashboard/templates/wizard_title.html
@@ -1,0 +1,145 @@
+{{define "content"}}
+{{template "wizard-steps" .}}
+<div class="wizard-step">
+  <h2>Issue Title</h2>
+  <p class="subtitle">Review and edit the generated title for your issue</p>
+  
+  <form id="title-form" hx-post="/wizard/create{{if .IsPage}}?page=1{{end}}" hx-target="#wizard-content" hx-swap="innerHTML" hx-disabled-elt="button[type='submit']" data-is-page="{{.IsPage}}">
+    <input type="hidden" name="session_id" value="{{.SessionID}}">
+    {{if .IsPage}}<input type="hidden" name="page" value="1">{{end}}
+    
+    <div class="form-group">
+      <label for="issue_title">Issue Title:</label>
+      <input type="text" id="issue_title" name="issue_title" value="{{.Title}}" maxlength="80" class="title-input" oninput="updateCharCounter(this)">
+      <div class="char-counter">
+        <span id="char-count">{{len .Title}}</span> / 80 characters
+        <span id="char-warning" class="warning" style="display:none;">⚠️ Title too long</span>
+      </div>
+    </div>
+    
+    {{if .SprintName}}
+    <div class="form-group sprint-option">
+      <label class="sprint-checkbox">
+        <input type="checkbox" name="add_to_sprint" value="1" checked>
+        <span class="sprint-checkbox-label">Add to current sprint <strong>{{.SprintName}}</strong></span>
+      </label>
+    </div>
+    {{end}}
+    
+    <div id="title-error" class="error-message" style="display:none; color: var(--error); margin: 1rem 0;"></div>
+    
+    <div class="form-actions">
+      {{if .IsPage}}
+      <a href="/" class="btn">Cancel</a>
+      {{else}}
+      <button type="button" class="btn" onclick="closeWizardModal()">Cancel</button>
+      {{end}}
+      <div class="nav-buttons">
+        <button type="button" class="btn" hx-get="/wizard/refine?type={{.Type}}&amp;session_id={{.SessionID}}{{if .IsPage}}&amp;page=1{{end}}" hx-target="#wizard-content">
+          ← Back
+        </button>
+        <button type="button" class="btn btn-secondary" hx-post="/wizard/title{{if .IsPage}}?page=1{{end}}" hx-target="#wizard-content" hx-disabled-elt="button[type='submit']" hx-vals='{"regenerate": "1"}'>
+          <span class="spinner" style="display:none;">⏳</span>
+          <span class="label">Regenerate</span>
+        </button>
+        <button type="submit" class="btn btn-primary">
+          <span class="spinner" style="display:none;">⏳</span>
+          <span class="label">Accept &amp; Create Issue</span>
+        </button>
+      </div>
+    </div>
+  </form>
+  
+</div>
+
+<style>
+.title-input {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  transition: border-color 0.15s;
+}
+
+.title-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.title-input.too-long {
+  border-color: var(--error);
+}
+
+.char-counter {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.char-counter .warning {
+  color: var(--error);
+  font-weight: 500;
+}
+
+.sprint-option {
+  margin-top: 1rem;
+}
+
+.sprint-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.sprint-checkbox input[type="checkbox"] {
+  width: 1.2rem;
+  height: 1.2rem;
+  cursor: pointer;
+}
+
+.sprint-checkbox-label {
+  color: var(--text);
+}
+</style>
+
+<script>
+(function() {
+  function updateCharCounter(input) {
+    const count = input.value.length;
+    const counter = document.getElementById('char-count');
+    const warning = document.getElementById('char-warning');
+    
+    if (counter) {
+      counter.textContent = count;
+    }
+    
+    if (warning) {
+      if (count > 80) {
+        warning.style.display = 'inline';
+        input.classList.add('too-long');
+      } else {
+        warning.style.display = 'none';
+        input.classList.remove('too-long');
+      }
+    }
+  }
+  
+  // Initialize counter on load
+  const titleInput = document.getElementById('issue_title');
+  if (titleInput) {
+    updateCharCounter(titleInput);
+  }
+  
+  // Expose to global scope for HTMX
+  window.updateCharCounter = updateCharCounter;
+})();
+</script>
+
+{{end}}

--- a/internal/dashboard/wizard.go
+++ b/internal/dashboard/wizard.go
@@ -45,6 +45,7 @@ const (
 	WizardStepNew    WizardStep = "new"
 	WizardStepRefine WizardStep = "refine"
 	// REMOVED: WizardStepBreakdown WizardStep = "breakdown"
+	WizardStepTitle  WizardStep = "title" // NEW: Title generation step
 	WizardStepCreate WizardStep = "create"
 	WizardStepDone   WizardStep = "done"
 )
@@ -83,6 +84,9 @@ type WizardSession struct {
 	RefinedDescription string     `json:"refined_description"`
 	// REMOVED: Tasks              []WizardTask   `json:"tasks"`
 	TechnicalPlanning string         `json:"technical_planning"` // NEW FIELD
+	GeneratedTitle    string         `json:"generated_title"`    // NEW: LLM-generated title
+	CustomTitle       string         `json:"custom_title"`       // NEW: User-edited title
+	UseCustomTitle    bool           `json:"use_custom_title"`   // NEW: Whether to use custom title
 	CreatedIssues     []CreatedIssue `json:"created_issues"`
 	EpicNumber        int            `json:"epic_number"`
 	AddToSprint       bool           `json:"add_to_sprint"`
@@ -129,6 +133,41 @@ func (s *WizardSession) SetTechnicalPlanning(planning string) {
 	defer s.mu.Unlock()
 	s.TechnicalPlanning = planning
 	s.UpdatedAt = time.Now()
+}
+
+// SetGeneratedTitle updates the generated title (thread-safe)
+func (s *WizardSession) SetGeneratedTitle(title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.GeneratedTitle = title
+	s.UpdatedAt = time.Now()
+}
+
+// SetCustomTitle updates the custom title (thread-safe)
+func (s *WizardSession) SetCustomTitle(title string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.CustomTitle = title
+	s.UpdatedAt = time.Now()
+}
+
+// SetUseCustomTitle updates the flag for using custom title (thread-safe)
+func (s *WizardSession) SetUseCustomTitle(use bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.UseCustomTitle = use
+	s.UpdatedAt = time.Now()
+}
+
+// GetFinalTitle returns the title to use for issue creation (thread-safe)
+// Returns custom title if UseCustomTitle is true, otherwise returns generated title
+func (s *WizardSession) GetFinalTitle() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.UseCustomTitle && s.CustomTitle != "" {
+		return s.CustomTitle
+	}
+	return s.GeneratedTitle
 }
 
 // SetLanguage updates the language preference (thread-safe)

--- a/internal/dashboard/wizard_test.go
+++ b/internal/dashboard/wizard_test.go
@@ -575,3 +575,80 @@ func TestWizardSession_SetLanguage(t *testing.T) {
 		t.Errorf("Expected Language to be 'pl-PL', got %q", session.Language)
 	}
 }
+
+// TestWizardSession_TitleFields tests the new title-related session fields
+func TestWizardSession_TitleFields(t *testing.T) {
+	session := &WizardSession{
+		ID:   "test-session",
+		Type: WizardTypeFeature,
+	}
+
+	// Test SetGeneratedTitle
+	session.SetGeneratedTitle("[Feature] Add user authentication")
+	if session.GeneratedTitle != "[Feature] Add user authentication" {
+		t.Errorf("Expected GeneratedTitle to be set correctly, got %q", session.GeneratedTitle)
+	}
+
+	// Test GetFinalTitle returns generated title by default
+	finalTitle := session.GetFinalTitle()
+	if finalTitle != "[Feature] Add user authentication" {
+		t.Errorf("Expected GetFinalTitle to return generated title, got %q", finalTitle)
+	}
+
+	// Test SetCustomTitle and SetUseCustomTitle
+	session.SetCustomTitle("[Feature] Custom authentication title")
+	session.SetUseCustomTitle(true)
+
+	if session.CustomTitle != "[Feature] Custom authentication title" {
+		t.Errorf("Expected CustomTitle to be set correctly, got %q", session.CustomTitle)
+	}
+	if !session.UseCustomTitle {
+		t.Error("Expected UseCustomTitle to be true")
+	}
+
+	// Test GetFinalTitle returns custom title when UseCustomTitle is true
+	finalTitle = session.GetFinalTitle()
+	if finalTitle != "[Feature] Custom authentication title" {
+		t.Errorf("Expected GetFinalTitle to return custom title, got %q", finalTitle)
+	}
+}
+
+// TestWizardSession_GetFinalTitle_EmptyCustom tests GetFinalTitle with empty custom title
+func TestWizardSession_GetFinalTitle_EmptyCustom(t *testing.T) {
+	session := &WizardSession{
+		ID:   "test-session",
+		Type: WizardTypeFeature,
+	}
+
+	session.SetGeneratedTitle("[Feature] Generated title")
+	session.SetUseCustomTitle(true)
+	session.SetCustomTitle("") // Empty custom title
+
+	// Should fall back to generated title when custom is empty
+	finalTitle := session.GetFinalTitle()
+	if finalTitle != "[Feature] Generated title" {
+		t.Errorf("Expected GetFinalTitle to fall back to generated title, got %q", finalTitle)
+	}
+}
+
+// TestWizardSession_GetFinalTitle_EmptyGenerated tests GetFinalTitle with empty generated title
+func TestWizardSession_GetFinalTitle_EmptyGenerated(t *testing.T) {
+	session := &WizardSession{
+		ID:   "test-session",
+		Type: WizardTypeFeature,
+	}
+
+	// Both empty - should return empty string
+	finalTitle := session.GetFinalTitle()
+	if finalTitle != "" {
+		t.Errorf("Expected GetFinalTitle to return empty string, got %q", finalTitle)
+	}
+}
+
+// TestWizardSession_TitleStep tests the Title wizard step constant
+func TestWizardSession_TitleStep(t *testing.T) {
+	// Verify WizardStepTitle exists and has correct value
+	if WizardStepTitle != "title" {
+		t.Errorf("Expected WizardStepTitle to be 'title', got %q", WizardStepTitle)
+	}
+}


### PR DESCRIPTION
Closes #150

## Problem Statement
Currently, GitHub issues created through the system have excessively long titles that are difficult to scan, understand at a glance, and manage in issue lists. This reduces productivity when triaging issues and creates cognitive overhead for team members.

## Target Users
- **Developers** reviewing issue boards and notifications
- **QA Engineers** tracking bug reports
- **Project Managers** monitoring sprint progress
- **External Contributors** browsing the repository

## Proposed Solution
Implement an intelligent title generation mechanism that:
- Summarizes the core issue in 5-8 words maximum
- Uses consistent naming conventions
- Prioritizes action-oriented language
- Includes relevant identifiers (component, type) only when necessary

## Acceptance Criteria
- [ ] Issue titles are limited to 80 characters
- [ ] Titles follow the format: `[Type] Brief description` (e.g., `[Bug] Login fails with 2FA enabled`)
- [ ] Integration with existing LLM pipeline to auto-generate concise titles from descriptions
- [ ] Manual override option preserved for edge cases
- [ ] Backward compatibility with existing long titles (migration path)

## Technical Considerations
- Leverage existing OpenCode LLM integration in `internal/llm/` package
- Modify GitHub issue creation flow in `internal/github/` or `internal/dashboard/`
- Add title validation in the wizard UI (`internal/dashboard/wizard/`)
- Consider prompt engineering for consistent output format
- Ensure non-English descriptions are handled gracefully

## Integration with Existing Patterns
This feature aligns with the current architecture:
- Uses established LLM client abstraction
- Fits within the dashboard wizard workflow
- Can reuse existing GitHub API wrapper
- Should follow the same error handling patterns as other LLM-powered features