### PR TITLE
[Bug] Fix stale CDN cache causing label regressions in issue sync

### DIFF
--- a/.oda/issue-cache-strategy.md
+++ b/.oda/issue-cache-strategy.md
@@ -1,0 +1,67 @@
+## Problem: Nieaktualne dane z GitHub API nadpisują lokalny cache
+
+### Opis problemu
+Obecnie mechanizm synchronizacji z GitHubem (`SyncService`) używa strategii **zawsze nadpisuj** (`INSERT OR REPLACE`). Gdy GitHub API zwraca nieaktualne dane (cache CDN po ich stronie), lokalny cache w SQLite jest nadpisywany starszymi informacjami.
+
+**Przykład scenariusza błędu:**
+1. Ticket #123 ma labelkę `stage:in-progress` (zapisana w lokalnym cache)
+2. Użytkownik przesuwa ticket na boardzie → labelka zmienia się na `stage:code-review`
+3. Przychodzi auto-sync z GitHuba (co 30s)
+4. GitHub zwraca jeszcze starą wersję (cache CDN)
+5. Lokalny cache jest nadpisywany starą labelką `stage:in-progress`
+6. Dashboard pokazuje nieaktualny stan
+
+### Proponowane rozwiązania
+
+#### Opcja 1: Konserwatywny (timestamp-based)
+**Mechanizm:** Przed zapisem porównuj `updated_at` z GitHub API z `cached_at` w SQLite. Zapisz tylko jeśli dane z GitHuba są nowsze.
+
+**Zalety:**
+- Chroni przed nadpisaniem nowszych danych starszymi
+- Prosta implementacja
+
+**Wady:**
+- Jeśli ktoś zmieni labelkę ręcznie w UI ODA (bezpośrednio w SQLite), a potem przyjdzie sync ze starszym timestampem ze strony GitHuba - zmiana zostanie cofnięta
+- Nie rozróżnia źródła zmiany (auto-sync vs ręczna akcja)
+
+#### Opcja 2: Hybrydowy (kontekstowy)
+**Mechanizm:** 
+- Dla **auto-sync** (co 30s): Konserwatywny - ignoruj starsze dane z GitHuba
+- Dla **ręcznych akcji** (przycisk w dashboard, zmiana stage przez API): Agresywny - zawsze zapisz + aktualizuj timestamp
+
+**Zalety:**
+- Chroni przed bugiem cache CDN
+- Ręczne zmiany w dashboardzie działają natychmiast i nie są cofane
+- Przewidywalne zachowanie dla użytkownika
+
+**Wady:**
+- Nieco bardziej złożona implementacja (trzeba dodać flagę `force` do `SaveIssueCache`)
+- Wymaga zmian w handlerach dashboardu
+
+#### Opcja 3: Pesymistyczny (zawsze czyść przed sync)
+**Mechanizm:** Przed każdym synciem czyść cały cache i buduj od nowa. Nie ma problemu nadpisywania, bo zawsze zaczynamy od zera.
+
+**Zalety:**
+- Najprostsza implementacja
+- Gwarancja spójności
+
+**Wady:**
+- Utrata historii zmian w cache (np. `merged_at` może się różnić między syncami)
+- Krótkie "miganie" danych na dashboardzie podczas sync
+- Większe obciążenie SQLite (DELETE + INSERT zamiast UPDATE)
+
+---
+
+### Rekomendacja
+**Opcja 2 (Hybrydowy)** - najlepszy balans między bezpieczeństwem a funkcjonalnością.
+
+### Zadania do wykonania
+- [ ] Dodać pole `updated_at` (timestamp z GitHub API) do struktury `github.Issue`
+- [ ] Zmodyfikować `SaveIssueCache` aby przyjmował flagę `force bool`
+- [ ] Zmienić logikę w `sync.go` (auto-sync) na konserwatywną
+- [ ] Zmienić logikę w `dashboard/handlers.go` (ręczne akcje) na agresywną
+- [ ] Dodać logowanie gdy dane są pomijane z powodu starego timestampa
+
+---
+
+**Którą opcję wybieramy?**

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -372,7 +372,7 @@ func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 	// Update cache
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -406,7 +406,7 @@ func (s *Server) handleReject(w http.ResponseWriter, r *http.Request) {
 	// Update cache
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -440,7 +440,7 @@ func (s *Server) handleRetry(w http.ResponseWriter, r *http.Request) {
 	// Update cache
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -489,7 +489,7 @@ func (s *Server) handleRetryFresh(w http.ResponseWriter, r *http.Request) {
 	// Update cache
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -533,7 +533,7 @@ func (s *Server) handleBlock(w http.ResponseWriter, r *http.Request) {
 
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -564,7 +564,7 @@ func (s *Server) handleUnblock(w http.ResponseWriter, r *http.Request) {
 
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -614,7 +614,7 @@ func (s *Server) handleDecline(w http.ResponseWriter, r *http.Request) {
 	// Update cache
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}
@@ -653,7 +653,7 @@ func (s *Server) handleApproveMerge(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if s.store != nil {
 			milestone := s.activeSprintName()
-			_ = s.store.SaveIssueCache(mergingIssue, milestone)
+			_ = s.store.SaveIssueCache(mergingIssue, milestone, true)
 		}
 		if s.hub != nil {
 			s.hub.BroadcastIssueUpdate(mergingIssue)
@@ -676,7 +676,7 @@ func (s *Server) handleApproveMerge(w http.ResponseWriter, r *http.Request) {
 		} else {
 			if s.store != nil {
 				milestone := s.activeSprintName()
-				if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+				if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 					log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 				}
 			}
@@ -714,7 +714,7 @@ func (s *Server) handleApproveMerge(w http.ResponseWriter, r *http.Request) {
 	// Update cache
 	if s.store != nil {
 		milestone := s.activeSprintName()
-		if err := s.store.SaveIssueCache(updatedIssue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(updatedIssue, milestone, true); err != nil {
 			log.Printf("[Dashboard] Error saving issue cache for #%d: %v", issueNum, err)
 		}
 	}

--- a/internal/dashboard/sync.go
+++ b/internal/dashboard/sync.go
@@ -17,7 +17,7 @@ type GitHubClient interface {
 
 // Store defines the interface for database operations needed by SyncService
 type Store interface {
-	SaveIssueCache(issue github.Issue, milestone string) error
+	SaveIssueCache(issue github.Issue, milestone string, force bool) error
 }
 
 // SyncService handles periodic synchronization of GitHub issues with the local cache
@@ -167,7 +167,7 @@ func (s *SyncService) syncNow() {
 			}
 		}
 
-		if err := s.store.SaveIssueCache(issue, milestone); err != nil {
+		if err := s.store.SaveIssueCache(issue, milestone, false); err != nil {
 			log.Printf("[SyncService] Error caching issue #%d: %v", issue.Number, err)
 			continue
 		}

--- a/internal/dashboard/sync_test.go
+++ b/internal/dashboard/sync_test.go
@@ -41,7 +41,7 @@ type mockStore struct {
 	saveErr      error
 }
 
-func (m *mockStore) SaveIssueCache(issue github.Issue, milestone string) error {
+func (m *mockStore) SaveIssueCache(issue github.Issue, milestone string, force bool) error {
 	if m.saveErr != nil {
 		return m.saveErr
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/github"
@@ -269,7 +270,23 @@ func (s *Store) GetPlanAttachmentURL(issueNumber int) (string, error) {
 }
 
 // SaveIssueCache stores an issue in the cache
-func (s *Store) SaveIssueCache(issue github.Issue, milestone string) error {
+// When force=false (auto-sync), it compares timestamps and skips if local data is newer
+// When force=true (manual actions), it always updates the cache
+func (s *Store) SaveIssueCache(issue github.Issue, milestone string, force bool) error {
+	// If not forcing, check if we should skip due to stale CDN data
+	if !force {
+		existing, err := s.GetIssueCache(issue.Number)
+		if err == nil && existing.UpdatedAt != nil && issue.UpdatedAt != nil {
+			// If local data is newer than GitHub data, skip the update
+			if existing.UpdatedAt.After(*issue.UpdatedAt) {
+				log.Printf("[DB] Skipping cache update for issue #%d: local data is newer (local: %v, GitHub: %v)",
+					issue.Number, existing.UpdatedAt, issue.UpdatedAt)
+				return nil
+			}
+		}
+		// If error getting existing cache (not found), continue with save
+	}
+
 	labelsJSON, err := json.Marshal(issue.GetLabelNames())
 	if err != nil {
 		return fmt.Errorf("marshaling labels: %w", err)
@@ -278,7 +295,7 @@ func (s *Store) SaveIssueCache(issue github.Issue, milestone string) error {
 	_, err = s.db.Exec(
 		`INSERT OR REPLACE INTO issue_cache (issue_number, title, body, state, labels, assignee, milestone, updated_at, cached_at, pr_merged, merged_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		issue.Number, issue.Title, issue.Body, issue.State, string(labelsJSON), issue.GetAssignee(), milestone, time.Now(), time.Now(),
+		issue.Number, issue.Title, issue.Body, issue.State, string(labelsJSON), issue.GetAssignee(), milestone, issue.UpdatedAt, time.Now(),
 		issue.PRMerged, issue.MergedAt,
 	)
 	if err != nil {
@@ -338,6 +355,7 @@ func (s *Store) GetIssueCache(issueNumber int) (github.Issue, error) {
 		Assignees: assignees,
 		PRMerged:  cache.PRMerged,
 		MergedAt:  cache.MergedAt,
+		UpdatedAt: cache.UpdatedAt,
 	}, nil
 }
 
@@ -424,6 +442,7 @@ func (s *Store) scanIssues(rows *sql.Rows) ([]github.Issue, error) {
 			Assignees: assignees,
 			PRMerged:  cache.PRMerged,
 			MergedAt:  cache.MergedAt,
+			UpdatedAt: cache.UpdatedAt,
 		})
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -279,7 +279,7 @@ func TestSaveAndGetIssueCache(t *testing.T) {
 		},
 	}
 
-	if err := store.SaveIssueCache(issue, "v1.0"); err != nil {
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
 		t.Fatalf("saving issue cache: %v", err)
 	}
 
@@ -338,7 +338,7 @@ func TestGetIssuesCacheByMilestone(t *testing.T) {
 		if issue.Number == 3 {
 			milestone = "v2.0"
 		}
-		if err := store.SaveIssueCache(issue, milestone); err != nil {
+		if err := store.SaveIssueCache(issue, milestone, true); err != nil {
 			t.Fatalf("saving issue cache: %v", err)
 		}
 	}
@@ -369,7 +369,7 @@ func TestGetAllCachedIssues(t *testing.T) {
 	}
 
 	for _, issue := range issues {
-		if err := store.SaveIssueCache(issue, "backlog"); err != nil {
+		if err := store.SaveIssueCache(issue, "backlog", true); err != nil {
 			t.Fatalf("saving issue cache: %v", err)
 		}
 	}
@@ -394,7 +394,7 @@ func TestClearIssueCache(t *testing.T) {
 		Labels: nil,
 	}
 
-	if err := store.SaveIssueCache(issue, "v1.0"); err != nil {
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
 		t.Fatalf("saving issue cache: %v", err)
 	}
 
@@ -434,7 +434,7 @@ func TestSaveAndGetIssueCache_WithMergeStatus(t *testing.T) {
 		Assignees: nil,
 	}
 
-	if err := store.SaveIssueCache(issue, "v1.0"); err != nil {
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
 		t.Fatalf("saving issue cache with merge status: %v", err)
 	}
 
@@ -473,7 +473,7 @@ func TestSaveAndGetIssueCache_NotMerged(t *testing.T) {
 		Assignees: nil,
 	}
 
-	if err := store.SaveIssueCache(issue, "v1.0"); err != nil {
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
 		t.Fatalf("saving issue cache without merge status: %v", err)
 	}
 
@@ -487,5 +487,209 @@ func TestSaveAndGetIssueCache_NotMerged(t *testing.T) {
 	}
 	if got.MergedAt != nil {
 		t.Errorf("merged_at should be nil, got %v", got.MergedAt)
+	}
+}
+
+func TestSaveIssueCache_TimestampComparison_SkipWhenLocalNewer(t *testing.T) {
+	store := openTestStore(t)
+
+	// Create initial issue with NEWER timestamp (simulating recent local edit)
+	newTime := time.Now().UTC().Truncate(time.Second)
+	issue := github.Issue{
+		Number:    200,
+		Title:     "Local Title",
+		Body:      "Local body",
+		State:     "open",
+		UpdatedAt: &newTime,
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save initial issue with force=true (simulating local edit)
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
+		t.Fatalf("saving initial issue cache: %v", err)
+	}
+
+	// Verify initial save
+	got, err := store.GetIssueCache(200)
+	if err != nil {
+		t.Fatalf("getting initial issue cache: %v", err)
+	}
+	if got.Title != "Local Title" {
+		t.Errorf("initial title = %q, want %q", got.Title, "Local Title")
+	}
+
+	// Simulate stale GitHub CDN data with OLDER timestamp
+	oldTime := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
+	staleGitHubIssue := github.Issue{
+		Number:    200,
+		Title:     "Stale GitHub Title",
+		Body:      "Stale GitHub body",
+		State:     "open",
+		UpdatedAt: &oldTime,
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save with force=false (auto-sync) - should skip because local is newer than GitHub
+	if err := store.SaveIssueCache(staleGitHubIssue, "v1.0", false); err != nil {
+		t.Fatalf("saving stale GitHub issue cache with force=false: %v", err)
+	}
+
+	// Verify the cache was NOT updated (still has local data)
+	got, err = store.GetIssueCache(200)
+	if err != nil {
+		t.Fatalf("getting issue cache after skip: %v", err)
+	}
+	if got.Title != "Local Title" {
+		t.Errorf("title after skip = %q, want %q (should not have updated)", got.Title, "Local Title")
+	}
+	if got.Body != "Local body" {
+		t.Errorf("body after skip = %q, want %q (should not have updated)", got.Body, "Local body")
+	}
+}
+
+func TestSaveIssueCache_TimestampComparison_UpdateWhenGitHubNewer(t *testing.T) {
+	store := openTestStore(t)
+
+	// Create initial issue with newer timestamp (simulating local edit)
+	newTime := time.Now().UTC().Truncate(time.Second)
+	issue := github.Issue{
+		Number:    201,
+		Title:     "Local Title",
+		Body:      "Local body",
+		State:     "open",
+		UpdatedAt: &newTime,
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save initial issue with force=true
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
+		t.Fatalf("saving initial issue cache: %v", err)
+	}
+
+	// Simulate GitHub update with even newer timestamp
+	newerTime := time.Now().UTC().Add(1 * time.Minute).Truncate(time.Second)
+	githubIssue := github.Issue{
+		Number:    201,
+		Title:     "GitHub Title",
+		Body:      "GitHub body",
+		State:     "open",
+		UpdatedAt: &newerTime,
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save with force=false (auto-sync) - should update because GitHub is newer
+	if err := store.SaveIssueCache(githubIssue, "v1.0", false); err != nil {
+		t.Fatalf("saving GitHub issue cache with force=false: %v", err)
+	}
+
+	// Verify the cache WAS updated
+	got, err := store.GetIssueCache(201)
+	if err != nil {
+		t.Fatalf("getting issue cache after update: %v", err)
+	}
+	if got.Title != "GitHub Title" {
+		t.Errorf("title after update = %q, want %q", got.Title, "GitHub Title")
+	}
+	if got.Body != "GitHub body" {
+		t.Errorf("body after update = %q, want %q", got.Body, "GitHub body")
+	}
+}
+
+func TestSaveIssueCache_ForceTrue_AlwaysUpdates(t *testing.T) {
+	store := openTestStore(t)
+
+	// Create initial issue
+	oldTime := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
+	issue := github.Issue{
+		Number:    202,
+		Title:     "Original Title",
+		Body:      "Original body",
+		State:     "open",
+		UpdatedAt: &oldTime,
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save initial issue
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
+		t.Fatalf("saving initial issue cache: %v", err)
+	}
+
+	// Update local issue with newer timestamp
+	newTime := time.Now().UTC().Truncate(time.Second)
+	localIssue := github.Issue{
+		Number:    202,
+		Title:     "Local Title",
+		Body:      "Local body",
+		State:     "open",
+		UpdatedAt: &newTime,
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save with force=true (manual action) - should always update even if local is newer
+	if err := store.SaveIssueCache(localIssue, "v1.0", true); err != nil {
+		t.Fatalf("saving local issue cache with force=true: %v", err)
+	}
+
+	// Verify the cache WAS updated despite local being newer
+	got, err := store.GetIssueCache(202)
+	if err != nil {
+		t.Fatalf("getting issue cache after force update: %v", err)
+	}
+	if got.Title != "Local Title" {
+		t.Errorf("title after force update = %q, want %q", got.Title, "Local Title")
+	}
+	if got.Body != "Local body" {
+		t.Errorf("body after force update = %q, want %q", got.Body, "Local body")
+	}
+}
+
+func TestSaveIssueCache_NoTimestamps_UpdatesAnyway(t *testing.T) {
+	store := openTestStore(t)
+
+	// Create issue without timestamps
+	issue := github.Issue{
+		Number:    203,
+		Title:     "First Title",
+		Body:      "First body",
+		State:     "open",
+		UpdatedAt: nil, // No timestamp
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save initial issue
+	if err := store.SaveIssueCache(issue, "v1.0", true); err != nil {
+		t.Fatalf("saving initial issue cache: %v", err)
+	}
+
+	// Update issue
+	updatedIssue := github.Issue{
+		Number:    203,
+		Title:     "Second Title",
+		Body:      "Second body",
+		State:     "open",
+		UpdatedAt: nil, // Still no timestamp
+		Labels:    nil,
+		Assignees: nil,
+	}
+
+	// Save with force=false - should update since we can't compare timestamps
+	if err := store.SaveIssueCache(updatedIssue, "v1.0", false); err != nil {
+		t.Fatalf("saving updated issue cache: %v", err)
+	}
+
+	// Verify the cache WAS updated
+	got, err := store.GetIssueCache(203)
+	if err != nil {
+		t.Fatalf("getting issue cache: %v", err)
+	}
+	if got.Title != "Second Title" {
+		t.Errorf("title = %q, want %q", got.Title, "Second Title")
 	}
 }

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -22,8 +22,9 @@ type Issue struct {
 		Name string `json:"name"`
 	} `json:"labels"`
 	// PR merge status fields for distinguishing merged vs manually closed issues
-	PRMerged bool       `json:"pr_merged,omitempty"`
-	MergedAt *time.Time `json:"merged_at,omitempty"`
+	PRMerged  bool       `json:"pr_merged,omitempty"`
+	MergedAt  *time.Time `json:"merged_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // GetAssignee returns the first assignee's login or empty string if unassigned

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func runServe() error {
 			// Step 5: Populate issue_cache table
 			cachedCount := 0
 			for _, issue := range issues {
-				if err := store.SaveIssueCache(issue, activeMilestone.Title); err != nil {
+				if err := store.SaveIssueCache(issue, activeMilestone.Title, true); err != nil {
 					fmt.Printf("  ! error caching issue #%d: %v\n", issue.Number, err)
 					continue
 				}


### PR DESCRIPTION
Closes #222

## Description
GitHub API occasionally returns stale cached data due to CDN caching. The current sync mechanism uses `INSERT OR REPLACE` which unconditionally overwrites the local SQLite cache, causing label regressions. For example, a ticket showing "code-review" gets reverted to "in-progress" when GitHub returns outdated data. A hybrid cache strategy is needed: auto-sync should only update when GitHub data is newer (comparing `updated_at` timestamps), while manual dashboard actions should always update immediately.

## Tasks
1. Add `updated_at` field to `github.Issue` struct to store the GitHub API timestamp
2. Modify `SaveIssueCache()` function signature to accept a `force bool` parameter
3. Update `SaveIssueCache()` logic to compare timestamps when `force=false`, skip save if local data is newer
4. Update auto-sync background job to call `SaveIssueCache()` with `force=false`
5. Update all dashboard handler functions to call `SaveIssueCache()` with `force=true`
6. Add debug logging when cache update is skipped due to stale timestamp

## Files to Modify
- `internal/github/types.go` - Add `updated_at` field to Issue struct
- `internal/github/cache.go` - Modify `SaveIssueCache()` signature and add timestamp comparison logic
- `internal/sync/sync.go` - Update auto-sync calls to use `force=false`
- `internal/dashboard/handlers.go` - Update manual action handlers to use `force=true`

## Acceptance Criteria
1. Auto-sync only updates cache when GitHub `updated_at` is newer than local cache timestamp
2. Manual dashboard actions (buttons) always update cache regardless of timestamp
3. Debug log entry is written when a cache update is skipped due to stale data
4. Label regressions no longer occur during normal auto-sync operations
5. Dashboard immediately reflects changes after manual user actions