### PR TITLE
[Bug] Missing dashboard UI for LLM configuration settings

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/db"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 	"github.com/crazy-goat/one-dev-army/internal/opencode"
@@ -1770,4 +1771,191 @@ func (s *Server) handleRateLimitRefresh(w http.ResponseWriter, r *http.Request) 
 	}
 	// Return the updated status
 	s.handleRateLimit(w, r)
+}
+
+// handleSettings renders the LLM configuration settings page
+func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
+	// Load current config
+	cfg, err := config.Load(s.rootDir)
+	if err != nil {
+		log.Printf("[Dashboard] Error loading config: %v", err)
+		// Use default config if load fails
+		cfg = &config.Config{LLM: config.DefaultLLMConfig()}
+	}
+
+	data := struct {
+		Active string
+		Config config.LLMConfig
+	}{
+		Active: "settings",
+		Config: cfg.LLM,
+	}
+
+	s.render(w, "llm-config.html", data)
+}
+
+// handleSaveSettings processes the settings form submission
+func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	// Load existing config
+	cfg, err := config.Load(s.rootDir)
+	if err != nil {
+		log.Printf("[Dashboard] Error loading config: %v", err)
+		cfg = &config.Config{LLM: config.DefaultLLMConfig()}
+	}
+
+	// Parse and validate form data
+	validationErrors := s.parseAndValidateSettings(r, cfg)
+	if len(validationErrors) > 0 {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		var html strings.Builder
+		html.WriteString(`<div class="error-message"><strong>Validation Errors:</strong><ul>`)
+		for _, err := range validationErrors {
+			html.WriteString(fmt.Sprintf("<li>%s</li>", err))
+		}
+		html.WriteString("</ul></div>")
+		w.Write([]byte(html.String()))
+		return
+	}
+
+	// Save config
+	if err := config.SaveConfig(s.rootDir, cfg); err != nil {
+		log.Printf("[Dashboard] Error saving config: %v", err)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(fmt.Sprintf(`<div class="error-message">Failed to save configuration: %s</div>`, err.Error())))
+		return
+	}
+
+	// Return success message
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(`<div class="success-message">Configuration saved successfully. Changes will take effect immediately.</div>`))
+}
+
+// parseAndValidateSettings parses form data and validates it
+func (s *Server) parseAndValidateSettings(r *http.Request, cfg *config.Config) []string {
+	var errors []string
+
+	// Helper function to get form value with default
+	getValue := func(key, defaultValue string) string {
+		if val := r.FormValue(key); val != "" {
+			return val
+		}
+		return defaultValue
+	}
+
+	// Parse Development models
+	cfg.LLM.Development.Strong.Provider = getValue("development_strong_provider", cfg.LLM.Development.Strong.Provider)
+	cfg.LLM.Development.Strong.Model = getValue("development_strong_model", cfg.LLM.Development.Strong.Model)
+	cfg.LLM.Development.Strong.APIKey = getValue("development_strong_api_key", cfg.LLM.Development.Strong.APIKey)
+	cfg.LLM.Development.Strong.BaseURL = getValue("development_strong_base_url", cfg.LLM.Development.Strong.BaseURL)
+
+	cfg.LLM.Development.Weak.Provider = getValue("development_weak_provider", cfg.LLM.Development.Weak.Provider)
+	cfg.LLM.Development.Weak.Model = getValue("development_weak_model", cfg.LLM.Development.Weak.Model)
+	cfg.LLM.Development.Weak.APIKey = getValue("development_weak_api_key", cfg.LLM.Development.Weak.APIKey)
+	cfg.LLM.Development.Weak.BaseURL = getValue("development_weak_base_url", cfg.LLM.Development.Weak.BaseURL)
+
+	// Parse Planning models
+	cfg.LLM.Planning.Strong.Provider = getValue("planning_strong_provider", cfg.LLM.Planning.Strong.Provider)
+	cfg.LLM.Planning.Strong.Model = getValue("planning_strong_model", cfg.LLM.Planning.Strong.Model)
+	cfg.LLM.Planning.Strong.APIKey = getValue("planning_strong_api_key", cfg.LLM.Planning.Strong.APIKey)
+	cfg.LLM.Planning.Strong.BaseURL = getValue("planning_strong_base_url", cfg.LLM.Planning.Strong.BaseURL)
+
+	cfg.LLM.Planning.Weak.Provider = getValue("planning_weak_provider", cfg.LLM.Planning.Weak.Provider)
+	cfg.LLM.Planning.Weak.Model = getValue("planning_weak_model", cfg.LLM.Planning.Weak.Model)
+	cfg.LLM.Planning.Weak.APIKey = getValue("planning_weak_api_key", cfg.LLM.Planning.Weak.APIKey)
+	cfg.LLM.Planning.Weak.BaseURL = getValue("planning_weak_base_url", cfg.LLM.Planning.Weak.BaseURL)
+
+	// Parse Orchestration models
+	cfg.LLM.Orchestration.Strong.Provider = getValue("orchestration_strong_provider", cfg.LLM.Orchestration.Strong.Provider)
+	cfg.LLM.Orchestration.Strong.Model = getValue("orchestration_strong_model", cfg.LLM.Orchestration.Strong.Model)
+	cfg.LLM.Orchestration.Strong.APIKey = getValue("orchestration_strong_api_key", cfg.LLM.Orchestration.Strong.APIKey)
+	cfg.LLM.Orchestration.Strong.BaseURL = getValue("orchestration_strong_base_url", cfg.LLM.Orchestration.Strong.BaseURL)
+
+	cfg.LLM.Orchestration.Weak.Provider = getValue("orchestration_weak_provider", cfg.LLM.Orchestration.Weak.Provider)
+	cfg.LLM.Orchestration.Weak.Model = getValue("orchestration_weak_model", cfg.LLM.Orchestration.Weak.Model)
+	cfg.LLM.Orchestration.Weak.APIKey = getValue("orchestration_weak_api_key", cfg.LLM.Orchestration.Weak.APIKey)
+	cfg.LLM.Orchestration.Weak.BaseURL = getValue("orchestration_weak_base_url", cfg.LLM.Orchestration.Weak.BaseURL)
+
+	// Parse Setup models
+	cfg.LLM.Setup.Strong.Provider = getValue("setup_strong_provider", cfg.LLM.Setup.Strong.Provider)
+	cfg.LLM.Setup.Strong.Model = getValue("setup_strong_model", cfg.LLM.Setup.Strong.Model)
+	cfg.LLM.Setup.Strong.APIKey = getValue("setup_strong_api_key", cfg.LLM.Setup.Strong.APIKey)
+	cfg.LLM.Setup.Strong.BaseURL = getValue("setup_strong_base_url", cfg.LLM.Setup.Strong.BaseURL)
+
+	cfg.LLM.Setup.Weak.Provider = getValue("setup_weak_provider", cfg.LLM.Setup.Weak.Provider)
+	cfg.LLM.Setup.Weak.Model = getValue("setup_weak_model", cfg.LLM.Setup.Weak.Model)
+	cfg.LLM.Setup.Weak.APIKey = getValue("setup_weak_api_key", cfg.LLM.Setup.Weak.APIKey)
+	cfg.LLM.Setup.Weak.BaseURL = getValue("setup_weak_base_url", cfg.LLM.Setup.Weak.BaseURL)
+
+	// Validate required fields
+	categories := []struct {
+		name   string
+		strong config.ModelConfig
+		weak   config.ModelConfig
+	}{
+		{"Development", cfg.LLM.Development.Strong, cfg.LLM.Development.Weak},
+		{"Planning", cfg.LLM.Planning.Strong, cfg.LLM.Planning.Weak},
+		{"Orchestration", cfg.LLM.Orchestration.Strong, cfg.LLM.Orchestration.Weak},
+		{"Setup", cfg.LLM.Setup.Strong, cfg.LLM.Setup.Weak},
+	}
+
+	for _, cat := range categories {
+		if cat.strong.Provider == "" {
+			errors = append(errors, fmt.Sprintf("%s Strong Provider is required", cat.name))
+		}
+		if cat.strong.Model == "" {
+			errors = append(errors, fmt.Sprintf("%s Strong Model is required", cat.name))
+		}
+		if cat.weak.Provider == "" {
+			errors = append(errors, fmt.Sprintf("%s Weak Provider is required", cat.name))
+		}
+		if cat.weak.Model == "" {
+			errors = append(errors, fmt.Sprintf("%s Weak Model is required", cat.name))
+		}
+	}
+
+	// Parse routing thresholds
+	if val := r.FormValue("routing_code_size_threshold"); val != "" {
+		if threshold, err := strconv.Atoi(val); err != nil || threshold < 1 {
+			errors = append(errors, "Code Size Threshold must be a positive integer")
+		} else {
+			cfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold = threshold
+		}
+	}
+
+	if val := r.FormValue("routing_high_complexity_threshold"); val != "" {
+		if threshold, err := strconv.Atoi(val); err != nil || threshold < 1 {
+			errors = append(errors, "High Complexity Threshold must be a positive integer")
+		} else {
+			cfg.LLM.RoutingRules.ComplexityThresholds.HighComplexityThreshold = threshold
+		}
+	}
+
+	if val := r.FormValue("routing_file_count_threshold"); val != "" {
+		if threshold, err := strconv.Atoi(val); err != nil || threshold < 1 {
+			errors = append(errors, "File Count Threshold must be a positive integer")
+		} else {
+			cfg.LLM.RoutingRules.ComplexityThresholds.FileCountThreshold = threshold
+		}
+	}
+
+	// Parse force strong stages
+	if val := r.FormValue("routing_force_strong_stages"); val != "" {
+		stages := strings.Split(val, ",")
+		cfg.LLM.RoutingRules.ForceStrongForStages = make([]string, 0, len(stages))
+		for _, stage := range stages {
+			stage = strings.TrimSpace(stage)
+			if stage != "" {
+				cfg.LLM.RoutingRules.ForceStrongForStages = append(cfg.LLM.RoutingRules.ForceStrongForStages, stage)
+			}
+		}
+	}
+
+	return errors
 }

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -38,6 +38,9 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 			}
 			return s[:n] + "\n... (truncated)"
 		},
