### PR TITLE
[Feature] Compressed GitHub API usage indicator with GraphQL support

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1682,28 +1682,99 @@ func (s *Server) handleRateLimit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := s.rateLimitService.GetData()
+	summary := s.rateLimitService.GetSummary()
+	if summary == nil {
+		w.Write([]byte(`<span class="rate-limit-unknown">GitHub API: Loading...</span>`))
+		return
+	}
 
-	// Build the HTML response
-	color := data.GetColorCSS()
-	statusText := fmt.Sprintf("GitHub API: %d/%d", data.Remaining, data.Limit)
-	resetText := data.GetResetTimeFormatted()
+	// Calculate worst percentage
+	worstPercentage := summary.GetWorstPercentage()
+	color := summary.GetWorstColorCSS()
+	worstLimit := summary.GetWorstLimit()
 
-	// Add warning indicator if there's an error but we have cached data
+	// Build the compressed indicator HTML with tooltip
+	var html strings.Builder
+
+	// Warning icon if there's an error but we have cached data
 	warningIcon := ""
-	if data.Error != "" && !data.UpdatedAt.IsZero() {
+	if summary.Error != "" && !summary.UpdatedAt.IsZero() {
 		warningIcon = " ⚠"
 	}
 
-	html := fmt.Sprintf(
-		`<div class="rate-limit-container" style="color: %s; cursor: pointer;" title="Click to refresh" hx-post="/api/rate-limit/refresh" hx-swap="outerHTML">
-			<span class="rate-limit-status">%s%s</span>
-			<span class="rate-limit-reset">%s</span>
-		</div>`,
-		color, statusText, warningIcon, resetText,
-	)
+	// Compressed indicator showing worst percentage
+	html.WriteString(fmt.Sprintf(
+		`<div class="rate-limit-compressed" style="color: %s;" title="Click to refresh" hx-post="/api/rate-limit/refresh" hx-swap="outerHTML">`,
+		color,
+	))
+	html.WriteString(fmt.Sprintf(
+		`<span class="rate-limit-percentage">%.0f%% used%s</span>`,
+		worstPercentage,
+		warningIcon,
+	))
 
-	w.Write([]byte(html))
+	// Add tooltip panel with detailed breakdown
+	html.WriteString(`<div class="rate-limit-tooltip">`)
+	html.WriteString(`<div class="rate-limit-tooltip-header">GitHub API Rate Limits</div>`)
+	html.WriteString(`<div class="rate-limit-tooltip-content">`)
+
+	// Core API
+	if summary.Core != nil {
+		corePercentage := summary.Core.GetUsagePercentage()
+		coreColor := GetColorCSSByPercentage(corePercentage)
+		html.WriteString(fmt.Sprintf(
+			`<div class="rate-limit-row"><span class="rate-limit-label">REST API:</span><span class="rate-limit-value" style="color: %s">%d/%d (%.0f%%)</span><span class="rate-limit-reset">%s</span></div>`,
+			coreColor,
+			summary.Core.Remaining,
+			summary.Core.Limit,
+			corePercentage,
+			summary.Core.GetResetTimeFormatted(),
+		))
+	}
+
+	// GraphQL API
+	if summary.GraphQL != nil {
+		graphqlPercentage := summary.GraphQL.GetUsagePercentage()
+		graphqlColor := GetColorCSSByPercentage(graphqlPercentage)
+		html.WriteString(fmt.Sprintf(
+			`<div class="rate-limit-row"><span class="rate-limit-label">GraphQL:</span><span class="rate-limit-value" style="color: %s">%d/%d (%.0f%%)</span><span class="rate-limit-reset">%s</span></div>`,
+			graphqlColor,
+			summary.GraphQL.Remaining,
+			summary.GraphQL.Limit,
+			graphqlPercentage,
+			summary.GraphQL.GetResetTimeFormatted(),
+		))
+	}
+
+	// Search API
+	if summary.Search != nil {
+		searchPercentage := summary.Search.GetUsagePercentage()
+		searchColor := GetColorCSSByPercentage(searchPercentage)
+		html.WriteString(fmt.Sprintf(
+			`<div class="rate-limit-row"><span class="rate-limit-label">Search:</span><span class="rate-limit-value" style="color: %s">%d/%d (%.0f%%)</span><span class="rate-limit-reset">%s</span></div>`,
+			searchColor,
+			summary.Search.Remaining,
+			summary.Search.Limit,
+			searchPercentage,
+			summary.Search.GetResetTimeFormatted(),
+		))
+	}
+
+	html.WriteString(`</div>`) // Close tooltip-content
+
+	// Show which limit is the worst
+	if worstLimit != nil {
+		html.WriteString(fmt.Sprintf(
+			`<div class="rate-limit-tooltip-footer">Worst: %s (%.0f%% used)</div>`,
+			worstLimit.Name,
+			worstPercentage,
+		))
+	}
+
+	html.WriteString(`</div>`) // Close tooltip
+	html.WriteString(`</div>`) // Close rate-limit-compressed
+
+	w.Write([]byte(html.String()))
 }
 
 // handleRateLimitRefresh triggers a manual refresh of the rate limit data

