### PR TITLE
[Bug] The user wants me to generate a GitHub issue title based on the technic...

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
 )
@@ -49,10 +50,20 @@ func (m *BranchManager) CreateBranch(branch string) error {
 }
 
 // RemoveBranch switches back to the default branch and deletes the given branch.
+// If the branch doesn't exist, it returns nil (no error) and logs a warning.
 func (m *BranchManager) RemoveBranch(branch string) error {
+	// First check if branch exists
+	cmd := exec.Command("git", "rev-parse", "--verify", branch)
+	cmd.Dir = m.repoDir
+	if err := cmd.Run(); err != nil {
+		// Branch doesn't exist - not an error, just log and return
+		log.Printf("[BranchManager] Branch %q does not exist, skipping deletion", branch)
+		return nil
+	}
+
 	// Switch to main/master first
 	defaultBranch := m.detectDefaultBranch()
-	cmd := exec.Command("git", "checkout", defaultBranch)
+	cmd = exec.Command("git", "checkout", defaultBranch)
 	cmd.Dir = m.repoDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git checkout %s: %w\n%s", defaultBranch, err, out)
@@ -64,6 +75,8 @@ func (m *BranchManager) RemoveBranch(branch string) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git branch -D %s: %w\n%s", branch, err, out)
 	}
+
+	log.Printf("[BranchManager] Deleted branch %q", branch)
 	return nil
 }
 

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -139,3 +139,20 @@ func TestLegacyAliases(t *testing.T) {
 		t.Error("expected non-empty output")
 	}
 }
+
+// TestRemoveBranchNonExistent verifies that RemoveBranch handles non-existent branches gracefully
+func TestRemoveBranchNonExistent(t *testing.T) {
+	repoDir := setupRepo(t)
+	mgr := git.NewBranchManager(repoDir)
+
+	// Try to remove a branch that doesn't exist - should not error
+	if err := mgr.RemoveBranch("non-existent-branch"); err != nil {
+		t.Errorf("RemoveBranch(non-existent) = %v, want nil", err)
+	}
+
+	// Verify we're still on the default branch
+	got := currentBranch(t, repoDir)
+	if got != "master" && got != "main" {
+		t.Errorf("current branch = %q, want master or main", got)
+	}
+}

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -243,6 +243,14 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 
 		processErr := o.worker.Process(ctx, task)
 
+		// Explicit cleanup: ensure branch is deleted after worker finishes (success or failure)
+		if task.Branch != "" {
+			log.Printf("[Orchestrator] Cleaning up branch %q for issue #%d", task.Branch, task.Issue.Number)
+			if err := o.brMgr.RemoveBranch(task.Branch); err != nil {
+				log.Printf("[Orchestrator] Warning: failed to remove branch %q: %v", task.Branch, err)
+			}
+		}
+
 		o.mu.Lock()
 		o.processing = false
 		o.currentTask = nil

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -177,6 +177,16 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 	task.Worktree = w.repoDir
 	log.Printf("[Worker %d] Branch %s ready, working in %s", w.id, branch, w.repoDir)
 
+	// Deferred cleanup: delete branch after PR workflow completes (success or failure)
+	defer func() {
+		if task.Branch != "" {
+			log.Printf("[Worker %d] Cleaning up branch %q", w.id, task.Branch)
+			if err := w.brMgr.RemoveBranch(task.Branch); err != nil {
+				log.Printf("[Worker %d] Warning: failed to remove branch %q: %v", w.id, task.Branch, err)
+			}
+		}
+	}()
+
 	var analysis, implPlan, prURL string
 	var err error
 


### PR DESCRIPTION
Closes #213

## Architecture Overview

System składa się z pipeline'u przetwarzania ticketów GitHub, gdzie worker realizuje zadania w kilku etapach: analiza, planowanie, implementacja, code review, tworzenie PR i merge. Po zakończeniu pracy worker tworzy PR, który następnie może być zmergowany (automatycznie lub po manualnej akceptacji).

Kluczowe komponenty:
- **Worker** (`internal/mvp/worker.go`, `internal/worker/processor.go`) - wykonuje pracę nad ticketem
- **BranchManager** (`internal/git/worktree.go`) - zarządza branchami git
- **Orchestrator** (`internal/mvp/orchestrator.go`) - koordynuje przepływ pracy
- **GitHub Client** (`internal/github/issues.go`) - obsługuje operacje na PR

Przepływ danych:
1. Worker tworzy branch dla ticketu
2. Implementuje zmiany i tworzy PR
3. Po zmergowaniu PR (automatycznie lub manualnie) branch lokalny powinien zostać usunięty

## Files Requiring Changes

- `internal/worker/processor.go` - dodanie wywołania usuwania brancha po zakończeniu pipeline'u (po merge PR)
- `internal/mvp/worker.go` - weryfikacja czy po utworzeniu PR i zakończeniu pracy worker czyści branch
- `internal/mvp/orchestrator.go` - upewnienie się że po zakończeniu pracy nad ticketem (sukces lub porażka) branch jest usuwany
- `internal/git/worktree.go` - metoda `RemoveBranch` już istnieje, weryfikacja czy obsługuje wszystkie edge case'y

## Component Dependencies

**Zależności między modułami:**
- Worker/Processor zależy od BranchManager do tworzenia i usuwania branchy
- Orchestrator zarządza cyklem życia tasku i powinien zapewnić cleanup
- BranchManager operuje na lokalnym repozytorium git

**Zależności zewnętrzne:**
- Git CLI - operacje na branchach (`git branch -D`, `git checkout`)
- GitHub API - status PR (merged/closed)

**Schemat bazy danych:**
- Brak zmian w schemacie wymaganych

## Implementation Boundaries

**W zakresie:**
- Automatyczne usuwanie lokalnego brancha po zmergowaniu PR
- Obsługa cleanup'u brancha w przypadku błędów (failed state)
- Logika hardcoded w kodzie Go, nie w promptach LLM
- Obsługa edge case'ów: branch nie istnieje, merge nie powiódł się, przerwanie pracy

**Poza zakresem:**
- Usuwanie remote brancha (GitHub CLI robi to przy merge z flagą `--delete-branch`)
- Zarządzanie worktrees (legacy feature)
- Zmiana logiki merge'owania PR
- Dodawanie nowych etapów do pipeline'u

**Ograniczenia:**
- BranchManager działa na pojedynczym repozytorium (single-branch mode)
- Nie używać git worktrees - tylko regular git checkout

## Acceptance Criteria

1. Po zmergowaniu PR przez worker (automatycznie lub po akceptacji) lokalny branch `task/{issue-number}-{slug}` jest usuwany z repozytorium
2. W przypadku błędu lub przerwania pracy nad ticketem branch jest usuwany (cleanup)
3. Logika usuwania brancha jest zaimplementowana w kodzie Go (wywołanie `brMgr.RemoveBranch()`), nie w promptach LLM
4. System loguje informację o usunięciu brancha w logach aplikacji