### PR TITLE
Move Blocked column to first position in dashboard

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -33,12 +33,12 @@ type boardData struct {
 	Paused       bool
 	Processing   bool
 	CurrentIssue string
+	Blocked      []taskCard
 	Backlog      []taskCard
 	Progress     []taskCard
 	AIReview     []taskCard
 	Approve      []taskCard
 	Done         []taskCard
-	Blocked      []taskCard
 	Failed       []taskCard
 }
 

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -64,6 +64,24 @@
 </div>
 
 <div class="board" id="board-container" hx-get="/api/board-data" hx-swap="outerHTML">
+  <div class="column col-blocked">
+    <div class="column-title">Blocked <span class="count">{{len .Blocked}}</span></div>
+    {{range .Blocked}}
+    <div class="card">
+      <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
+      <div class="card-title">{{.Title}}</div>
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
+      <div class="card-actions">
+        <form method="post" action="/approve/{{.ID}}"><button type="submit" class="btn btn-success">Approve</button></form>
+        <form method="post" action="/reject/{{.ID}}"><button type="submit" class="btn btn-danger">Reject</button></form>
+      </div>
+    </div>
+    {{else}}
+    <div class="empty-state">No blocked tickets</div>
+    {{end}}
+  </div>
+
   <div class="column">
     <div class="column-title">Backlog <span class="count">{{len .Backlog}}</span></div>
     {{range .Backlog}}
@@ -137,24 +155,6 @@
     </div>
     {{else}}
     <div class="empty-state">No completed tickets</div>
-    {{end}}
-  </div>
-
-  <div class="column col-blocked">
-    <div class="column-title">Blocked <span class="count">{{len .Blocked}}</span></div>
-    {{range .Blocked}}
-    <div class="card">
-      <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
-      <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
-      {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
-      <div class="card-actions">
-        <form method="post" action="/approve/{{.ID}}"><button type="submit" class="btn btn-success">Approve</button></form>
-        <form method="post" action="/reject/{{.ID}}"><button type="submit" class="btn btn-danger">Reject</button></form>
-      </div>
-    </div>
-    {{else}}
-    <div class="empty-state">No blocked tickets</div>
     {{end}}
   </div>
 


### PR DESCRIPTION
Closes #163

## Summary
Move the "Blocked" column to the first position (before Backlog) in the dashboard board view to prioritize visibility of blocked tickets.

## Current Behavior
Columns are displayed in this order:
1. Backlog
2. In Progress
3. AI Review
4. Approve
5. Done
6. Blocked ← Currently here (6th position)
7. Failed

## Proposed Behavior
New column order:
1. **Blocked** ← Move to first position
2. Backlog
3. In Progress
4. AI Review
5. Approve
6. Done
7. Failed

## Rationale
Blocked tickets require immediate attention and should be the most visible. By placing them first, users immediately see what needs unblocking before looking at new work.

## Files to Modify

- `internal/dashboard/templates/board.html` (lines 66-165)
  - Move Blocked column section (lines 143-159) to position before Backlog
  - Update CSS classes if needed

- `internal/dashboard/handlers.go:30-43` (optional)
  - Reorder fields in `boardData` struct for consistency

## Acceptance Criteria

- [ ] Blocked column appears as the first column in the dashboard
- [ ] Blocked tickets are visible immediately when opening the board
- [ ] All existing functionality (approve/reject buttons) works in new position
- [ ] Column styling (red border) preserved
- [ ] Responsive layout works correctly

## Related

This is a prerequisite for: Split In Progress column into Plan and Code columns