--- a/internal/dashboard/ratelimit.go
+++ b/internal/dashboard/ratelimit.go
@@ -9,6 +9,7 @@ import (
 )
 
 // RateLimitInfo holds the rate limit data from GitHub API
+// Deprecated: Use APILimit for individual limits or RateLimitSummary for all limits
 type RateLimitInfo struct {
 	Limit     int       `json:"limit"`
 	Remaining int       `json:"remaining"`
@@ -17,7 +18,130 @@ type RateLimitInfo struct {
 	Error     string    `json:"error,omitempty"`
 }
 
+// APILimit represents an individual API rate limit type (core, graphql, search)
+type APILimit struct {
+	Name      string    `json:"name"`
+	Limit     int       `json:"limit"`
+	Remaining int       `json:"remaining"`
+	Reset     int64     `json:"reset"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// GetUsagePercentage returns the percentage of API quota used
+func (a *APILimit) GetUsagePercentage() float64 {
+	if a.Limit == 0 {
+		return 0
+	}
+	return float64(a.Limit-a.Remaining) / float64(a.Limit) * 100
+}
+
+// GetResetTimeFormatted returns the reset time in a human-readable format
+func (a *APILimit) GetResetTimeFormatted() string {
+	if a.Reset == 0 {
+		return "Unknown"
+	}
+
+	resetTime := time.Unix(a.Reset, 0)
+	duration := time.Until(resetTime)
+
+	if duration <= 0 {
+		return "Resets soon"
+	}
+
+	minutes := int(duration.Minutes())
+	if minutes < 1 {
+		return "Resets in <1 min"
+	}
+	if minutes < 60 {
+		return fmt.Sprintf("Resets in %d min", minutes)
+	}
+
+	hours := minutes / 60
+	remainingMinutes := minutes % 60
+	if remainingMinutes == 0 {
+		return fmt.Sprintf("Resets in %d hr", hours)
+	}
+	return fmt.Sprintf("Resets in %d hr %d min", hours, remainingMinutes)
+}
+
+// RateLimitSummary holds all three API rate limit types
+type RateLimitSummary struct {
+	Core      *APILimit `json:"core"`
+	GraphQL   *APILimit `json:"graphql"`
+	Search    *APILimit `json:"search"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Error     string    `json:"error,omitempty"`
+}
+
+// GetWorstLimit returns the API limit with the highest usage percentage
+func (r *RateLimitSummary) GetWorstLimit() *APILimit {
+	if r.Core == nil && r.GraphQL == nil && r.Search == nil {
+		return nil
+	}
+
+	var worst *APILimit
+	maxPercentage := -1.0
+
+	limits := []*APILimit{r.Core, r.GraphQL, r.Search}
+	for _, limit := range limits {
+		if limit != nil && limit.Limit > 0 {
+			percentage := limit.GetUsagePercentage()
+			if percentage > maxPercentage {
+				maxPercentage = percentage
+				worst = limit
+			}
+		}
+	}
+
+	return worst
+}
+
+// GetWorstPercentage returns the highest usage percentage across all API types
+func (r *RateLimitSummary) GetWorstPercentage() float64 {
+	worst := r.GetWorstLimit()
+	if worst == nil {
+		return 0
+	}
+	return worst.GetUsagePercentage()
+}
+
+// GetColorByPercentage returns the color code based on usage percentage
+// Green (<50%), Yellow (50-80%), Red (>80%)
+func GetColorByPercentage(percentage float64) string {
+	if percentage > 80 {
+		return "red"
+	}
+	if percentage > 50 {
+		return "yellow"
+	}
+	return "green"
+}
+
+// GetColorCSSByPercentage returns the CSS color variable based on usage percentage
+func GetColorCSSByPercentage(percentage float64) string {
+	color := GetColorByPercentage(percentage)
+	switch color {
+	case "red":
+		return "var(--red)"
+	case "yellow":
+		return "var(--orange)"
+	default:
+		return "var(--green)"
+	}
+}
+
+// GetWorstColor returns the color code for the worst limit
+func (r *RateLimitSummary) GetWorstColor() string {
+	return GetColorByPercentage(r.GetWorstPercentage())
+}
+
+// GetWorstColorCSS returns the CSS color variable for the worst limit
+func (r *RateLimitSummary) GetWorstColorCSS() string {
+	return GetColorCSSByPercentage(r.GetWorstPercentage())
+}
+
 // GetColor returns the color code based on remaining requests
+// Deprecated: Use GetColorByPercentage for percentage-based coloring
 // Green (>1000), Yellow (500-1000), Red (<500)
 func (r *RateLimitInfo) GetColor() string {
 	if r.Remaining < 500 {
@@ -30,6 +154,7 @@ func (r *RateLimitInfo) GetColor() string {
 }
 
 // GetColorCSS returns the CSS color variable based on remaining requests
+// Deprecated: Use GetColorCSSByPercentage for percentage-based coloring
 func (r *RateLimitInfo) GetColorCSS() string {
 	color := r.GetColor()
 	switch color {
@@ -75,6 +200,7 @@ func (r *RateLimitInfo) GetResetTimeFormatted() string {
 type RateLimitService struct {
 	mu       sync.RWMutex
 	data     *RateLimitInfo
+	summary  *RateLimitSummary
 	client   *http.Client
 	token    string
 	interval time.Duration
@@ -93,6 +219,13 @@ func NewRateLimitService(token string) *RateLimitService {
 			Limit:     0,
 			Remaining: 0,
 			Reset:     0,
+			UpdatedAt: time.Time{},
+			Error:     "Initializing...",
+		},
+		summary: &RateLimitSummary{
+			Core:      nil,
+			GraphQL:   nil,
+			Search:    nil,
 			UpdatedAt: time.Time{},
 			Error:     "Initializing...",
 		},
@@ -171,6 +304,16 @@ func (s *RateLimitService) fetch() {
 				Remaining int   `json:"remaining"`
 				Reset     int64 `json:"reset"`
 			} `json:"core"`
+			GraphQL struct {
+				Limit     int   `json:"limit"`
+				Remaining int   `json:"remaining"`
+				Reset     int64 `json:"reset"`
+			} `json:"graphql"`
+			Search struct {
+				Limit     int   `json:"limit"`
+				Remaining int   `json:"remaining"`
+				Reset     int64 `json:"reset"`
+			} `json:"search"`
 		} `json:"resources"`
 	}
 
@@ -179,12 +322,42 @@ func (s *RateLimitService) fetch() {
 		return
 	}
 
+	now := time.Now()
+
 	s.mu.Lock()
+	// Update legacy data for backward compatibility
 	s.data = &RateLimitInfo{
 		Limit:     result.Resources.Core.Limit,
 		Remaining: result.Resources.Core.Remaining,
 		Reset:     result.Resources.Core.Reset,
-		UpdatedAt: time.Now(),
+		UpdatedAt: now,
+		Error:     "",
+	}
+
+	// Update new summary data
+	s.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     result.Resources.Core.Limit,
+			Remaining: result.Resources.Core.Remaining,
+			Reset:     result.Resources.Core.Reset,
+			UpdatedAt: now,
+		},
+		GraphQL: &APILimit{
+			Name:      "GraphQL",
+			Limit:     result.Resources.GraphQL.Limit,
+			Remaining: result.Resources.GraphQL.Remaining,
+			Reset:     result.Resources.GraphQL.Reset,
+			UpdatedAt: now,
+		},
+		Search: &APILimit{
+			Name:      "Search",
+			Limit:     result.Resources.Search.Limit,
+			Remaining: result.Resources.Search.Remaining,
+			Reset:     result.Resources.Search.Reset,
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
 		Error:     "",
 	}
 	s.mu.Unlock()
@@ -202,10 +375,17 @@ func (s *RateLimitService) updateWithError(errMsg string) {
 		// The UI will show cached values with a warning indicator
 		s.data.Error = errMsg
 	}
+	// Also update summary error
+	if s.summary.UpdatedAt.IsZero() {
+		s.summary.Error = errMsg
+	} else {
+		s.summary.Error = errMsg
+	}
 	s.mu.Unlock()
 }
 
 // GetData returns the current rate limit data (thread-safe)
+// Deprecated: Use GetSummary() for multi-type rate limit data
 func (s *RateLimitService) GetData() *RateLimitInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -213,6 +393,33 @@ func (s *RateLimitService) GetData() *RateLimitInfo {
 	// Return a copy to prevent external modification
 	data := *s.data
 	return &data
+}
+
+// GetSummary returns the current rate limit summary for all API types (thread-safe)
+func (s *RateLimitService) GetSummary() *RateLimitSummary {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a copy to prevent external modification
+	if s.summary == nil {
+		return nil
+	}
+
+	summary := *s.summary
+	// Deep copy the limit pointers
+	if s.summary.Core != nil {
+		core := *s.summary.Core
+		summary.Core = &core
+	}
+	if s.summary.GraphQL != nil {
+		graphql := *s.summary.GraphQL
+		summary.GraphQL = &graphql
+	}
+	if s.summary.Search != nil {
+		search := *s.summary.Search
+		summary.Search = &search
+	}
+	return &summary
 }
 
 // Refresh triggers an immediate refresh of the rate limit data

--- a/internal/dashboard/ratelimit_test.go
+++ b/internal/dashboard/ratelimit_test.go
@@ -259,11 +259,16 @@ func TestHandleRateLimit(t *testing.T) {
 // TestHandleRateLimit_WithService tests the handler with a configured service
 func TestHandleRateLimit_WithService(t *testing.T) {
 	service := NewRateLimitService("")
-	service.data = &RateLimitInfo{
-		Limit:     5000,
-		Remaining: 4500,
-		Reset:     time.Now().Add(30 * time.Minute).Unix(),
-		UpdatedAt: time.Now(),
+	now := time.Now()
+	service.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     5000,
+			Remaining: 4500,
+			Reset:     now.Add(30 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
 		Error:     "",
 	}
 
@@ -284,27 +289,35 @@ func TestHandleRateLimit_WithService(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, "4500/5000") {
-		t.Errorf("expected '4500/5000' in response, got: %s", body)
-	}
-	if !strings.Contains(body, "rate-limit-container") {
-		t.Errorf("expected rate-limit-container class, got: %s", body)
+	// Should contain compressed format with percentage (10% used for core)
+	if !strings.Contains(body, "rate-limit-compressed") {
+		t.Errorf("expected 'rate-limit-compressed' class, got: %s", body)
 	}
 
-	// Should have green color for high remaining
+	// Should show percentage (10% for core at 4500/5000)
+	if !strings.Contains(body, "10%") {
+		t.Errorf("expected percentage in response, got: %s", body)
+	}
+
+	// Should have green color for low usage
 	if !strings.Contains(body, "var(--green)") {
-		t.Errorf("expected green color for high remaining, got: %s", body)
+		t.Errorf("expected green color for low usage, got: %s", body)
 	}
 }
 
 // TestHandleRateLimit_WithError tests the handler when service has error but cached data
 func TestHandleRateLimit_WithError(t *testing.T) {
 	service := NewRateLimitService("")
-	service.data = &RateLimitInfo{
-		Limit:     5000,
-		Remaining: 4500,
-		Reset:     time.Now().Add(30 * time.Minute).Unix(),
-		UpdatedAt: time.Now(),
+	now := time.Now()
+	service.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     5000,
+			Remaining: 4500,
+			Reset:     now.Add(30 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
 		Error:     "API connection failed",
 	}
 
@@ -330,11 +343,16 @@ func TestHandleRateLimit_WithError(t *testing.T) {
 // TestHandleRateLimitRefresh tests the refresh handler
 func TestHandleRateLimitRefresh(t *testing.T) {
 	service := NewRateLimitService("")
-	service.data = &RateLimitInfo{
-		Limit:     5000,
-		Remaining: 4500,
-		Reset:     time.Now().Add(30 * time.Minute).Unix(),
-		UpdatedAt: time.Now(),
+	now := time.Now()
+	service.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     5000,
+			Remaining: 4500,
+			Reset:     now.Add(30 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
 		Error:     "",
 	}
 
@@ -355,7 +373,8 @@ func TestHandleRateLimitRefresh(t *testing.T) {
 	}
 
 	body := rec.Body.String()
-	if !strings.Contains(body, "4500/5000") {
+	// Should show compressed format with percentage
+	if !strings.Contains(body, "rate-limit-compressed") {
 		t.Errorf("expected rate limit data after refresh, got: %s", body)
 	}
 }
@@ -478,5 +497,424 @@ func TestRateLimitInfo_JSONSerialization(t *testing.T) {
 	}
 	if decoded.Reset != original.Reset {
 		t.Errorf("Reset mismatch: got %v, want %v", decoded.Reset, original.Reset)
+	}
+}
+
+// TestAPILimit_GetUsagePercentage tests percentage calculation
+func TestAPILimit_GetUsagePercentage(t *testing.T) {
+	tests := []struct {
+		name      string
+		limit     int
+		remaining int
+		want      float64
+	}{
+		{"no usage", 5000, 5000, 0},
+		{"25% used", 5000, 3750, 25},
+		{"50% used", 5000, 2500, 50},
+		{"75% used", 5000, 1250, 75},
+		{"100% used", 5000, 0, 100},
+		{"zero limit", 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit := &APILimit{
+				Limit:     tt.limit,
+				Remaining: tt.remaining,
+			}
+			got := limit.GetUsagePercentage()
+			if got != tt.want {
+				t.Errorf("GetUsagePercentage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAPILimit_GetResetTimeFormatted tests reset time formatting
+func TestAPILimit_GetResetTimeFormatted(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		reset         int64
+		shouldContain string
+	}{
+		{"zero reset", 0, "Unknown"},
+		{"past time", now.Add(-5 * time.Minute).Unix(), "Resets soon"},
+		{"less than 1 minute", now.Add(30 * time.Second).Unix(), "<1 min"},
+		{"5 minutes", now.Add(5 * time.Minute).Unix(), "min"},
+		{"1 hour", now.Add(61 * time.Minute).Unix(), "hr"},
+		{"2 hours", now.Add(120 * time.Minute).Unix(), "hr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limit := &APILimit{Reset: tt.reset}
+			got := limit.GetResetTimeFormatted()
+			if !strings.Contains(got, tt.shouldContain) {
+				t.Errorf("GetResetTimeFormatted() = %v, should contain %v", got, tt.shouldContain)
+			}
+		})
+	}
+}
+
+// TestGetColorByPercentage tests color determination by percentage
+func TestGetColorByPercentage(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentage float64
+		want       string
+	}{
+		{"0% - green", 0, "green"},
+		{"25% - green", 25, "green"},
+		{"49% - green", 49, "green"},
+		{"50% - green", 50, "green"}, // 50% is green (yellow starts at >50%)
+		{"51% - yellow", 51, "yellow"},
+		{"65% - yellow", 65, "yellow"},
+		{"80% - yellow", 80, "yellow"}, // 80% is yellow (red starts at >80%)
+		{"81% - red", 81, "red"},
+		{"100% - red", 100, "red"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetColorByPercentage(tt.percentage)
+			if got != tt.want {
+				t.Errorf("GetColorByPercentage(%v) = %v, want %v", tt.percentage, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetColorCSSByPercentage tests CSS color variable mapping
+func TestGetColorCSSByPercentage(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentage float64
+		want       string
+	}{
+		{"green", 25, "var(--green)"},
+		{"yellow", 65, "var(--orange)"},
+		{"red", 85, "var(--red)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetColorCSSByPercentage(tt.percentage)
+			if got != tt.want {
+				t.Errorf("GetColorCSSByPercentage(%v) = %v, want %v", tt.percentage, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRateLimitSummary_GetWorstLimit tests worst limit selection
+func TestRateLimitSummary_GetWorstLimit(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		summary  *RateLimitSummary
+		wantName string
+	}{
+		{
+			name: "core is worst",
+			summary: &RateLimitSummary{
+				Core:    &APILimit{Name: "REST API", Limit: 5000, Remaining: 1000, UpdatedAt: now},
+				GraphQL: &APILimit{Name: "GraphQL", Limit: 5000, Remaining: 4000, UpdatedAt: now},
+				Search:  &APILimit{Name: "Search", Limit: 5000, Remaining: 4000, UpdatedAt: now},
+			},
+			wantName: "REST API",
+		},
+		{
+			name: "graphql is worst",
+			summary: &RateLimitSummary{
+				Core:    &APILimit{Name: "REST API", Limit: 5000, Remaining: 4000, UpdatedAt: now},
+				GraphQL: &APILimit{Name: "GraphQL", Limit: 5000, Remaining: 500, UpdatedAt: now},
+				Search:  &APILimit{Name: "Search", Limit: 5000, Remaining: 4000, UpdatedAt: now},
+			},
+			wantName: "GraphQL",
+		},
+		{
+			name: "search is worst",
+			summary: &RateLimitSummary{
+				Core:    &APILimit{Name: "REST API", Limit: 5000, Remaining: 4000, UpdatedAt: now},
+				GraphQL: &APILimit{Name: "GraphQL", Limit: 5000, Remaining: 4000, UpdatedAt: now},
+				Search:  &APILimit{Name: "Search", Limit: 5000, Remaining: 500, UpdatedAt: now},
+			},
+			wantName: "Search",
+		},
+		{
+			name:     "all nil",
+			summary:  &RateLimitSummary{},
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.summary.GetWorstLimit()
+			if tt.wantName == "" {
+				if got != nil {
+					t.Errorf("GetWorstLimit() = %v, want nil", got)
+				}
+			} else {
+				if got == nil {
+					t.Errorf("GetWorstLimit() = nil, want %v", tt.wantName)
+				} else if got.Name != tt.wantName {
+					t.Errorf("GetWorstLimit().Name = %v, want %v", got.Name, tt.wantName)
+				}
+			}
+		})
+	}
+}
+
+// TestRateLimitSummary_GetWorstPercentage tests worst percentage calculation
+func TestRateLimitSummary_GetWorstPercentage(t *testing.T) {
+	now := time.Now()
+
+	summary := &RateLimitSummary{
+		Core:    &APILimit{Limit: 5000, Remaining: 1000, UpdatedAt: now}, // 80% used
+		GraphQL: &APILimit{Limit: 5000, Remaining: 500, UpdatedAt: now},  // 90% used
+		Search:  &APILimit{Limit: 5000, Remaining: 4000, UpdatedAt: now}, // 20% used
+	}
+
+	got := summary.GetWorstPercentage()
+	want := 90.0
+	if got != want {
+		t.Errorf("GetWorstPercentage() = %v, want %v", got, want)
+	}
+}
+
+// TestRateLimitSummary_GetWorstColor tests worst color determination
+func TestRateLimitSummary_GetWorstColor(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		summary   *RateLimitSummary
+		wantColor string
+	}{
+		{
+			name: "green - low usage",
+			summary: &RateLimitSummary{
+				Core: &APILimit{Limit: 5000, Remaining: 4000, UpdatedAt: now}, // 20% used
+			},
+			wantColor: "green",
+		},
+		{
+			name: "yellow - medium usage",
+			summary: &RateLimitSummary{
+				Core: &APILimit{Limit: 5000, Remaining: 2000, UpdatedAt: now}, // 60% used
+			},
+			wantColor: "yellow",
+		},
+		{
+			name: "red - high usage",
+			summary: &RateLimitSummary{
+				Core: &APILimit{Limit: 5000, Remaining: 500, UpdatedAt: now}, // 90% used
+			},
+			wantColor: "red",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.summary.GetWorstColor()
+			if got != tt.wantColor {
+				t.Errorf("GetWorstColor() = %v, want %v", got, tt.wantColor)
+			}
+		})
+	}
+}
+
+// TestRateLimitService_GetSummary tests the GetSummary method
+func TestRateLimitService_GetSummary(t *testing.T) {
+	service := NewRateLimitService("")
+
+	// Set test summary data
+	now := time.Now()
+	service.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     5000,
+			Remaining: 4500,
+			Reset:     now.Add(1 * time.Hour).Unix(),
+			UpdatedAt: now,
+		},
+		GraphQL: &APILimit{
+			Name:      "GraphQL",
+			Limit:     5000,
+			Remaining: 4000,
+			Reset:     now.Add(1 * time.Hour).Unix(),
+			UpdatedAt: now,
+		},
+		Search: &APILimit{
+			Name:      "Search",
+			Limit:     30,
+			Remaining: 25,
+			Reset:     now.Add(1 * time.Hour).Unix(),
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
+		Error:     "",
+	}
+
+	summary := service.GetSummary()
+
+	if summary == nil {
+		t.Fatal("GetSummary() returned nil")
+	}
+
+	if summary.Core == nil {
+		t.Error("Core limit is nil")
+	} else if summary.Core.Limit != 5000 {
+		t.Errorf("Core.Limit = %v, want 5000", summary.Core.Limit)
+	}
+
+	if summary.GraphQL == nil {
+		t.Error("GraphQL limit is nil")
+	} else if summary.GraphQL.Remaining != 4000 {
+		t.Errorf("GraphQL.Remaining = %v, want 4000", summary.GraphQL.Remaining)
+	}
+
+	if summary.Search == nil {
+		t.Error("Search limit is nil")
+	} else if summary.Search.Limit != 30 {
+		t.Errorf("Search.Limit = %v, want 30", summary.Search.Limit)
+	}
+
+	// Verify we got a copy, not the original
+	summary.Core.Remaining = 100
+	originalSummary := service.GetSummary()
+	if originalSummary.Core.Remaining != 4500 {
+		t.Error("GetSummary should return a copy, not the original")
+	}
+}
+
+// TestRateLimitService_GetSummary_Nil tests GetSummary when summary is nil
+func TestRateLimitService_GetSummary_Nil(t *testing.T) {
+	service := NewRateLimitService("")
+	service.summary = nil
+
+	summary := service.GetSummary()
+	if summary != nil {
+		t.Error("GetSummary() should return nil when summary is nil")
+	}
+}
+
+// TestHandleRateLimit_WithSummary tests the handler with new summary data
+func TestHandleRateLimit_WithSummary(t *testing.T) {
+	service := NewRateLimitService("")
+	now := time.Now()
+	service.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     5000,
+			Remaining: 4500,
+			Reset:     now.Add(30 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		GraphQL: &APILimit{
+			Name:      "GraphQL",
+			Limit:     5000,
+			Remaining: 4000,
+			Reset:     now.Add(30 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		Search: &APILimit{
+			Name:      "Search",
+			Limit:     30,
+			Remaining: 25,
+			Reset:     now.Add(1 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
+		Error:     "",
+	}
+
+	srv := &Server{
+		tmpls:            make(map[string]*template.Template),
+		wizardStore:      NewWizardSessionStore(),
+		rateLimitService: service,
+	}
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/rate-limit", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleRateLimit(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Should contain compressed format with percentage
+	if !strings.Contains(body, "rate-limit-compressed") {
+		t.Errorf("expected 'rate-limit-compressed' class, got: %s", body)
+	}
+
+	// Should show worst percentage (GraphQL at 20%)
+	if !strings.Contains(body, "20%") && !strings.Contains(body, "10%") {
+		// GraphQL is 20% used, but we might round differently
+		t.Errorf("expected percentage in response, got: %s", body)
+	}
+
+	// Should have tooltip panel
+	if !strings.Contains(body, "rate-limit-tooltip") {
+		t.Errorf("expected 'rate-limit-tooltip' class, got: %s", body)
+	}
+
+	// Should show all three API types
+	if !strings.Contains(body, "REST API") {
+		t.Errorf("expected 'REST API' in response, got: %s", body)
+	}
+	if !strings.Contains(body, "GraphQL") {
+		t.Errorf("expected 'GraphQL' in response, got: %s", body)
+	}
+	if !strings.Contains(body, "Search") {
+		t.Errorf("expected 'Search' in response, got: %s", body)
+	}
+
+	// Should have color coding
+	if !strings.Contains(body, "var(--") {
+		t.Errorf("expected CSS color variable, got: %s", body)
+	}
+}
+
+// TestHandleRateLimit_WithSummaryError tests the handler with summary error but cached data
+func TestHandleRateLimit_WithSummaryError(t *testing.T) {
+	service := NewRateLimitService("")
+	now := time.Now()
+	service.summary = &RateLimitSummary{
+		Core: &APILimit{
+			Name:      "REST API",
+			Limit:     5000,
+			Remaining: 4500,
+			Reset:     now.Add(30 * time.Minute).Unix(),
+			UpdatedAt: now,
+		},
+		UpdatedAt: now,
+		Error:     "API connection failed",
+	}
+
+	srv := &Server{
+		tmpls:            make(map[string]*template.Template),
+		wizardStore:      NewWizardSessionStore(),
+		rateLimitService: service,
+	}
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/rate-limit", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleRateLimit(rec, req)
+
+	body := rec.Body.String()
+	// Should show warning icon when there's an error but cached data
+	if !strings.Contains(body, "⚠") {
+		t.Errorf("expected warning icon for error state, got: %s", body)
 	}
 }

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -40,6 +40,29 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
 .rate-limit-status{font-weight:500}
 .rate-limit-reset{color:var(--muted);font-size:.75rem}
 .rate-limit-unknown{color:var(--muted);font-style:italic}
+
+/* Compressed rate limit indicator with tooltip */
+.rate-limit-compressed{position:relative;display:inline-flex;align-items:center;gap:.5rem;padding:.25rem .5rem;border-radius:4px;background:var(--bg);border:1px solid var(--border);cursor:pointer;transition:opacity .2s;font-size:.85rem}
+.rate-limit-compressed:hover{opacity:.8}
+.rate-limit-compressed:hover .rate-limit-tooltip{display:block}
+.rate-limit-percentage{font-weight:500}
+
+/* Tooltip panel */
+.rate-limit-tooltip{display:none;position:absolute;bottom:100%;right:0;margin-bottom:.5rem;padding:.75rem;background:var(--surface);border:1px solid var(--border);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,.3);min-width:280px;z-index:1000}
+.rate-limit-tooltip-header{font-weight:600;font-size:.9rem;margin-bottom:.5rem;padding-bottom:.5rem;border-bottom:1px solid var(--border);color:var(--text)}
+.rate-limit-tooltip-content{display:flex;flex-direction:column;gap:.5rem}
+.rate-limit-row{display:flex;align-items:center;gap:.5rem;font-size:.8rem}
+.rate-limit-label{min-width:70px;color:var(--muted)}
+.rate-limit-value{font-weight:500;flex:1}
+.rate-limit-reset{color:var(--muted);font-size:.75rem}
+.rate-limit-tooltip-footer{margin-top:.5rem;padding-top:.5rem;border-top:1px solid var(--border);font-size:.75rem;color:var(--muted);font-style:italic}
+
+/* Ensure tooltip stays visible when hovering over it */
+.rate-limit-tooltip:hover{display:block}
+
+/* Arrow for tooltip */
+.rate-limit-tooltip::after{content:'';position:absolute;top:100%;right:1rem;border:6px solid transparent;border-top-color:var(--surface)}
+.rate-limit-tooltip::before{content:'';position:absolute;top:100%;right:calc(1rem - 1px);border:7px solid transparent;border-top-color:var(--border)}
 </style>
 </head>
 <body>


### PR DESCRIPTION
Closes #232

## Description
Replace the current GitHub API usage indicator that only shows REST API (core) limits with a compressed indicator displaying the highest percentage usage across all API types (REST, GraphQL, Search). This addresses the confusion where users see healthy REST API limits while GraphQL limits (used for fetching issues/PRs) may be critically low.

## Tasks
1. Extend `internal/dashboard/ratelimit.go` to add GraphQL rate limit structure and fetching logic from `/rate_limit` endpoint
2. Add Search API limit structure to the same file for complete coverage
3. Modify `internal/dashboard/handlers.go` to calculate percentage usage for each limit type and determine the worst (highest) percentage
4. Update the HTML template in handlers.go to display compressed format: "GitHub API: X% used" with color coding
5. Implement tooltip/panel HTML structure that expands on hover/click showing detailed breakdown
6. Add reset time calculation and display for each limit type in the tooltip
7. Implement color logic: green (<50%), yellow (50-80%), red (>80%)
8. Add CSS styling for the compressed indicator and tooltip panel

## Files to Modify
- `internal/dashboard/ratelimit.go` - Add GraphQL and Search limit structures, extend rate limit fetching to include all API types
- `internal/dashboard/handlers.go` - Update HTML generation to show compressed indicator with worst percentage, add tooltip with detailed breakdown
- `internal/dashboard/static/css/dashboard.css` (or similar) - Add styles for color-coded indicator and tooltip panel

## Acceptance Criteria
- [ ] GraphQL rate limit is fetched from `/rate_limit` endpoint and stored alongside REST limits
- [ ] Dashboard displays compressed indicator showing the highest percentage usage across all API types
- [ ] Indicator color changes based on usage: green (<50%), yellow (50-80%), red (>80%)
- [ ] Clicking/hovering the indicator reveals a panel with detailed breakdown: REST API (core), GraphQL, and Search limits with exact numbers and percentages
- [ ] Each limit in the detailed view shows time remaining until reset