### PR TITLE
Auto-create AGENTS.md with simple template if missing

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -46,20 +46,57 @@ func (s *Setup) checkAgentsMD() error {
 		return nil
 	}
 
-	fmt.Println("AGENTS.md not found. Generating via opencode init...")
+	fmt.Println("AGENTS.md not found. Creating with template...")
 
-	session, err := s.oc.CreateSession("generate-agents-md")
-	if err != nil {
-		return fmt.Errorf("creating session: %w", err)
-	}
+	projectName := filepath.Base(s.projectDir)
+	language := detectLanguage(s.projectDir)
+	content := generateAgentsTemplate(projectName, language)
 
-	model := opencode.ParseModelRef(s.cfg.Planning.LLM)
-	if err := s.oc.InitSession(session.ID, model); err != nil {
-		return fmt.Errorf("generating AGENTS.md: %w", err)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("writing AGENTS.md: %w", err)
 	}
 
 	fmt.Println("AGENTS.md created.")
 	return nil
+}
+
+func detectLanguage(projectDir string) string {
+	patterns := map[string]string{
+		"go.mod":           "Go",
+		"Cargo.toml":       "Rust",
+		"package.json":     "JavaScript/TypeScript",
+		"requirements.txt": "Python",
+		"pyproject.toml":   "Python",
+		"composer.json":    "PHP",
+		"pom.xml":          "Java",
+		"build.gradle":     "Java/Kotlin",
+		"Gemfile":          "Ruby",
+		"Cargo.lock":       "Rust",
+	}
+
+	for file, lang := range patterns {
+		if fileExists(filepath.Join(projectDir, file)) {
+			return lang
+		}
+	}
+
+	return "Unknown"
+}
+
+func generateAgentsTemplate(projectName, language string) string {
+	return fmt.Sprintf(`# %s
+
+## Project Overview
+
+- **Language**: %s
+- **Project**: %s
+
+## Development Guidelines
+
+- Follow existing code conventions
+- Write tests for new functionality
+- Update documentation as needed
+`, projectName, language, projectName)
 }
 
 func (s *Setup) checkGitHubActions() error {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/crazy-goat/one-dev-army/internal/config"
@@ -23,6 +24,153 @@ func TestCheckAgentsMD_Exists(t *testing.T) {
 
 	if err := s.checkAgentsMD(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify existing file was not overwritten
+	content, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "# Agents" {
+		t.Errorf("existing AGENTS.md was overwritten: got %q, want %q", string(content), "# Agents")
+	}
+}
+
+func TestCheckAgentsMD_CreatesTemplate(t *testing.T) {
+	dir := t.TempDir()
+
+	s := &Setup{
+		projectDir: dir,
+		oc:         opencode.NewClient("http://localhost:0"),
+		cfg:        &config.Config{},
+	}
+
+	if err := s.checkAgentsMD(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify file was created
+	path := filepath.Join(dir, "AGENTS.md")
+	if !fileExists(path) {
+		t.Fatal("AGENTS.md was not created")
+	}
+
+	// Verify content contains project name
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+	if !strings.Contains(contentStr, filepath.Base(dir)) {
+		t.Errorf("AGENTS.md does not contain project name: %q", contentStr)
+	}
+
+	// Verify file permissions
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o644 {
+		t.Errorf("AGENTS.md has wrong permissions: got %o, want %o", mode, 0o644)
+	}
+}
+
+func TestDetectLanguage(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    map[string]string
+		expected string
+	}{
+		{
+			name:     "Go project",
+			files:    map[string]string{"go.mod": "module test"},
+			expected: "Go",
+		},
+		{
+			name:     "Rust project",
+			files:    map[string]string{"Cargo.toml": "[package]"},
+			expected: "Rust",
+		},
+		{
+			name:     "Node.js project",
+			files:    map[string]string{"package.json": "{}"},
+			expected: "JavaScript/TypeScript",
+		},
+		{
+			name:     "Python project (requirements.txt)",
+			files:    map[string]string{"requirements.txt": "requests"},
+			expected: "Python",
+		},
+		{
+			name:     "Python project (pyproject.toml)",
+			files:    map[string]string{"pyproject.toml": "[project]"},
+			expected: "Python",
+		},
+		{
+			name:     "PHP project",
+			files:    map[string]string{"composer.json": "{}"},
+			expected: "PHP",
+		},
+		{
+			name:     "Java project (pom.xml)",
+			files:    map[string]string{"pom.xml": "<project>"},
+			expected: "Java",
+		},
+		{
+			name:     "Java/Kotlin project (build.gradle)",
+			files:    map[string]string{"build.gradle": "plugins"},
+			expected: "Java/Kotlin",
+		},
+		{
+			name:     "Ruby project",
+			files:    map[string]string{"Gemfile": "source"},
+			expected: "Ruby",
+		},
+		{
+			name:     "Unknown project",
+			files:    map[string]string{},
+			expected: "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for filename, content := range tt.files {
+				if err := os.WriteFile(filepath.Join(dir, filename), []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := detectLanguage(dir)
+			if got != tt.expected {
+				t.Errorf("detectLanguage() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGenerateAgentsTemplate(t *testing.T) {
+	projectName := "my-awesome-project"
+	language := "Go"
+
+	got := generateAgentsTemplate(projectName, language)
+
+	if !strings.Contains(got, projectName) {
+		t.Errorf("template does not contain project name: %q", got)
+	}
+	if !strings.Contains(got, language) {
+		t.Errorf("template does not contain language: %q", got)
+	}
+	if !strings.Contains(got, "# my-awesome-project") {
+		t.Errorf("template does not contain header: %q", got)
+	}
+	if !strings.Contains(got, "Project Overview") {
+		t.Errorf("template does not contain 'Project Overview' section: %q", got)
+	}
+	if !strings.Contains(got, "Development Guidelines") {
+		t.Errorf("template does not contain 'Development Guidelines' section: %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #188

## Description
When ODA starts and AGENTS.md doesn't exist, create it with a simple template instead of generating via LLM.

## Current Behavior
`setup.go` uses `opencode.InitSession()` which calls LLM to generate AGENTS.md. This is slow and requires LLM availability.

## Expected Behavior
If AGENTS.md doesn't exist, create it with a simple, static template immediately without LLM call.

## Tasks
- [ ] Modify `internal/setup/setup.go`:
  - In `checkAgentsMD()` method
  - If file doesn't exist, create it with template content (not via LLM)
  - Remove or deprecate the LLM-based generation path
- [ ] Create simple AGENTS.md template with:
  - Project name from directory
  - Basic structure (language, purpose)
  - Common commands placeholder
  - Testing approach placeholder
- [ ] Add logging: "Created AGENTS.md with default template"
- [ ] Ensure file permissions are correct (0644)

## Template Content (example)
```markdown
# Project Agents Configuration

## Project Overview
- **Name**: [directory name]
- **Language**: [detected from files]
- **Purpose**: [basic description]

## Development Commands
- Build: 
- Test: 
- Lint: 

## Testing Approach
- Unit tests location: 
- Integration tests: 
- Test command: 

## Notes
Add project-specific instructions here.
```

## Files to Modify
- `internal/setup/setup.go`

## Acceptance Criteria
- [ ] If AGENTS.md missing, it's created immediately without LLM call
- [ ] Template contains basic project info
- [ ] File has correct permissions
- [ ] ODA starts successfully even without LLM
- [ ] Existing AGENTS.md is not overwritten
- [ ] Tests updated if needed

## Priority
Medium - improves startup time and reliability

Part of Sprint 4