### PR TITLE
Merge analyze and plan steps into single Technical Planning step in worker

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan for Issue #168
 
-**Created:** 2026-03-23T12:38:47+01:00
-**Updated:** 2026-03-23T12:38:47+01:00
+**Created:** 2026-03-23T12:39:05+01:00
+**Updated:** 2026-03-23T12:39:05+01:00
 
 ## Analysis
 
@@ -98,4 +98,51 @@ The implementation is **complete and production-ready**:
 - ✅ Old tickets with analyze/plan steps are migrated automatically
 - ✅ Tests updated and passing
 - ✅ 50% reduction in LLM calls (one round-trip instead of two)
+
+## Implementation Steps
+
+### Step 1: `TestParseTechnicalPlanningResponse` - PASS
+
+### Step 2: `TestCheckAlreadyDone` - PASS
+
+### Step 3: `TestGetLastCompletedStep_Migration` - PASS
+
+### Step 4: `TestGetStepResponse_Migration` - PASS
+
+The implementation is fully complete. The issue #168 has already been implemented:
+
+### Step 1: **Combined prompt** (`technicalPlanningPrompt` at lines 23-51 in worker.go)
+
+### Step 2: **Single step function** (`technicalPlanning()` at lines 296-333)
+
+### Step 3: **Response parsing** (`parseTechnicalPlanningResponse()` at lines 335-374)
+
+### Step 4: **Updated step order** (line 130: `["technical-planning", "implement", "code-review", "create-pr"]`)
+
+### Step 5: **Database migration** (lines 178-181 and 193-196 in db.go)
+
+### Step 6: **Backward compatibility** (lines 193-196 in worker.go)
+
+### Step 7: **All tests passing**
+
+I should respond with "ALREADY_DONE:" prefix as instructed.ALREADY_DONE: The feature has been fully implemented in the codebase:
+
+### Step 1: **Combined prompt** (`technicalPlanningPrompt` at `internal/mvp/worker.go:23-51`) - Single prompt requesting both "## Analysis" and "## Implementation Plan" sections with ALREADY_DONE detection
+
+### Step 2: **Unified step function** (`technicalPlanning()` at `internal/mvp/worker.go:296-333`) - Handles combined analysis and planning in one LLM call
+
+### Step 3: **Response parsing** (`parseTechnicalPlanningResponse()` at `internal/mvp/worker.go:335-374`) - Extracts analysis and plan sections from combined response with fallback heuristics
+
+### Step 4: **Updated step order** (`internal/mvp/worker.go:130`) - Changed to `["technical-planning", "implement", "code-review", "create-pr"]` (4 steps instead of 5)
+
+### Step 5: **Database migration** (`internal/db/db.go:178-181`) - `GetLastCompletedStep()` maps old "analyze"/"plan" → "technical-planning"
+
+### Step 6: **Backward compatibility** (`internal/db/db.go:193-196`) - `GetStepResponse()` falls back to old "plan" step if "technical-planning" not found
+
+### Step 7: **All tests passing**:
+
+- `TestParseTechnicalPlanningResponse` - validates parsing of combined response
+- `TestCheckAlreadyDone` - tests ALREADY_DONE prefix detection
+- `TestGetLastCompletedStep_Migration` - verifies step name migration
+- `TestGetStepResponse_Migration` - confirms fallback to old step responses
 


### PR DESCRIPTION
Closes #168

## Summary
Merge the separate "analyze" and "plan" steps in the ODA worker into a single "Technical Planning" step, similar to what was done in the wizard (issue #148). Currently these are two separate LLM calls and two separate steps in the pipeline.

## Current Behavior
Worker has two separate steps:
1. **analyze** - LLM analyzes issue requirements
2. **plan** - LLM creates implementation plan based on analysis

Two separate prompts, two separate LLM calls, two separate resume points.

## Proposed Behavior
Single "Technical Planning" step that combines both:
- One LLM call with combined prompt
- Output: analysis + plan in one response
- Single resume point
- Faster execution (one round-trip to LLM instead of two)

## Current Code Structure

`internal/mvp/worker.go:132`:
```go
stepOrder = []string{"analyze", "plan", "implement", "code-review", "create-pr"}
```

Separate functions:
- `analyze()` - line 309
- `plan()` - line 340

## Implementation Plan

### 1. Create combined prompt
Merge `analysisPrompt` and `planningPrompt` into single `technicalPlanningPrompt`

### 2. Create new function
```go
func (w *Worker) technicalPlanning(ctx context.Context, task *Task) (analysis, plan string, err error)
```

### 3. Update stepOrder
```go
stepOrder = []string{"technical-planning", "implement", "code-review", "create-pr"}
```

### 4. Update Process() method
Replace separate analyze() and plan() calls with single technicalPlanning() call

### 5. Update resume logic
Handle migration from old "analyze"/"plan" steps to new "technical-planning" step

### 6. Update database schema (if needed)
Store combined result or keep separate fields for backward compatibility

## Files to Modify

- `internal/mvp/worker.go` - Main implementation
- `internal/mvp/worker_test.go` - Update tests
- `internal/db/` - Update step storage if needed

## Acceptance Criteria

- [ ] Single "technical-planning" step replaces "analyze" + "plan"
- [ ] Combined prompt generates both analysis and plan
- [ ] Can resume from technical-planning step
- [ ] Old tickets with analyze/plan steps can be migrated
- [ ] Tests updated and passing
- [ ] Performance improvement (one LLM call instead of two)

## Related

- Issue #148 - Same change was done for wizard (dashboard) but not for worker
- Issue #162 - State label management (will need to add state:technical-planning label)

## Benefits

1. **Performance** - 50% reduction in LLM calls for first phase
2. **Simplicity** - One step instead of two
3. **Consistency** - Matches wizard behavior
4. **Better context** - LLM sees full picture at once
