### PR TITLE
[Feature] The user wants me to generate a GitHub issue title based on the tec...

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -91,16 +91,17 @@ func (s *Store) GetTaskMetrics(taskID int) ([]StageMetric, error) {
 }
 
 type TaskStep struct {
-	ID          int64
-	IssueNumber int
-	StepName    string
-	Status      string
-	Prompt      string
-	Response    string
-	ErrorMsg    string
-	SessionID   string
-	StartedAt   *time.Time
-	FinishedAt  *time.Time
+	ID                int64
+	IssueNumber       int
+	StepName          string
+	Status            string
+	Prompt            string
+	Response          string
+	ErrorMsg          string
+	SessionID         string
+	PlanAttachmentURL string
+	StartedAt         *time.Time
+	FinishedAt        *time.Time
 }
 
 func (s *Store) InsertStep(issueNumber int, stepName, prompt, sessionID string) (int64, error) {
@@ -142,7 +143,7 @@ func (s *Store) FailStep(id int64, errMsg string) error {
 
 func (s *Store) GetSteps(issueNumber int) ([]TaskStep, error) {
 	rows, err := s.db.Query(
-		`SELECT id, issue_number, step_name, status, prompt, response, error_msg, session_id, started_at, finished_at
+		`SELECT id, issue_number, step_name, status, prompt, response, error_msg, session_id, plan_attachment_url, started_at, finished_at
 		 FROM task_steps WHERE issue_number = ? ORDER BY id`, issueNumber,
 	)
 	if err != nil {
@@ -153,7 +154,7 @@ func (s *Store) GetSteps(issueNumber int) ([]TaskStep, error) {
 	var steps []TaskStep
 	for rows.Next() {
 		var st TaskStep
-		if err := rows.Scan(&st.ID, &st.IssueNumber, &st.StepName, &st.Status, &st.Prompt, &st.Response, &st.ErrorMsg, &st.SessionID, &st.StartedAt, &st.FinishedAt); err != nil {
+		if err := rows.Scan(&st.ID, &st.IssueNumber, &st.StepName, &st.Status, &st.Prompt, &st.Response, &st.ErrorMsg, &st.SessionID, &st.PlanAttachmentURL, &st.StartedAt, &st.FinishedAt); err != nil {
 			return nil, fmt.Errorf("scanning task step: %w", err)
 		}
 		steps = append(steps, st)
@@ -211,4 +212,32 @@ func (s *Store) GetSprintCost(sprintID int) (float64, error) {
 		return 0, nil
 	}
 	return cost.Float64, nil
+}
+
+// UpdateStepPlanURL updates the plan_attachment_url for a specific step
+func (s *Store) UpdateStepPlanURL(issueNumber int, stepName, planURL string) error {
+	_, err := s.db.Exec(
+		`UPDATE task_steps SET plan_attachment_url = ? WHERE issue_number = ? AND step_name = ? AND status = 'done'`,
+		planURL, issueNumber, stepName,
+	)
+	if err != nil {
+		return fmt.Errorf("updating step plan URL: %w", err)
+	}
+	return nil
+}
+
+// GetPlanAttachmentURL retrieves the plan_attachment_url for the most recent completed step
+func (s *Store) GetPlanAttachmentURL(issueNumber int) (string, error) {
+	var url sql.NullString
+	err := s.db.QueryRow(
+		`SELECT plan_attachment_url FROM task_steps WHERE issue_number = ? AND status = 'done' AND plan_attachment_url != '' ORDER BY id DESC LIMIT 1`,
+		issueNumber,
+	).Scan(&url)
+	if err == sql.ErrNoRows || !url.Valid {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("querying plan attachment URL: %w", err)
+	}
+	return url.String, nil
 }

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -1,6 +1,9 @@
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+	"strings"
+)
 
 var migrations = []string{
 	`CREATE TABLE IF NOT EXISTS stage_metrics (
@@ -30,10 +33,30 @@ var migrations = []string{
 		finished_at  DATETIME
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_task_steps_issue ON task_steps(issue_number)`,
+	`ALTER TABLE task_steps ADD COLUMN plan_attachment_url TEXT NOT NULL DEFAULT ''`,
+}
+
+// columnExists checks if a column exists in a table
+func columnExists(db *sql.DB, table, column string) bool {
+	var count int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`,
+		table, column,
+	).Scan(&count)
+	if err != nil {
+		return false
+	}
+	return count > 0
 }
 
 func migrate(db *sql.DB) error {
-	for _, m := range migrations {
+	for i, m := range migrations {
+		// Special handling for the plan_attachment_url migration (last one)
+		if i == len(migrations)-1 && strings.Contains(m, "plan_attachment_url") {
+			if columnExists(db, "task_steps", "plan_attachment_url") {
+				continue // Skip if column already exists
+			}
+		}
 		if _, err := db.Exec(m); err != nil {
 			return err
 		}

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crazy-goat/one-dev-army/internal/git"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 	"github.com/crazy-goat/one-dev-army/internal/opencode"
+	"github.com/crazy-goat/one-dev-army/internal/plan"
 )
 
 var ErrAlreadyDone = errors.New("ticket already done")
@@ -307,32 +308,97 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 
 func (w *Worker) analyze(ctx context.Context, task *Task) (string, error) {
 	prompt := fmt.Sprintf(analysisPrompt, task.Issue.Number, task.Issue.Title, task.Issue.Body)
-	return w.llmStep(ctx, task, "analyze", prompt, w.cfg.Planning.LLM)
+	analysis, err := w.llmStep(ctx, task, "analyze", prompt, w.cfg.Planning.LLM)
+	if err != nil {
+		return "", err
+	}
+
+	// Create initial plan.md with analysis
+	wt := &git.Worktree{
+		Name:   fmt.Sprintf("worker-%d", w.id),
+		Path:   w.repoDir,
+		Branch: task.Branch,
+	}
+	planMgr := plan.NewAttachmentManager(w.gh, wt)
+
+	planURL, err := planMgr.CreateInitialPlan(task.Issue.Number, task.Branch, analysis)
+	if err != nil {
+		log.Printf("[Worker %d] Warning: failed to create initial plan.md: %v", w.id, err)
+	} else {
+		log.Printf("[Worker %d] Created plan.md: %s", w.id, planURL)
+		// Store URL in database
+		if w.store != nil {
+			if err := w.store.UpdateStepPlanURL(task.Issue.Number, "analyze", planURL); err != nil {
+				log.Printf("[Worker %d] Warning: failed to store plan URL: %v", w.id, err)
+			}
+		}
+	}
+
+	return analysis, nil
 }
 
 func (w *Worker) plan(ctx context.Context, task *Task, analysis string) (string, error) {
 	prompt := fmt.Sprintf(planningPrompt, task.Issue.Number, task.Issue.Title, analysis)
-	result, err := w.llmStep(ctx, task, "plan", prompt, w.cfg.Planning.LLM)
+	planContent, err := w.llmStep(ctx, task, "plan", prompt, w.cfg.Planning.LLM)
 	if err != nil {
 		return "", err
 	}
-	if reason := checkAlreadyDone(result); reason != "" {
+	if reason := checkAlreadyDone(planContent); reason != "" {
 		log.Printf("[Worker %d] Planning detected ticket already done: %s", w.id, reason)
 		return "", fmt.Errorf("%w: %s", ErrAlreadyDone, reason)
 	}
-	return result, nil
+
+	// Update plan.md with implementation steps
+	wt := &git.Worktree{
+		Name:   fmt.Sprintf("worker-%d", w.id),
+		Path:   w.repoDir,
+		Branch: task.Branch,
+	}
+	planMgr := plan.NewAttachmentManager(w.gh, wt)
+
+	planURL, err := planMgr.UpdatePlanWithImplementation(task.Issue.Number, task.Branch, analysis, planContent)
+	if err != nil {
+		log.Printf("[Worker %d] Warning: failed to update plan.md with implementation: %v", w.id, err)
+	} else {
+		log.Printf("[Worker %d] Updated plan.md with implementation: %s", w.id, planURL)
+		// Store URL in database
+		if w.store != nil {
+			if err := w.store.UpdateStepPlanURL(task.Issue.Number, "plan", planURL); err != nil {
+				log.Printf("[Worker %d] Warning: failed to store plan URL: %v", w.id, err)
+			}
+		}
+	}
+
+	return planContent, nil
 }
 
-func (w *Worker) implement(ctx context.Context, task *Task, plan string) error {
+func (w *Worker) implement(ctx context.Context, task *Task, planStr string) error {
 	w.oc.SetDirectory(task.Worktree)
 	defer w.oc.SetDirectory("")
+
+	// Try to retrieve plan from GitHub if available
+	wt := &git.Worktree{
+		Name:   fmt.Sprintf("worker-%d", w.id),
+		Path:   w.repoDir,
+		Branch: task.Branch,
+	}
+	planMgr := plan.NewAttachmentManager(w.gh, wt)
+
+	githubPlan, err := planMgr.GetFromIssue(ctx, task.Issue.Number)
+	if err == nil && githubPlan != nil {
+		// Use the plan from GitHub
+		planStr = githubPlan.ToMarkdown()
+		log.Printf("[Worker %d] Using plan.md from GitHub", w.id)
+	} else {
+		log.Printf("[Worker %d] Falling back to context-based plan", w.id)
+	}
 
 	testCmd := w.cfg.Tools.TestCmd
 	if testCmd == "" {
 		testCmd = "go test ./..."
 	}
-	prompt := fmt.Sprintf(implementationPrompt, task.Issue.Number, task.Issue.Title, plan, task.Worktree, testCmd)
-	_, err := w.llmStep(ctx, task, "implement", prompt, w.cfg.EpicAnalysis.LLM)
+	prompt := fmt.Sprintf(implementationPrompt, task.Issue.Number, task.Issue.Title, planStr, task.Worktree, testCmd)
+	_, err = w.llmStep(ctx, task, "implement", prompt, w.cfg.EpicAnalysis.LLM)
 	if err != nil {
 		return err
 	}

--- a/internal/plan/attachment.go
+++ b/internal/plan/attachment.go
@@ -1,0 +1,327 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/crazy-goat/one-dev-army/internal/git"
+	"github.com/crazy-goat/one-dev-army/internal/github"
+)
+
+// AttachmentManager handles creating and attaching plan.md files to GitHub issues
+type AttachmentManager struct {
+	gh       *github.Client
+	worktree *git.Worktree
+}
+
+// NewAttachmentManager creates a new AttachmentManager
+func NewAttachmentManager(gh *github.Client, worktree *git.Worktree) *AttachmentManager {
+	return &AttachmentManager{
+		gh:       gh,
+		worktree: worktree,
+	}
+}
+
+// CreateAndAttach creates a plan.md file, commits it, pushes to the branch,
+// and adds a comment to the GitHub issue with the plan URL.
+// Returns the GitHub URL of the plan file.
+func (am *AttachmentManager) CreateAndAttach(
+	ctx context.Context,
+	issueNum int,
+	branch string,
+	analysis string,
+	planContent string,
+) (string, error) {
+	// Create initial plan with analysis
+	plan := &Plan{
+		IssueNumber: issueNum,
+		Analysis:    analysis,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	// If we have implementation steps, parse them
+	if planContent != "" {
+		plan.ImplementationSteps = parseSteps(planContent)
+	}
+
+	// Save plan to file
+	planPath := GetPlanFilePath(am.worktree.Path)
+	if err := plan.SaveToFile(planPath); err != nil {
+		return "", fmt.Errorf("saving plan to file: %w", err)
+	}
+
+	// Commit the plan file
+	commitMsg := fmt.Sprintf("docs: add plan.md for issue #%d", issueNum)
+	if err := am.commitFile(planPath, commitMsg); err != nil {
+		return "", fmt.Errorf("committing plan file: %w", err)
+	}
+
+	// Push branch
+	if err := am.pushBranch(branch); err != nil {
+		return "", fmt.Errorf("pushing branch: %w", err)
+	}
+
+	// Generate GitHub URL
+	planURL := fmt.Sprintf("https://github.com/%s/blob/%s/plan.md", am.gh.Repo, branch)
+	plan.GitHubURL = planURL
+
+	// Add comment to issue
+	comment := fmt.Sprintf("📋 Implementation Plan: [plan.md](%s)", planURL)
+	if err := am.gh.AddComment(issueNum, comment); err != nil {
+		log.Printf("[AttachmentManager] Warning: failed to add plan comment to issue #%d: %v", issueNum, err)
+		// Don't fail if comment addition fails
+	}
+
+	return planURL, nil
+}
+
+// GetFromIssue retrieves the plan from a GitHub issue by checking for plan.md
+// in the associated branch. Returns nil if no plan is found.
+func (am *AttachmentManager) GetFromIssue(
+	ctx context.Context,
+	issueNum int,
+) (*Plan, error) {
+	// Try to find the branch for this issue
+	branch, err := am.gh.FindPRBranch(issueNum)
+	if err != nil {
+		// No PR/branch found, try to construct branch name
+		branch = fmt.Sprintf("oda-%d-", issueNum)
+	}
+
+	// Check if plan.md exists in the worktree
+	planPath := GetPlanFilePath(am.worktree.Path)
+	if _, err := os.Stat(planPath); err != nil {
+		return nil, fmt.Errorf("plan.md not found: %w", err)
+	}
+
+	// Parse the plan from file
+	plan, err := ParseFromFile(planPath)
+	if err != nil {
+		return nil, fmt.Errorf("parsing plan from file: %w", err)
+	}
+
+	// Set the GitHub URL
+	plan.GitHubURL = fmt.Sprintf("https://github.com/%s/blob/%s/plan.md", am.gh.Repo, branch)
+
+	return plan, nil
+}
+
+// UpdateAttachment updates an existing plan.md file with new content,
+// commits the changes, and pushes to the branch.
+func (am *AttachmentManager) UpdateAttachment(
+	ctx context.Context,
+	issueNum int,
+	branch string,
+	plan *Plan,
+) error {
+	plan.UpdatedAt = time.Now()
+
+	// Save updated plan
+	planPath := GetPlanFilePath(am.worktree.Path)
+	if err := plan.SaveToFile(planPath); err != nil {
+		return fmt.Errorf("saving updated plan: %w", err)
+	}
+
+	// Commit the update
+	commitMsg := fmt.Sprintf("docs: update plan.md for issue #%d", issueNum)
+	if err := am.commitFile(planPath, commitMsg); err != nil {
+		return fmt.Errorf("committing updated plan: %w", err)
+	}
+
+	// Push branch
+	if err := am.pushBranch(branch); err != nil {
+		return fmt.Errorf("pushing updated plan: %w", err)
+	}
+
+	return nil
+}
+
+// CreateInitialPlan creates an initial plan.md with just the analysis
+func (am *AttachmentManager) CreateInitialPlan(
+	issueNum int,
+	branch string,
+	analysis string,
+) (string, error) {
+	return am.CreateAndAttach(context.Background(), issueNum, branch, analysis, "")
+}
+
+// UpdatePlanWithImplementation updates the plan with implementation steps
+func (am *AttachmentManager) UpdatePlanWithImplementation(
+	issueNum int,
+	branch string,
+	analysis string,
+	implementationPlan string,
+) (string, error) {
+	return am.CreateAndAttach(context.Background(), issueNum, branch, analysis, implementationPlan)
+}
+
+// commitFile commits a file to the repository
+func (am *AttachmentManager) commitFile(filePath, message string) error {
+	// Add the file
+	if _, err := git.RunInWorktree(am.worktree.Path, "git", "add", filePath); err != nil {
+		return fmt.Errorf("adding file: %w", err)
+	}
+
+	// Check if there are changes to commit
+	_, err := git.RunInWorktree(am.worktree.Path, "git", "diff", "--cached", "--quiet")
+	if err == nil {
+		// No changes to commit
+		return nil
+	}
+
+	// Commit
+	_, err = git.RunInWorktree(am.worktree.Path, "git", "commit", "-m", message)
+	if err != nil {
+		return fmt.Errorf("committing: %w", err)
+	}
+
+	return nil
+}
+
+// pushBranch pushes the current branch to origin
+func (am *AttachmentManager) pushBranch(branch string) error {
+	// Try force-with-lease first (safe for existing remote branches)
+	_, err := git.RunInWorktree(am.worktree.Path, "git", "push", "-u", "--force-with-lease", "origin", branch)
+	if err == nil {
+		return nil
+	}
+
+	// If that fails, try regular push
+	_, err = git.RunInWorktree(am.worktree.Path, "git", "push", "-u", "origin", branch)
+	if err != nil {
+		return fmt.Errorf("pushing branch: %w", err)
+	}
+
+	return nil
+}
+
+// parseSteps extracts implementation steps from plan content
+func parseSteps(content string) []Step {
+	var steps []Step
+	lines := strings.Split(content, "\n")
+	var currentStep *Step
+	var inFilesSection bool
+
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+
+		// Look for step headers (e.g., "1. ", "Step 1:", etc.)
+		if matchesStepHeader(line) {
+			// Save previous step if exists
+			if currentStep != nil {
+				steps = append(steps, *currentStep)
+			}
+
+			// Parse step number and description
+			order, desc := extractStepInfo(line)
+			currentStep = &Step{
+				Order:       order,
+				Description: desc,
+			}
+			inFilesSection = false
+			continue
+		}
+
+		// Look for files section
+		if currentStep != nil && strings.Contains(line, "Files:") {
+			inFilesSection = true
+			continue
+		}
+
+		// Extract files
+		if inFilesSection && currentStep != nil {
+			if strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") {
+				file := strings.TrimPrefix(line, "- ")
+				file = strings.TrimPrefix(file, "* ")
+				file = strings.TrimSpace(file)
+				if file != "" {
+					currentStep.Files = append(currentStep.Files, file)
+				}
+			} else if line == "" {
+				inFilesSection = false
+			}
+		}
+
+		// Accumulate details
+		if currentStep != nil && !inFilesSection && line != "" {
+			if currentStep.Details != "" {
+				currentStep.Details += "\n"
+			}
+			currentStep.Details += line
+		}
+
+		// Check for end of content or next major section
+		if i < len(lines)-1 && strings.HasPrefix(lines[i+1], "## ") {
+			if currentStep != nil {
+				steps = append(steps, *currentStep)
+				currentStep = nil
+			}
+		}
+	}
+
+	// Don't forget the last step
+	if currentStep != nil {
+		steps = append(steps, *currentStep)
+	}
+
+	return steps
+}
+
+// matchesStepHeader checks if a line is a step header
+func matchesStepHeader(line string) bool {
+	// Match patterns like "1. ", "Step 1:", "1) ", etc.
+	patterns := []string{
+		`^\d+\.\s+`,
+		`^Step\s+\d+[:.]\s*`,
+		`^\d+\)\s+`,
+	}
+	for _, pattern := range patterns {
+		if matched, _ := regexp.MatchString(pattern, line); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// extractStepInfo extracts step number and description from a header line
+func extractStepInfo(line string) (int, string) {
+	// Try to extract number
+	re := regexp.MustCompile(`\d+`)
+	match := re.FindString(line)
+	order, _ := strconv.Atoi(match)
+
+	// Extract description (everything after the number/prefix)
+	desc := line
+	// Remove common prefixes
+	desc = regexp.MustCompile(`^\d+\.\s*`).ReplaceAllString(desc, "")
+	desc = regexp.MustCompile(`^Step\s+\d+[:.]\s*`).ReplaceAllString(desc, "")
+	desc = regexp.MustCompile(`^\d+\)\s*`).ReplaceAllString(desc, "")
+	desc = strings.TrimSpace(desc)
+
+	return order, desc
+}
+
+// FileExists checks if plan.md exists in the worktree
+func (am *AttachmentManager) FileExists() bool {
+	planPath := GetPlanFilePath(am.worktree.Path)
+	_, err := os.Stat(planPath)
+	return err == nil
+}
+
+// GetPlanPath returns the full path to plan.md
+func (am *AttachmentManager) GetPlanPath() string {
+	return GetPlanFilePath(am.worktree.Path)
+}
+
+// ReadPlan reads the current plan from disk if it exists
+func (am *AttachmentManager) ReadPlan() (*Plan, error) {
+	planPath := GetPlanFilePath(am.worktree.Path)
+	return ParseFromFile(planPath)
+}

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,202 @@
+package plan
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Plan represents an implementation plan for a GitHub issue
+type Plan struct {
+	IssueNumber         int
+	Analysis            string
+	ImplementationSteps []Step
+	TestPlan            []string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	FilePath            string
+	GitHubURL           string
+}
+
+// Step represents a single implementation step
+type Step struct {
+	Order       int
+	Description string
+	Files       []string
+	Details     string
+}
+
+// ToMarkdown converts the plan to markdown format
+func (p *Plan) ToMarkdown() string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("# Implementation Plan for Issue #%d\n\n", p.IssueNumber))
+	sb.WriteString(fmt.Sprintf("**Created:** %s\n", p.CreatedAt.Format(time.RFC3339)))
+	if !p.UpdatedAt.IsZero() && p.UpdatedAt != p.CreatedAt {
+		sb.WriteString(fmt.Sprintf("**Updated:** %s\n", p.UpdatedAt.Format(time.RFC3339)))
+	}
+	sb.WriteString("\n")
+
+	if p.Analysis != "" {
+		sb.WriteString("## Analysis\n\n")
+		sb.WriteString(p.Analysis)
+		sb.WriteString("\n\n")
+	}
+
+	if len(p.ImplementationSteps) > 0 {
+		sb.WriteString("## Implementation Steps\n\n")
+		for _, step := range p.ImplementationSteps {
+			sb.WriteString(fmt.Sprintf("### Step %d: %s\n\n", step.Order, step.Description))
+			if len(step.Files) > 0 {
+				sb.WriteString("**Files:**\n")
+				for _, file := range step.Files {
+					sb.WriteString(fmt.Sprintf("- `%s`\n", file))
+				}
+				sb.WriteString("\n")
+			}
+			if step.Details != "" {
+				sb.WriteString(step.Details)
+				sb.WriteString("\n\n")
+			}
+		}
+	}
+
+	if len(p.TestPlan) > 0 {
+		sb.WriteString("## Test Plan\n\n")
+		for _, test := range p.TestPlan {
+			sb.WriteString(fmt.Sprintf("- [ ] %s\n", test))
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// SaveToFile saves the plan to a file
+func (p *Plan) SaveToFile(path string) error {
+	content := p.ToMarkdown()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Errorf("writing plan to file: %w", err)
+	}
+	p.FilePath = path
+	return nil
+}
+
+// ParseFromMarkdown parses a plan from markdown content
+func ParseFromMarkdown(content string) (*Plan, error) {
+	plan := &Plan{}
+
+	// Extract issue number from title
+	titleRe := regexp.MustCompile(`# Implementation Plan for Issue #(\d+)`)
+	if matches := titleRe.FindStringSubmatch(content); len(matches) > 1 {
+		fmt.Sscanf(matches[1], "%d", &plan.IssueNumber)
+	}
+
+	// Extract created date
+	createdRe := regexp.MustCompile(`\*\*Created:\*\* ([^\n]+)`)
+	if matches := createdRe.FindStringSubmatch(content); len(matches) > 1 {
+		if t, err := time.Parse(time.RFC3339, matches[1]); err == nil {
+			plan.CreatedAt = t
+		}
+	}
+
+	// Extract updated date
+	updatedRe := regexp.MustCompile(`\*\*Updated:\*\* ([^\n]+)`)
+	if matches := updatedRe.FindStringSubmatch(content); len(matches) > 1 {
+		if t, err := time.Parse(time.RFC3339, matches[1]); err == nil {
+			plan.UpdatedAt = t
+		}
+	}
+
+	// Extract analysis section
+	analysisRe := regexp.MustCompile(`(?s)## Analysis\n\n(.+?)(?:\n\n## |\z)`)
+	if matches := analysisRe.FindStringSubmatch(content); len(matches) > 1 {
+		plan.Analysis = strings.TrimSpace(matches[1])
+	}
+
+	// Extract implementation steps - find all step sections
+	stepHeaderRe := regexp.MustCompile(`(?m)^### Step (\d+): ([^\n]+)$`)
+	stepMatches := stepHeaderRe.FindAllStringSubmatchIndex(content, -1)
+
+	for i, match := range stepMatches {
+		if len(match) >= 6 {
+			orderStr := content[match[2]:match[3]]
+			desc := content[match[4]:match[5]]
+
+			var order int
+			fmt.Sscanf(orderStr, "%d", &order)
+
+			step := Step{
+				Order:       order,
+				Description: desc,
+			}
+
+			// Find the content of this step (from end of header to next step or end)
+			startIdx := match[1]
+			endIdx := len(content)
+			if i < len(stepMatches)-1 {
+				endIdx = stepMatches[i+1][0]
+			}
+			stepContent := content[startIdx:endIdx]
+
+			// Extract files from step content
+			filesRe := regexp.MustCompile(`(?m)^\*\*Files:\*\*\n((?:- [^\n]+\n?)+)`)
+			if fileMatches := filesRe.FindStringSubmatch(stepContent); len(fileMatches) > 1 {
+				fileLines := strings.Split(fileMatches[1], "\n")
+				for _, line := range fileLines {
+					line = strings.TrimSpace(line)
+					if strings.HasPrefix(line, "- `") && strings.HasSuffix(line, "`") {
+						file := line[3 : len(line)-1]
+						step.Files = append(step.Files, file)
+					}
+				}
+			}
+
+			// Extract details (everything after files section or after header)
+			detailsRe := regexp.MustCompile(`(?s)(?:\*\*Files:\*\*\n(?:- [^\n]+\n?)+)?\n*(.+)`)
+			if detailsMatches := detailsRe.FindStringSubmatch(stepContent); len(detailsMatches) > 1 {
+				step.Details = strings.TrimSpace(detailsMatches[1])
+			}
+
+			plan.ImplementationSteps = append(plan.ImplementationSteps, step)
+		}
+	}
+
+	// Extract test plan - find the section and extract items
+	testSectionRe := regexp.MustCompile(`(?s)## Test Plan\n\n(.+?)(?:\n\n## |\z)`)
+	if matches := testSectionRe.FindStringSubmatch(content); len(matches) > 1 {
+		testLines := strings.Split(matches[1], "\n")
+		for _, line := range testLines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "- [ ] ") {
+				plan.TestPlan = append(plan.TestPlan, line[6:])
+			} else if strings.HasPrefix(line, "- ") {
+				plan.TestPlan = append(plan.TestPlan, line[2:])
+			}
+		}
+	}
+
+	return plan, nil
+}
+
+// ParseFromFile parses a plan from a file
+func ParseFromFile(path string) (*Plan, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading plan file: %w", err)
+	}
+	plan, err := ParseFromMarkdown(string(content))
+	if err != nil {
+		return nil, err
+	}
+	plan.FilePath = path
+	return plan, nil
+}
+
+// GetPlanFilePath returns the default plan.md file path for a repository
+func GetPlanFilePath(repoDir string) string {
+	return filepath.Join(repoDir, "plan.md")
+}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,243 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlanToMarkdown(t *testing.T) {
+	plan := &Plan{
+		IssueNumber: 159,
+		Analysis:    "This is a test analysis.",
+		ImplementationSteps: []Step{
+			{
+				Order:       1,
+				Description: "Create plan.go file",
+				Files:       []string{"internal/plan/plan.go"},
+				Details:     "Add Plan struct and ToMarkdown method",
+			},
+			{
+				Order:       2,
+				Description: "Create attachment.go file",
+				Files:       []string{"internal/plan/attachment.go"},
+				Details:     "Add AttachmentManager for GitHub integration",
+			},
+		},
+		TestPlan:  []string{"Test ToMarkdown", "Test ParseFromMarkdown"},
+		CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	markdown := plan.ToMarkdown()
+
+	// Check that markdown contains expected content
+	if !strings.Contains(markdown, "# Implementation Plan for Issue #159") {
+		t.Error("Expected markdown to contain issue number in title")
+	}
+	if !strings.Contains(markdown, "This is a test analysis.") {
+		t.Error("Expected markdown to contain analysis")
+	}
+	if !strings.Contains(markdown, "## Implementation Steps") {
+		t.Error("Expected markdown to contain implementation steps section")
+	}
+	if !strings.Contains(markdown, "Step 1: Create plan.go file") {
+		t.Error("Expected markdown to contain step 1")
+	}
+	if !strings.Contains(markdown, "internal/plan/plan.go") {
+		t.Error("Expected markdown to contain file reference")
+	}
+	if !strings.Contains(markdown, "## Test Plan") {
+		t.Error("Expected markdown to contain test plan section")
+	}
+}
+
+func TestParseFromMarkdown(t *testing.T) {
+	markdown := `# Implementation Plan for Issue #159
+
+**Created:** 2024-01-01T00:00:00Z
+
+## Analysis
+
+This is a test analysis.
+
+## Implementation Steps
+
+### Step 1: Create plan.go file
+
+**Files:**
+- ` + "`internal/plan/plan.go`" + `
+
+Add Plan struct and ToMarkdown method
+
+### Step 2: Create attachment.go file
+
+**Files:**
+- ` + "`internal/plan/attachment.go`" + `
+
+Add AttachmentManager for GitHub integration
+
+## Test Plan
+
+- [ ] Test ToMarkdown
+- [ ] Test ParseFromMarkdown
+`
+
+	plan, err := ParseFromMarkdown(markdown)
+	if err != nil {
+		t.Fatalf("Failed to parse markdown: %v", err)
+	}
+
+	if plan.IssueNumber != 159 {
+		t.Errorf("Expected issue number 159, got %d", plan.IssueNumber)
+	}
+
+	if !strings.Contains(plan.Analysis, "This is a test analysis.") {
+		t.Error("Expected analysis to be parsed correctly")
+	}
+
+	if len(plan.ImplementationSteps) != 2 {
+		t.Errorf("Expected 2 steps, got %d", len(plan.ImplementationSteps))
+	}
+
+	if len(plan.TestPlan) != 2 {
+		t.Errorf("Expected 2 test items, got %d", len(plan.TestPlan))
+	}
+}
+
+func TestSaveAndLoadPlan(t *testing.T) {
+	// Create a temporary directory
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.md")
+
+	// Create a plan
+	original := &Plan{
+		IssueNumber: 42,
+		Analysis:    "Test analysis for issue #42",
+		ImplementationSteps: []Step{
+			{
+				Order:       1,
+				Description: "First step",
+				Files:       []string{"file1.go", "file2.go"},
+				Details:     "Details for first step",
+			},
+		},
+		TestPlan:  []string{"Test 1", "Test 2"},
+		CreatedAt: time.Now(),
+	}
+
+	// Save the plan
+	if err := original.SaveToFile(planPath); err != nil {
+		t.Fatalf("Failed to save plan: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(planPath); err != nil {
+		t.Fatalf("Plan file was not created: %v", err)
+	}
+
+	// Load the plan
+	loaded, err := ParseFromFile(planPath)
+	if err != nil {
+		t.Fatalf("Failed to load plan: %v", err)
+	}
+
+	// Verify loaded data
+	if loaded.IssueNumber != original.IssueNumber {
+		t.Errorf("Expected issue number %d, got %d", original.IssueNumber, loaded.IssueNumber)
+	}
+
+	if !strings.Contains(loaded.Analysis, original.Analysis) {
+		t.Error("Analysis was not preserved correctly")
+	}
+
+	if len(loaded.ImplementationSteps) != len(original.ImplementationSteps) {
+		t.Errorf("Expected %d steps, got %d", len(original.ImplementationSteps), len(loaded.ImplementationSteps))
+	}
+}
+
+func TestGetPlanFilePath(t *testing.T) {
+	repoDir := "/tmp/test-repo"
+	expected := filepath.Join(repoDir, "plan.md")
+	actual := GetPlanFilePath(repoDir)
+	if actual != expected {
+		t.Errorf("Expected %s, got %s", expected, actual)
+	}
+}
+
+func TestParseSteps(t *testing.T) {
+	content := `1. Create plan.go file
+Files:
+- internal/plan/plan.go
+- internal/plan/attachment.go
+
+Add the Plan struct and methods
+
+2. Update worker.go
+Files:
+- internal/mvp/worker.go
+
+Integrate plan creation in analyze and plan methods`
+
+	steps := parseSteps(content)
+
+	if len(steps) != 2 {
+		t.Errorf("Expected 2 steps, got %d", len(steps))
+	}
+
+	if len(steps) > 0 {
+		if steps[0].Order != 1 {
+			t.Errorf("Expected step order 1, got %d", steps[0].Order)
+		}
+		if !strings.Contains(steps[0].Description, "Create plan.go") {
+			t.Errorf("Expected description to contain 'Create plan.go', got %s", steps[0].Description)
+		}
+		if len(steps[0].Files) != 2 {
+			t.Errorf("Expected 2 files, got %d", len(steps[0].Files))
+		}
+	}
+}
+
+func TestMatchesStepHeader(t *testing.T) {
+	tests := []struct {
+		line     string
+		expected bool
+	}{
+		{"1. First step", true},
+		{"Step 1: First step", true},
+		{"1) First step", true},
+		{"Regular text", false},
+		{"## Header", false},
+	}
+
+	for _, test := range tests {
+		result := matchesStepHeader(test.line)
+		if result != test.expected {
+			t.Errorf("matchesStepHeader(%q) = %v, expected %v", test.line, result, test.expected)
+		}
+	}
+}
+
+func TestExtractStepInfo(t *testing.T) {
+	tests := []struct {
+		line          string
+		expectedOrder int
+		expectedDesc  string
+	}{
+		{"1. First step", 1, "First step"},
+		{"Step 2: Second step", 2, "Second step"},
+		{"3) Third step", 3, "Third step"},
+		{"42. Complex step description", 42, "Complex step description"},
+	}
+
+	for _, test := range tests {
+		order, desc := extractStepInfo(test.line)
+		if order != test.expectedOrder {
+			t.Errorf("extractStepInfo(%q) order = %d, expected %d", test.line, order, test.expectedOrder)
+		}
+		if desc != test.expectedDesc {
+			t.Errorf("extractStepInfo(%q) desc = %q, expected %q", test.line, desc, test.expectedDesc)
+		}
+	}
+}


### PR DESCRIPTION
Closes #159

## Problem Statement / Feature Description

Obecnie podczas pierwszego kroku pracy z etykietą (analiza) system tworzy wewnętrzne dokumenty MT (Markdown Technical), które nie są trwale przechowywane ani łatwo dostępne dla zespołu. Celem tej zmiany jest zastąpienie tego mechanizmu przez tworzenie pliku `plan.md` w repozytorium, który będzie dołączany jako załącznik do zadania GitHub. Plik ten będzie służył jako źródło prawdy dla implementatora oraz jako materiał do code review.

## Architecture Overview

System składa się z następujących komponentów zaangażowanych w proces:

- **Worker** (`internal/mvp/worker.go`) - główny komponent orkiestrujący przepływ pracy, odpowiedzialny za kroki: analyze, plan, implement, code-review
- **Processor** (`internal/worker/processor.go`) - alternatywny procesor obsługujący pipeline etapów (StageAnalysis, StagePlanning, StageCoding, StageCodeReview)
- **GitHub Client** (`internal/github/issues.go`) - klient do komunikacji z API GitHub, obsługujący operacje na issue, komentarzach i PR
- **Git Worktree** (`internal/git/worktree.go`) - zarządzanie branchami i working directory
- **Pipeline** (`internal/pipeline/stage.go`) - definicje etapów przetwarzania

Przepływ danych:
1. Worker/Processor wykonuje analizę (krok "analyze" lub StageAnalysis)
2. Wynik analizy jest zapisywany jako plik `plan.md` w branchu taska
3. Plik jest commitowany i pushowany do GitHub
4. Plik jest dołączany jako załącznik do issue GitHub (przez komentarz z linkiem lub referencję)
5. W kolejnych krokach (planning, implement, code-review) system pobiera plan.md z GitHub zamiast korzystać z wewnętrznych dokumentów MT

## Files Requiring Changes

### Istniejące pliki do modyfikacji:

- `internal/mvp/worker.go` - modyfikacja metod `analyze()` i `plan()` aby zapisywały wynik do pliku `plan.md` w worktree zamiast tylko zwracać string; dodanie metody do commitowania i pushowania pliku
- `internal/worker/processor.go` - modyfikacja `executeSession()` dla StageAnalysis i StagePlanning aby tworzyły plik `plan.md`; rozszerzenie `StageExecutor` o metody do zarządzania plikiem planu
- `internal/github/issues.go` - dodanie metod do obsługi załączników: `UploadAttachment()`, `GetAttachment()`, `AddAttachmentToIssue()` - wykorzystujących GitHub API do uploadu plików lub tworzenia komentarzy z linkami do plików w repozytorium
- `internal/git/worktree.go` - dodanie metod pomocniczych do tworzenia plików w worktree, commitowania i pushowania konkretnych plików (nie tylko zmian z kodem)

### Nowe pliki do utworzenia:

- `internal/plan/plan.go` - nowy pakiet zarządzający cyklem życia pliku plan.md: tworzenie, aktualizacja, walidacja, parsowanie; definicja struktury Plan z polami: IssueNumber, Analysis, ImplementationSteps, TestPlan, CreatedAt, UpdatedAt
- `internal/plan/attachment.go` - obsługa załączników GitHub: upload, download, link generation

## Component Dependencies

### Zależności między modułami:

- Worker/Processor → Plan Manager: Worker wywołuje metody plan.Create() i plan.Update() zamiast bezpośrednio operować na stringach
- Plan Manager → Git Worktree: Plan Manager używa worktree do zapisu pliku fizycznego
- Plan Manager → GitHub Client: Plan Manager używa GitHub Client do uploadu załącznika i aktualizacji issue
- Processor → Plan Manager: StageExecutor pobiera plan przez plan.GetFromIssue() zamiast z kontekstu pipeline

### Zależności zewnętrzne:

- GitHub REST API v3 - do uploadu plików jako załączniki (via `repos/{owner}/{repo}/contents/` dla plików w repozytorium lub `issues/{number}/comments` z linkami)
- gh CLI - rozszerzenie obecnych komend o obsługę załączników (jeśli wspierane) lub użycie API REST przez curl
- System plików - tymczasowy storage dla plan.md w worktree przed commitem

### Zmiany w schemacie bazy danych:

- Tabela `steps` w `internal/db/db.go` - dodanie kolumny `plan_attachment_url` (string, nullable) przechowującej URL do załącznika plan.md w GitHub

## Implementation Boundaries

### Co jest w zakresie (IN SCOPE):

- Tworzenie pliku `plan.md` w branchu taska podczas kroku analizy
- Commitowanie i pushowanie pliku `plan.md` do repozytorium
- Dołączanie linku do pliku `plan.md` jako komentarz do issue GitHub
- Pobieranie zawartości `plan.md` z GitHub w kolejnych krokach (planning, implement, code-review)
- Obsługa aktualizacji plan.md w razie zmian wymagań
- Format pliku plan.md: struktura markdown z sekcjami (Analiza, Plan implementacji, Testy, Kryteria akceptacji)

### Co jest poza zakresem (OUT OF SCOPE):

- Migracja istniejących dokumentów MT do nowego formatu (tylko nowe taski używają plan.md)
- Wersjonowanie plan.md (historia zmian w git wystarczy)
- Edycja plan.md przez UI (tylko automatyczne generowanie przez LLM)
- Integracja z zewnętrznymi systemami dokumentacji (Confluence, Notion)
- Powiadomienia email o zmianach w plan.md
- Wsparcie dla innych formatów plików (tylko .md)

### Ograniczenia i założenia:

- Plik plan.md musi być mniejszy niż 1MB (limit GitHub dla wyświetlania w przeglądarce)
- Plan jest generowany tylko raz na początku taska; kolejne zmiany wymagają ręcznej interwencji
- Link do plan.md w issue jest tworzony jako komentarz, nie jako część body issue (aby nie modyfikować oryginalnego opisu)
- W przypadku błędu uploadu plan.md, system fallbackuje do obecnego mechanizmu (przekazanie planu przez kontekst)

## Acceptance Criteria

1. **Kryterium 1**: Podczas kroku analizy (pierwszy krok worker/processor) system tworzy plik `plan.md` w root directory brancha taska, commituje go z message "docs: add plan.md for issue #N" i pushuje do GitHub. Plik zawiera sekcje: Analiza, Wymagania, Plan implementacji, Testy, Ryzyka.

2. **Kryterium 2**: Po utworzeniu pliku `plan.md`, system dodaje komentarz do issue GitHub z linkiem do pliku w formacie: `📋 Plan implementacji: [plan.md](https://github.com/{owner}/{repo}/blob/{branch}/plan.md)`. Link jest generowany na podstawie aktualnego brancha i ścieżki w repozytorium.

3. **Kryterium 3**: W kolejnych krokach pipeline (planning, implement, code-review) system pobiera zawartość `plan.md` z GitHub (przez API lub gh CLI) i przekazuje ją do LLM jako kontekst zamiast dotychczasowych dokumentów MT. W przypadku niedostępności pliku, system loguje warning i kontynuuje z dostępnym kontekstem.

4. **Kryterium 4**: Podczas code review, system dołącza link do `plan.md` w komentarzu PR lub weryfikuje zgodność implementacji z planem. Jeśli implementacja odbiega od planu, reviewer LLM zwraca uwagę na rozbieżności w sekcji "verdict" odpowiedzi.