### PR TITLE
[Feature] Make dashboard use full available width

### DIFF
--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -19,7 +19,7 @@ nav .links a{padding:.4rem .8rem;border-radius:6px;color:var(--muted);font-size:
 nav .links a:hover{color:var(--text);background:var(--border);text-decoration:none}
 nav .links a.active{color:var(--text);background:var(--border)}
 nav .nav-actions{display:flex;gap:.5rem;margin-left:auto}
-.container{max-width:1400px;margin:0 auto;padding:1.5rem}
+.container{margin:0 auto;padding:1.5rem}
 .btn{display:inline-flex;align-items:center;gap:.4rem;padding:.5rem 1rem;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-size:.85rem;cursor:pointer;transition:background .15s}
 .btn:hover{background:var(--border)}
 .btn-primary{background:var(--accent);border-color:var(--accent);color:#fff}


### PR DESCRIPTION
Closes #224

## Description
The dashboard currently uses only a portion of the available screen width, leaving unused space on the sides. This feature request is to make the dashboard expand to utilize the full available width for better use of screen real estate.

## Tasks
1. Locate the dashboard layout/container component in the codebase
2. Identify the CSS or styling that limits the width (max-width, width constraints, container classes)
3. Modify the styling to allow the dashboard to expand to 100% of available width
4. Test the change at different screen resolutions to ensure proper display
5. Verify that content remains readable and well-formatted at full width

## Files to Modify
- Dashboard layout/template files (likely in `internal/dashboard/` or web UI directory)
- CSS/styling files that control dashboard container width

## Acceptance Criteria
- [ ] Dashboard container spans the full available width of the viewport
- [ ] No horizontal scrollbars appear on standard screen sizes
- [ ] Content remains properly aligned and readable at all widths
- [ ] Change works correctly on both desktop and tablet screen sizes