+		"join": func(arr []string, sep string) string {
+			return strings.Join(arr, sep)
+		},
 	}
 
 	pages := []string{"board.html", "task.html"}
@@ -86,6 +89,16 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 		}
 		tmpls[page] = t
 	}
+
+	// Parse settings template
+	settingsTmpl, err := template.New("").Funcs(funcMap).ParseFiles(
+		filepath.Join(templateDir, "layout.html"),
+		filepath.Join(templateDir, "llm-config.html"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parsing llm-config.html: %w", err)
+	}
+	tmpls["llm-config.html"] = settingsTmpl
 
 	return tmpls, nil
 }
@@ -3479,5 +3492,523 @@ func TestHandleWizardCreateSingle_SyncFailureDoesNotBlockCreation(t *testing.T) 
 	_, ok := srv.wizardStore.Get(session.ID)
 	if ok {
 		t.Error("session should be deleted after single issue creation (creation should succeed even if sync fails)")
+	}
+}
+
+// TestHandleSettings tests the GET /settings handler
+func TestHandleSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal config file
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `llm:
+  development:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider-weak
+      model: test-model-weak
+  planning:
+    strong:
+      provider: planning-provider
+      model: planning-model
+    weak:
+      provider: planning-provider-weak
+      model: planning-model-weak
+  orchestration:
+    strong:
+      provider: orch-provider
+      model: orch-model
+    weak:
+      provider: orch-provider-weak
+      model: orch-model-weak
+  setup:
+    strong:
+      provider: setup-provider
+      model: setup-model
+    weak:
+      provider: setup-provider-weak
+      model: setup-model-weak
+  routing_rules:
+    complexity_thresholds:
+      code_size_threshold: 150
+      high_complexity_threshold: 600
+      file_count_threshold: 10
+    force_strong_for_stages:
+      - plan-review
+      - code-review
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify the page contains expected content
+	if !strings.Contains(body, "LLM Configuration") {
+		t.Error("settings page missing title")
+	}
+
+	// Verify form fields are populated with config values
+	if !strings.Contains(body, "test-provider") {
+		t.Error("settings page missing development strong provider")
+	}
+	if !strings.Contains(body, "test-model") {
+		t.Error("settings page missing development strong model")
+	}
+	if !strings.Contains(body, "planning-provider") {
+		t.Error("settings page missing planning strong provider")
+	}
+	if !strings.Contains(body, "150") {
+		t.Error("settings page missing code size threshold")
+	}
+}
+
+// TestHandleSettings_NoConfig tests the settings handler when no config exists
+func TestHandleSettings_NoConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleSettings(rec, req)
+
+	// Should still return 200 with default config
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "LLM Configuration") {
+		t.Error("settings page missing title")
+	}
+}
+
+// TestHandleSaveSettings tests the POST /settings handler
+func TestHandleSaveSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal config file
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `llm:
+  development:
+    strong:
+      provider: old-provider
+      model: old-model
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Prepare form data
+	formData := url.Values{}
+	formData.Set("development_strong_provider", "new-provider")
+	formData.Set("development_strong_model", "new-model")
+	formData.Set("development_strong_api_key", "new-api-key")
+	formData.Set("development_strong_base_url", "https://new-api.example.com")
+	formData.Set("development_weak_provider", "weak-provider")
+	formData.Set("development_weak_model", "weak-model")
+	formData.Set("planning_strong_provider", "planning-provider")
+	formData.Set("planning_strong_model", "planning-model")
+	formData.Set("orchestration_strong_provider", "orch-provider")
+	formData.Set("orchestration_strong_model", "orch-model")
+	formData.Set("setup_strong_provider", "setup-provider")
+	formData.Set("setup_strong_model", "setup-model")
+	formData.Set("routing_code_size_threshold", "200")
+	formData.Set("routing_high_complexity_threshold", "700")
+	formData.Set("routing_file_count_threshold", "15")
+	formData.Set("routing_force_strong_stages", "plan-review, code-review, merge")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "saved successfully") {
+		t.Errorf("expected success message, got: %s", body)
+	}
+
+	// Verify config was saved
+	savedConfig, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading saved config: %v", err)
+	}
+
+	savedContent := string(savedConfig)
+	if !strings.Contains(savedContent, "new-provider") {
+		t.Error("saved config missing new provider")
+	}
+	if !strings.Contains(savedContent, "new-model") {
+		t.Error("saved config missing new model")
+	}
+	if !strings.Contains(savedContent, "200") {
+		t.Error("saved config missing updated threshold")
+	}
+}
+
+// TestHandleSaveSettingsValidation tests form validation
+func TestHandleSaveSettingsValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal config file
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `llm:
+  development:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model
+  planning:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model
+  orchestration:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model
+  setup:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	tests := []struct {
+		name      string
+		formData  url.Values
+		wantError string
+	}{
+		{
+			name: "negative code size threshold",
+			formData: url.Values{
+				"development_strong_provider":   {"test"},
+				"development_strong_model":      {"test"},
+				"development_weak_provider":     {"test"},
+				"development_weak_model":        {"test"},
+				"planning_strong_provider":      {"test"},
+				"planning_strong_model":         {"test"},
+				"planning_weak_provider":        {"test"},
+				"planning_weak_model":           {"test"},
+				"orchestration_strong_provider": {"test"},
+				"orchestration_strong_model":    {"test"},
+				"orchestration_weak_provider":   {"test"},
+				"orchestration_weak_model":      {"test"},
+				"setup_strong_provider":         {"test"},
+				"setup_strong_model":            {"test"},
+				"setup_weak_provider":           {"test"},
+				"setup_weak_model":              {"test"},
+				"routing_code_size_threshold":   {"-1"},
+			},
+			wantError: "positive integer",
+		},
+		{
+			name: "zero file count threshold",
+			formData: url.Values{
+				"development_strong_provider":   {"test"},
+				"development_strong_model":      {"test"},
+				"development_weak_provider":     {"test"},
+				"development_weak_model":        {"test"},
+				"planning_strong_provider":      {"test"},
+				"planning_strong_model":         {"test"},
+				"planning_weak_provider":        {"test"},
+				"planning_weak_model":           {"test"},
+				"orchestration_strong_provider": {"test"},
+				"orchestration_strong_model":    {"test"},
+				"orchestration_weak_provider":   {"test"},
+				"orchestration_weak_model":      {"test"},
+				"setup_strong_provider":         {"test"},
+				"setup_strong_model":            {"test"},
+				"setup_weak_provider":           {"test"},
+				"setup_weak_model":              {"test"},
+				"routing_file_count_threshold":  {"0"},
+			},
+			wantError: "positive integer",
+		},
+		{
+			name: "invalid threshold value",
+			formData: url.Values{
+				"development_strong_provider":       {"test"},
+				"development_strong_model":          {"test"},
+				"development_weak_provider":         {"test"},
+				"development_weak_model":            {"test"},
+				"planning_strong_provider":          {"test"},
+				"planning_strong_model":             {"test"},
+				"planning_weak_provider":            {"test"},
+				"planning_weak_model":               {"test"},
+				"orchestration_strong_provider":     {"test"},
+				"orchestration_strong_model":        {"test"},
+				"orchestration_weak_provider":       {"test"},
+				"orchestration_weak_model":          {"test"},
+				"setup_strong_provider":             {"test"},
+				"setup_strong_model":                {"test"},
+				"setup_weak_provider":               {"test"},
+				"setup_weak_model":                  {"test"},
+				"routing_high_complexity_threshold": {"abc"},
+			},
+			wantError: "positive integer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(tt.formData.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec := httptest.NewRecorder()
+
+			srv.handleSaveSettings(rec, req)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("expected status 400, got %d", rec.Code)
+			}
+
+			body := rec.Body.String()
+			if !strings.Contains(strings.ToLower(body), strings.ToLower(tt.wantError)) {
+				t.Errorf("expected error containing %q, got: %s", tt.wantError, body)
+			}
+		})
+	}
+}
+
+// TestSettingsPersistence verifies that saved config reloads correctly
+func TestSettingsPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal config file
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `llm:
+  development:
+    strong:
+      provider: original-provider
+      model: original-model
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Save new settings
+	formData := url.Values{}
+	formData.Set("development_strong_provider", "persisted-provider")
+	formData.Set("development_strong_model", "persisted-model")
+	formData.Set("development_weak_provider", "weak-provider")
+	formData.Set("development_weak_model", "weak-model")
+	formData.Set("planning_strong_provider", "planning-provider")
+	formData.Set("planning_strong_model", "planning-model")
+	formData.Set("planning_weak_provider", "planning-weak")
+	formData.Set("planning_weak_model", "planning-weak-model")
+	formData.Set("orchestration_strong_provider", "orch-provider")
+	formData.Set("orchestration_strong_model", "orch-model")
+	formData.Set("orchestration_weak_provider", "orch-weak")
+	formData.Set("orchestration_weak_model", "orch-weak-model")
+	formData.Set("setup_strong_provider", "setup-provider")
+	formData.Set("setup_strong_model", "setup-model")
+	formData.Set("setup_weak_provider", "setup-weak")
+	formData.Set("setup_weak_model", "setup-weak-model")
+	formData.Set("routing_code_size_threshold", "250")
+	formData.Set("routing_high_complexity_threshold", "800")
+	formData.Set("routing_file_count_threshold", "20")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	srv.handleSaveSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("save failed: expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Now load the settings page again to verify persistence
+	req = httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec = httptest.NewRecorder()
+	srv.handleSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reload failed: expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify persisted values are displayed
+	if !strings.Contains(body, "persisted-provider") {
+		t.Error("reloaded settings missing persisted provider")
+	}
+	if !strings.Contains(body, "persisted-model") {
+		t.Error("reloaded settings missing persisted model")
+	}
+	if !strings.Contains(body, "250") {
+		t.Error("reloaded settings missing persisted threshold")
+	}
+}
+
+// TestSettingsNavigationLink tests that the settings link appears in the navigation
+func TestSettingsNavigationLink(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleBoard(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	// Verify settings link is present
+	if !strings.Contains(body, `href="/settings"`) {
+		t.Error("navigation missing settings link")
+	}
+	if !strings.Contains(body, "Settings") {
+		t.Error("navigation missing Settings text")
+	}
+}
+
+// TestHandleSaveSettings_MissingRequiredFields tests validation of required fields
+func TestHandleSaveSettings_MissingRequiredFields(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a minimal config file
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("creating config dir: %v", err)
+	}
+
+	configContent := `llm:
+  development:
+    strong:
+      provider: test
+      model: test
+    weak:
+      provider: test
+      model: test
+  planning:
+    strong:
+      provider: test
+      model: test
+    weak:
+      provider: test
+      model: test
+  orchestration:
+    strong:
+      provider: test
+      model: test
+    weak:
+      provider: test
+      model: test
+  setup:
+    strong:
+      provider: test
+      model: test
+    weak:
+      provider: test
+      model: test
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("writing config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Test with empty provider (should use existing value from config)
+	formData := url.Values{}
+	formData.Set("development_strong_provider", "") // Empty - should use existing
+	formData.Set("development_strong_model", "new-model")
+	formData.Set("development_weak_provider", "weak")
+	formData.Set("development_weak_model", "weak-model")
+	formData.Set("planning_strong_provider", "planning")
+	formData.Set("planning_strong_model", "planning-model")
+	formData.Set("planning_weak_provider", "planning-weak")
+	formData.Set("planning_weak_model", "planning-weak-model")
+	formData.Set("orchestration_strong_provider", "orch")
+	formData.Set("orchestration_strong_model", "orch-model")
+	formData.Set("orchestration_weak_provider", "orch-weak")
+	formData.Set("orchestration_weak_model", "orch-weak-model")
+	formData.Set("setup_strong_provider", "setup")
+	formData.Set("setup_strong_model", "setup-model")
+	formData.Set("setup_weak_provider", "setup-weak")
+	formData.Set("setup_weak_model", "setup-weak-model")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should succeed because empty values fall back to existing config
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200 (empty values use existing), got %d: %s", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/db"
@@ -33,9 +34,10 @@ type Server struct {
 	hub              *Hub
 	syncService      *SyncService
 	rateLimitService *RateLimitService
+	rootDir          string
 }
 
-func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService) (*Server, error) {
+func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService, rootDir string) (*Server, error) {
 	tmpls, err := parseTemplates()
 	if err != nil {
 		return nil, err
@@ -60,6 +62,7 @@ func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *g
 		wizardLLM:   wizardLLM,
 		hub:         hub,
 		syncService: syncService,
+		rootDir:     rootDir,
 	}
 	if s.wizardLLM == "" {
 		s.wizardLLM = DefaultLLMModel
@@ -94,6 +97,9 @@ func parseTemplates() (map[string]*template.Template, error) {
 			}
 			return s[:n] + "\n... (truncated)"
 		},
+		"join": func(arr []string, sep string) string {
+			return strings.Join(arr, sep)
+		},
 	}
 
 	pages := []string{"board.html", "task.html"}
@@ -126,6 +132,13 @@ func parseTemplates() (map[string]*template.Template, error) {
 		}
 		tmpls[page] = t
 	}
+
+	// Parse settings template
+	settingsTmpl, err := template.New("").Funcs(funcMap).ParseFS(templateFS, "templates/layout.html", "templates/llm-config.html")
+	if err != nil {
+		return nil, fmt.Errorf("parsing llm-config.html: %w", err)
+	}
+	tmpls["llm-config.html"] = settingsTmpl
 
 	return tmpls, nil
 }
@@ -171,6 +184,10 @@ func (s *Server) routes() {
 	// Rate limit endpoints
 	s.mux.HandleFunc("GET /api/rate-limit", s.handleRateLimit)
 	s.mux.HandleFunc("POST /api/rate-limit/refresh", s.handleRateLimitRefresh)
+
+	// Settings routes
+	s.mux.HandleFunc("GET /settings", s.handleSettings)
+	s.mux.HandleFunc("POST /settings", s.handleSaveSettings)
 }
 
 func (s *Server) Start() error {

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -70,6 +70,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
   <span class="logo">ODA</span>
   <div class="links">
     <a href="/" {{if eq .Active "board"}}class="active"{{end}}>Sprint Board</a>
+    <a href="/settings" {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
   </div>
   <div class="nav-actions">
     <a href="/wizard" class="btn btn-primary">+ New Issue</a>

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -1,0 +1,359 @@
+{{define "content"}}
+<div class="settings-container">
+  <h1>LLM Configuration</h1>
+  
+  <form id="llm-config-form" hx-post="/settings" hx-target="#settings-result" hx-swap="innerHTML">
+    
+    <!-- Development Category -->
+    <div class="category-section">
+      <h2>Development</h2>
+      <div class="model-pair">
+        <div class="model-config">
+          <h3>Strong Model</h3>
+          <div class="form-group">
+            <label for="development_strong_provider">Provider</label>
+            <input type="text" id="development_strong_provider" name="development_strong_provider" value="{{.Config.Development.Strong.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="development_strong_model">Model</label>
+            <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="development_strong_api_key">API Key (optional)</label>
+            <input type="password" id="development_strong_api_key" name="development_strong_api_key" value="{{.Config.Development.Strong.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="development_strong_base_url">Base URL (optional)</label>
+            <input type="url" id="development_strong_base_url" name="development_strong_base_url" value="{{.Config.Development.Strong.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+        
+        <div class="model-config">
+          <h3>Weak Model</h3>
+          <div class="form-group">
+            <label for="development_weak_provider">Provider</label>
+            <input type="text" id="development_weak_provider" name="development_weak_provider" value="{{.Config.Development.Weak.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="development_weak_model">Model</label>
+            <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="development_weak_api_key">API Key (optional)</label>
+            <input type="password" id="development_weak_api_key" name="development_weak_api_key" value="{{.Config.Development.Weak.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="development_weak_base_url">Base URL (optional)</label>
+            <input type="url" id="development_weak_base_url" name="development_weak_base_url" value="{{.Config.Development.Weak.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Planning Category -->
+    <div class="category-section">
+      <h2>Planning</h2>
+      <div class="model-pair">
+        <div class="model-config">
+          <h3>Strong Model</h3>
+          <div class="form-group">
+            <label for="planning_strong_provider">Provider</label>
+            <input type="text" id="planning_strong_provider" name="planning_strong_provider" value="{{.Config.Planning.Strong.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="planning_strong_model">Model</label>
+            <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="planning_strong_api_key">API Key (optional)</label>
+            <input type="password" id="planning_strong_api_key" name="planning_strong_api_key" value="{{.Config.Planning.Strong.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="planning_strong_base_url">Base URL (optional)</label>
+            <input type="url" id="planning_strong_base_url" name="planning_strong_base_url" value="{{.Config.Planning.Strong.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+        
+        <div class="model-config">
+          <h3>Weak Model</h3>
+          <div class="form-group">
+            <label for="planning_weak_provider">Provider</label>
+            <input type="text" id="planning_weak_provider" name="planning_weak_provider" value="{{.Config.Planning.Weak.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="planning_weak_model">Model</label>
+            <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="planning_weak_api_key">API Key (optional)</label>
+            <input type="password" id="planning_weak_api_key" name="planning_weak_api_key" value="{{.Config.Planning.Weak.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="planning_weak_base_url">Base URL (optional)</label>
+            <input type="url" id="planning_weak_base_url" name="planning_weak_base_url" value="{{.Config.Planning.Weak.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Orchestration Category -->
+    <div class="category-section">
+      <h2>Orchestration</h2>
+      <div class="model-pair">
+        <div class="model-config">
+          <h3>Strong Model</h3>
+          <div class="form-group">
+            <label for="orchestration_strong_provider">Provider</label>
+            <input type="text" id="orchestration_strong_provider" name="orchestration_strong_provider" value="{{.Config.Orchestration.Strong.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="orchestration_strong_model">Model</label>
+            <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="orchestration_strong_api_key">API Key (optional)</label>
+            <input type="password" id="orchestration_strong_api_key" name="orchestration_strong_api_key" value="{{.Config.Orchestration.Strong.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="orchestration_strong_base_url">Base URL (optional)</label>
+            <input type="url" id="orchestration_strong_base_url" name="orchestration_strong_base_url" value="{{.Config.Orchestration.Strong.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+        
+        <div class="model-config">
+          <h3>Weak Model</h3>
+          <div class="form-group">
+            <label for="orchestration_weak_provider">Provider</label>
+            <input type="text" id="orchestration_weak_provider" name="orchestration_weak_provider" value="{{.Config.Orchestration.Weak.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="orchestration_weak_model">Model</label>
+            <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="orchestration_weak_api_key">API Key (optional)</label>
+            <input type="password" id="orchestration_weak_api_key" name="orchestration_weak_api_key" value="{{.Config.Orchestration.Weak.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="orchestration_weak_base_url">Base URL (optional)</label>
+            <input type="url" id="orchestration_weak_base_url" name="orchestration_weak_base_url" value="{{.Config.Orchestration.Weak.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Setup Category -->
+    <div class="category-section">
+      <h2>Setup</h2>
+      <div class="model-pair">
+        <div class="model-config">
+          <h3>Strong Model</h3>
+          <div class="form-group">
+            <label for="setup_strong_provider">Provider</label>
+            <input type="text" id="setup_strong_provider" name="setup_strong_provider" value="{{.Config.Setup.Strong.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="setup_strong_model">Model</label>
+            <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="setup_strong_api_key">API Key (optional)</label>
+            <input type="password" id="setup_strong_api_key" name="setup_strong_api_key" value="{{.Config.Setup.Strong.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="setup_strong_base_url">Base URL (optional)</label>
+            <input type="url" id="setup_strong_base_url" name="setup_strong_base_url" value="{{.Config.Setup.Strong.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+        
+        <div class="model-config">
+          <h3>Weak Model</h3>
+          <div class="form-group">
+            <label for="setup_weak_provider">Provider</label>
+            <input type="text" id="setup_weak_provider" name="setup_weak_provider" value="{{.Config.Setup.Weak.Provider}}" required>
+          </div>
+          <div class="form-group">
+            <label for="setup_weak_model">Model</label>
+            <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required>
+          </div>
+          <div class="form-group">
+            <label for="setup_weak_api_key">API Key (optional)</label>
+            <input type="password" id="setup_weak_api_key" name="setup_weak_api_key" value="{{.Config.Setup.Weak.APIKey}}" placeholder="Uses env var if empty">
+          </div>
+          <div class="form-group">
+            <label for="setup_weak_base_url">Base URL (optional)</label>
+            <input type="url" id="setup_weak_base_url" name="setup_weak_base_url" value="{{.Config.Setup.Weak.BaseURL}}" placeholder="https://api.example.com">
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Routing Rules -->
+    <div class="category-section">
+      <h2>Routing Rules</h2>
+      <div class="routing-config">
+        <h3>Complexity Thresholds</h3>
+        <div class="form-group">
+          <label for="routing_code_size_threshold">Code Size Threshold (lines)</label>
+          <input type="number" id="routing_code_size_threshold" name="routing_code_size_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.CodeSizeThreshold}}" min="1" required>
+          <small>Number of lines that triggers medium complexity</small>
+        </div>
+        <div class="form-group">
+          <label for="routing_high_complexity_threshold">High Complexity Threshold (lines)</label>
+          <input type="number" id="routing_high_complexity_threshold" name="routing_high_complexity_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.HighComplexityThreshold}}" min="1" required>
+          <small>Number of lines that triggers high complexity</small>
+        </div>
+        <div class="form-group">
+          <label for="routing_file_count_threshold">File Count Threshold</label>
+          <input type="number" id="routing_file_count_threshold" name="routing_file_count_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.FileCountThreshold}}" min="1" required>
+          <small>Number of files that triggers higher complexity</small>
+        </div>
+        
+        <h3>Force Strong Model For Stages</h3>
+        <div class="form-group">
+          <label for="routing_force_strong_stages">Stages (comma-separated)</label>
+          <input type="text" id="routing_force_strong_stages" name="routing_force_strong_stages" value="{{join .Config.RoutingRules.ForceStrongForStages ", "}}" placeholder="plan-review, code-review, merge">
+          <small>Pipeline stages that always use strong models</small>
+        </div>
+      </div>
+    </div>
+    
+    <div class="form-actions">
+      <button type="submit" class="btn btn-primary">Save Configuration</button>
+      <a href="/" class="btn">Cancel</a>
+    </div>
+    
+    <div id="settings-result"></div>
+  </form>
+</div>
+
+<style>
+.settings-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.category-section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.category-section h2 {
+  color: var(--text);
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.model-pair {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.model-config {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.model-config h3 {
+  color: var(--accent);
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.form-group small {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.routing-config {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.routing-config h3 {
+  color: var(--accent);
+  font-size: 0.95rem;
+  margin: 1.5rem 0 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.routing-config h3:first-child {
+  margin-top: 0;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+#settings-result {
+  margin-top: 1rem;
+}
+
+.success-message {
+  background: rgba(63, 185, 80, 0.1);
+  border: 1px solid var(--green);
+  color: var(--green);
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.error-message {
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid var(--red);
+  color: var(--red);
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+@media (max-width: 768px) {
+  .model-pair {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+}
+</style>
+{{end}}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -578,7 +578,7 @@ func TestDashboardRendering(t *testing.T) {
 		}
 	}
 
-	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil)
+	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil, t.TempDir())
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestDashboard_WizardFlow_Integration(t *testing.T) {
 		return []worker.WorkerInfo{}
 	}
 
-	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil)
+	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil, t.TempDir())
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -279,7 +279,7 @@ func runServe() error {
 		}
 	}()
 
-	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers, gh, orchestrator, oc, cfg.Planning.LLM, hub, syncService)
+	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers, gh, orchestrator, oc, cfg.Planning.LLM, hub, syncService, dir)
 	if err != nil {
 		return fmt.Errorf("creating dashboard server: %w", err)
 	}


### PR DESCRIPTION
Closes #241

## Description
The LLM configuration system was implemented in PR #220 but the dashboard UI components are missing. Users cannot view or modify LLM settings through the web interface, making the configuration system inaccessible.

## Tasks
1. Create settings page template at `dashboard/templates/llm-config.html` with forms for 4 configuration categories
2. Add GET /settings route in `dashboard/router.go`
3. Implement `handleSaveSettings` handler in `dashboard/handlers.go` for configuration updates
4. Add settings icon to `dashboard/templates/header.html` linking to /settings
5. Wire up settings route registration in main dashboard initialization

## Files to Modify
- `dashboard/templates/llm-config.html` - Create new settings page template with configuration forms
- `dashboard/router.go` - Add GET /settings route handler
- `dashboard/handlers.go` - Add handleSaveSettings handler for POST requests
- `dashboard/templates/header.html` - Add settings icon navigation link

## Acceptance Criteria
1. Settings page accessible at /settings URL and displays current configuration
2. Settings icon visible in dashboard header and navigates to settings page
3. Users can view and modify LLM configuration for all 4 categories
4. Configuration changes save successfully and persist after page reload
5. Form validation prevents invalid configuration values