### PR TITLE
[Bug] Missing dashboard UI for LLM configuration settings

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/db"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 	"github.com/crazy-goat/one-dev-army/internal/opencode"
@@ -1770,4 +1771,177 @@ func (s *Server) handleRateLimitRefresh(w http.ResponseWriter, r *http.Request) 
 	}
 	// Return the updated status
 	s.handleRateLimit(w, r)
+}
+
+// handleSettings displays the LLM configuration settings page
+func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
+	// Load current config
+	cfg, err := config.Load(s.rootDir)
+	if err != nil {
+		log.Printf("[Dashboard] Error loading config: %v", err)
+		// Use default config if load fails
+		cfg = &config.Config{LLM: config.DefaultLLMConfig()}
+	}
+
+	// Build force strong stages string
+	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ")
+
+	data := struct {
+		Active            string
+		Config            config.LLMConfig
+		ForceStrongStages string
+		SuccessMessage    string
+		ErrorMessage      string
+	}{
+		Active:            "settings",
+		Config:            cfg.LLM,
+		ForceStrongStages: forceStrongStages,
+	}
+
+	s.render(w, "llm-config.html", data)
+}
+
+// handleSaveSettings processes the settings form submission
+func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	// Load existing config
+	cfg, err := config.Load(s.rootDir)
+	if err != nil {
+		log.Printf("[Dashboard] Error loading config: %v", err)
+		cfg = &config.Config{LLM: config.DefaultLLMConfig()}
+	}
+
+	// Parse form data for all categories
+	categories := []struct {
+		name   string
+		strong *config.ModelConfig
+		weak   *config.ModelConfig
+	}{
+		{"development", &cfg.LLM.Development.Strong, &cfg.LLM.Development.Weak},
+		{"planning", &cfg.LLM.Planning.Strong, &cfg.LLM.Planning.Weak},
+		{"orchestration", &cfg.LLM.Orchestration.Strong, &cfg.LLM.Orchestration.Weak},
+		{"setup", &cfg.LLM.Setup.Strong, &cfg.LLM.Setup.Weak},
+	}
+
+	var validationErrors []string
+
+	for _, cat := range categories {
+		// Parse strong model
+		cat.strong.Provider = r.FormValue(cat.name + "_strong_provider")
+		cat.strong.Model = r.FormValue(cat.name + "_strong_model")
+		cat.strong.APIKey = r.FormValue(cat.name + "_strong_api_key")
+		cat.strong.BaseURL = r.FormValue(cat.name + "_strong_base_url")
+
+		// Parse weak model
+		cat.weak.Provider = r.FormValue(cat.name + "_weak_provider")
+		cat.weak.Model = r.FormValue(cat.name + "_weak_model")
+		cat.weak.APIKey = r.FormValue(cat.name + "_weak_api_key")
+		cat.weak.BaseURL = r.FormValue(cat.name + "_weak_base_url")
+
+		// Validate
+		if cat.strong.Provider == "" || cat.strong.Model == "" {
+			validationErrors = append(validationErrors, cat.name+" strong model: provider and model are required")
+		}
+		if cat.weak.Provider == "" || cat.weak.Model == "" {
+			validationErrors = append(validationErrors, cat.name+" weak model: provider and model are required")
+		}
+	}
+
+	// Parse routing rules
+	codeSizeThreshold, err := strconv.Atoi(r.FormValue("routing_code_size_threshold"))
+	if err != nil || codeSizeThreshold < 1 {
+		validationErrors = append(validationErrors, "code size threshold must be a positive integer")
+	} else {
+		cfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold = codeSizeThreshold
+	}
+
+	highComplexityThreshold, err := strconv.Atoi(r.FormValue("routing_high_complexity_threshold"))
+	if err != nil || highComplexityThreshold < 1 {
+		validationErrors = append(validationErrors, "high complexity threshold must be a positive integer")
+	} else {
+		cfg.LLM.RoutingRules.ComplexityThresholds.HighComplexityThreshold = highComplexityThreshold
+	}
+
+	fileCountThreshold, err := strconv.Atoi(r.FormValue("routing_file_count_threshold"))
+	if err != nil || fileCountThreshold < 1 {
+		validationErrors = append(validationErrors, "file count threshold must be a positive integer")
+	} else {
+		cfg.LLM.RoutingRules.ComplexityThresholds.FileCountThreshold = fileCountThreshold
+	}
+
+	// Parse force strong stages
+	forceStrongStagesStr := r.FormValue("routing_force_strong_stages")
+	if forceStrongStagesStr != "" {
+		stages := strings.Split(forceStrongStagesStr, ",")
+		cfg.LLM.RoutingRules.ForceStrongForStages = make([]string, 0, len(stages))
+		for _, stage := range stages {
+			stage = strings.TrimSpace(stage)
+			if stage != "" {
+				cfg.LLM.RoutingRules.ForceStrongForStages = append(cfg.LLM.RoutingRules.ForceStrongForStages, stage)
+			}
+		}
+	} else {
+		cfg.LLM.RoutingRules.ForceStrongForStages = []string{}
+	}
+
+	// If validation errors, re-render form with errors
+	if len(validationErrors) > 0 {
+		forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ")
+		data := struct {
+			Active            string
+			Config            config.LLMConfig
+			ForceStrongStages string
+			SuccessMessage    string
+			ErrorMessage      string
+		}{
+			Active:            "settings",
+			Config:            cfg.LLM,
+			ForceStrongStages: forceStrongStages,
+			ErrorMessage:      strings.Join(validationErrors, "; "),
+		}
+		s.render(w, "llm-config.html", data)
+		return
+	}
+
+	// Save config
+	if err := config.SaveConfig(s.rootDir, cfg); err != nil {
+		log.Printf("[Dashboard] Error saving config: %v", err)
+		forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ")
+		data := struct {
+			Active            string
+			Config            config.LLMConfig
+			ForceStrongStages string
+			SuccessMessage    string
+			ErrorMessage      string
+		}{
+			Active:            "settings",
+			Config:            cfg.LLM,
+			ForceStrongStages: forceStrongStages,
+			ErrorMessage:      "Failed to save configuration: " + err.Error(),
+		}
+		s.render(w, "llm-config.html", data)
+		return
+	}
+
+	log.Printf("[Dashboard] LLM configuration saved successfully")
+
+	// Re-render with success message
+	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ")
+	data := struct {
+		Active            string
+		Config            config.LLMConfig
+		ForceStrongStages string
+		SuccessMessage    string
+		ErrorMessage      string
+	}{
+		Active:            "settings",
+		Config:            cfg.LLM,
+		ForceStrongStages: forceStrongStages,
+		SuccessMessage:    "Configuration saved successfully. Changes will take effect immediately.",
+	}
+	s.render(w, "llm-config.html", data)
 }

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
 
@@ -86,6 +87,16 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 		}
 		tmpls[page] = t
 	}
+
+	// Parse settings template
+	settingsTmpl, err := template.New("").Funcs(funcMap).ParseFiles(
+		filepath.Join(templateDir, "layout.html"),
+		filepath.Join(templateDir, "llm-config.html"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("parsing llm-config.html: %w", err)
+	}
+	tmpls["llm-config.html"] = settingsTmpl
 
 	return tmpls, nil
 }
@@ -3479,5 +3490,452 @@ func TestHandleWizardCreateSingle_SyncFailureDoesNotBlockCreation(t *testing.T) 
 	_, ok := srv.wizardStore.Get(session.ID)
 	if ok {
 		t.Error("session should be deleted after single issue creation (creation should succeed even if sync fails)")
+	}
+}
+
+// TestHandleSettings tests the GET /settings handler
+func TestHandleSettings(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	// Create a minimal config file
+	configContent := `github:
+  repo: test/repo
+llm:
+  development:
+    strong:
+      provider: nexos-ai
+      model: Kimi K2.5
+    weak:
+      provider: nexos-ai
+      model: Kimi K2.5
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleSettings(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify content type is HTML
+	contentType := rec.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/html") {
+		t.Errorf("expected Content-Type to contain 'text/html', got %s", contentType)
+	}
+
+	// Verify the page contains expected content
+	body := rec.Body.String()
+	if !strings.Contains(body, "LLM Configuration Settings") {
+		t.Error("settings page missing title")
+	}
+	if !strings.Contains(body, "Development") {
+		t.Error("settings page missing Development section")
+	}
+	if !strings.Contains(body, "Planning") {
+		t.Error("settings page missing Planning section")
+	}
+	if !strings.Contains(body, "Orchestration") {
+		t.Error("settings page missing Orchestration section")
+	}
+	if !strings.Contains(body, "Setup") {
+		t.Error("settings page missing Setup section")
+	}
+	if !strings.Contains(body, "Routing Rules") {
+		t.Error("settings page missing Routing Rules section")
+	}
+}
+
+// TestHandleSettings_NoConfig tests the settings handler when no config exists
+func TestHandleSettings_NoConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleSettings(rec, req)
+
+	// Should still return 200 OK with default config
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleSaveSettings tests the POST /settings handler
+func TestHandleSaveSettings(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	// Create initial config file
+	configContent := `github:
+  repo: test/repo
+llm:
+  development:
+    strong:
+      provider: nexos-ai
+      model: Kimi K2.5
+    weak:
+      provider: nexos-ai
+      model: Kimi K2.5
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Prepare form data
+	form := url.Values{}
+	form.Set("development_strong_provider", "openai")
+	form.Set("development_strong_model", "gpt-4")
+	form.Set("development_strong_api_key", "test-key")
+	form.Set("development_strong_base_url", "https://api.openai.com")
+	form.Set("development_weak_provider", "openai")
+	form.Set("development_weak_model", "gpt-3.5-turbo")
+	form.Set("planning_strong_provider", "anthropic")
+	form.Set("planning_strong_model", "claude-3-opus")
+	form.Set("planning_weak_provider", "anthropic")
+	form.Set("planning_weak_model", "claude-3-haiku")
+	form.Set("orchestration_strong_provider", "nexos-ai")
+	form.Set("orchestration_strong_model", "Kimi K2.5")
+	form.Set("orchestration_weak_provider", "nexos-ai")
+	form.Set("orchestration_weak_model", "Kimi K2.5")
+	form.Set("setup_strong_provider", "nexos-ai")
+	form.Set("setup_strong_model", "Kimi K2.5")
+	form.Set("setup_weak_provider", "nexos-ai")
+	form.Set("setup_weak_model", "Kimi K2.5")
+	form.Set("routing_code_size_threshold", "150")
+	form.Set("routing_high_complexity_threshold", "600")
+	form.Set("routing_file_count_threshold", "10")
+	form.Set("routing_force_strong_stages", "plan-review, code-review, merge")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify success message is shown
+	body := rec.Body.String()
+	if !strings.Contains(body, "saved successfully") {
+		t.Error("response missing success message")
+	}
+
+	// Verify config was saved by loading it back
+	cfg, err := config.Load(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to load saved config: %v", err)
+	}
+
+	// Verify Development strong model
+	if cfg.LLM.Development.Strong.Provider != "openai" {
+		t.Errorf("expected development strong provider 'openai', got %s", cfg.LLM.Development.Strong.Provider)
+	}
+	if cfg.LLM.Development.Strong.Model != "gpt-4" {
+		t.Errorf("expected development strong model 'gpt-4', got %s", cfg.LLM.Development.Strong.Model)
+	}
+	if cfg.LLM.Development.Strong.APIKey != "test-key" {
+		t.Errorf("expected development strong api_key 'test-key', got %s", cfg.LLM.Development.Strong.APIKey)
+	}
+
+	// Verify routing rules
+	if cfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold != 150 {
+		t.Errorf("expected code size threshold 150, got %d", cfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold)
+	}
+	if cfg.LLM.RoutingRules.ComplexityThresholds.HighComplexityThreshold != 600 {
+		t.Errorf("expected high complexity threshold 600, got %d", cfg.LLM.RoutingRules.ComplexityThresholds.HighComplexityThreshold)
+	}
+	if cfg.LLM.RoutingRules.ComplexityThresholds.FileCountThreshold != 10 {
+		t.Errorf("expected file count threshold 10, got %d", cfg.LLM.RoutingRules.ComplexityThresholds.FileCountThreshold)
+	}
+	if len(cfg.LLM.RoutingRules.ForceStrongForStages) != 3 {
+		t.Errorf("expected 3 force strong stages, got %d", len(cfg.LLM.RoutingRules.ForceStrongForStages))
+	}
+}
+
+// TestHandleSaveSettingsValidation tests form validation
+func TestHandleSaveSettingsValidation(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	// Create initial config
+	configContent := `github:
+  repo: test/repo
+llm:
+  development:
+    strong:
+      provider: nexos-ai
+      model: Kimi K2.5
+    weak:
+      provider: nexos-ai
+      model: Kimi K2.5
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	testCases := []struct {
+		name          string
+		form          url.Values
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name: "empty provider",
+			form: url.Values{
+				"development_strong_provider":       {""},
+				"development_strong_model":          {"gpt-4"},
+				"development_weak_provider":         {"nexos-ai"},
+				"development_weak_model":            {"Kimi K2.5"},
+				"planning_strong_provider":          {"nexos-ai"},
+				"planning_strong_model":             {"Kimi K2.5"},
+				"planning_weak_provider":            {"nexos-ai"},
+				"planning_weak_model":               {"Kimi K2.5"},
+				"orchestration_strong_provider":     {"nexos-ai"},
+				"orchestration_strong_model":        {"Kimi K2.5"},
+				"orchestration_weak_provider":       {"nexos-ai"},
+				"orchestration_weak_model":          {"Kimi K2.5"},
+				"setup_strong_provider":             {"nexos-ai"},
+				"setup_strong_model":                {"Kimi K2.5"},
+				"setup_weak_provider":               {"nexos-ai"},
+				"setup_weak_model":                  {"Kimi K2.5"},
+				"routing_code_size_threshold":       {"100"},
+				"routing_high_complexity_threshold": {"500"},
+				"routing_file_count_threshold":      {"5"},
+			},
+			expectError:   true,
+			errorContains: "development strong model: provider and model are required",
+		},
+		{
+			name: "negative threshold",
+			form: url.Values{
+				"development_strong_provider":       {"nexos-ai"},
+				"development_strong_model":          {"Kimi K2.5"},
+				"development_weak_provider":         {"nexos-ai"},
+				"development_weak_model":            {"Kimi K2.5"},
+				"planning_strong_provider":          {"nexos-ai"},
+				"planning_strong_model":             {"Kimi K2.5"},
+				"planning_weak_provider":            {"nexos-ai"},
+				"planning_weak_model":               {"Kimi K2.5"},
+				"orchestration_strong_provider":     {"nexos-ai"},
+				"orchestration_strong_model":        {"Kimi K2.5"},
+				"orchestration_weak_provider":       {"nexos-ai"},
+				"orchestration_weak_model":          {"Kimi K2.5"},
+				"setup_strong_provider":             {"nexos-ai"},
+				"setup_strong_model":                {"Kimi K2.5"},
+				"setup_weak_provider":               {"nexos-ai"},
+				"setup_weak_model":                  {"Kimi K2.5"},
+				"routing_code_size_threshold":       {"-1"},
+				"routing_high_complexity_threshold": {"500"},
+				"routing_file_count_threshold":      {"5"},
+			},
+			expectError:   true,
+			errorContains: "code size threshold must be a positive integer",
+		},
+		{
+			name: "zero threshold",
+			form: url.Values{
+				"development_strong_provider":       {"nexos-ai"},
+				"development_strong_model":          {"Kimi K2.5"},
+				"development_weak_provider":         {"nexos-ai"},
+				"development_weak_model":            {"Kimi K2.5"},
+				"planning_strong_provider":          {"nexos-ai"},
+				"planning_strong_model":             {"Kimi K2.5"},
+				"planning_weak_provider":            {"nexos-ai"},
+				"planning_weak_model":               {"Kimi K2.5"},
+				"orchestration_strong_provider":     {"nexos-ai"},
+				"orchestration_strong_model":        {"Kimi K2.5"},
+				"orchestration_weak_provider":       {"nexos-ai"},
+				"orchestration_weak_model":          {"Kimi K2.5"},
+				"setup_strong_provider":             {"nexos-ai"},
+				"setup_strong_model":                {"Kimi K2.5"},
+				"setup_weak_provider":               {"nexos-ai"},
+				"setup_weak_model":                  {"Kimi K2.5"},
+				"routing_code_size_threshold":       {"0"},
+				"routing_high_complexity_threshold": {"500"},
+				"routing_file_count_threshold":      {"5"},
+			},
+			expectError:   true,
+			errorContains: "code size threshold must be a positive integer",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(tc.form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			rec := httptest.NewRecorder()
+
+			srv.handleSaveSettings(rec, req)
+
+			if tc.expectError {
+				// Should return 200 OK but with error message in body
+				if rec.Code != http.StatusOK {
+					t.Errorf("expected status 200, got %d", rec.Code)
+				}
+				body := rec.Body.String()
+				if !strings.Contains(body, tc.errorContains) {
+					t.Errorf("expected error containing %q, got: %s", tc.errorContains, body)
+				}
+			}
+		})
+	}
+}
+
+// TestSettingsPersistence verifies that saved config persists and reloads correctly
+func TestSettingsPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+
+	// Create initial config
+	configContent := `github:
+  repo: test/repo
+llm:
+  development:
+    strong:
+      provider: nexos-ai
+      model: Kimi K2.5
+    weak:
+      provider: nexos-ai
+      model: Kimi K2.5
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Save new settings
+	form := url.Values{}
+	form.Set("development_strong_provider", "anthropic")
+	form.Set("development_strong_model", "claude-3-opus")
+	form.Set("development_weak_provider", "anthropic")
+	form.Set("development_weak_model", "claude-3-haiku")
+	form.Set("planning_strong_provider", "nexos-ai")
+	form.Set("planning_strong_model", "Kimi K2.5")
+	form.Set("planning_weak_provider", "nexos-ai")
+	form.Set("planning_weak_model", "Kimi K2.5")
+	form.Set("orchestration_strong_provider", "nexos-ai")
+	form.Set("orchestration_strong_model", "Kimi K2.5")
+	form.Set("orchestration_weak_provider", "nexos-ai")
+	form.Set("orchestration_weak_model", "Kimi K2.5")
+	form.Set("setup_strong_provider", "nexos-ai")
+	form.Set("setup_strong_model", "Kimi K2.5")
+	form.Set("setup_weak_provider", "nexos-ai")
+	form.Set("setup_weak_model", "Kimi K2.5")
+	form.Set("routing_code_size_threshold", "200")
+	form.Set("routing_high_complexity_threshold", "800")
+	form.Set("routing_file_count_threshold", "15")
+	form.Set("routing_force_strong_stages", "test-stage")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+	srv.handleSaveSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("failed to save settings: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Create a new server instance to simulate reload
+	srv2 := createTestServerWithTemplates(t)
+	srv2.rootDir = tmpDir
+	defer srv2.wizardStore.Stop()
+
+	// Load settings page
+	req = httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec = httptest.NewRecorder()
+	srv2.handleSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("failed to load settings: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify the saved values are displayed
+	body := rec.Body.String()
+	if !strings.Contains(body, `value="anthropic"`) {
+		t.Error("settings page doesn't show saved provider")
+	}
+	if !strings.Contains(body, `value="claude-3-opus"`) {
+		t.Error("settings page doesn't show saved model")
+	}
+	if !strings.Contains(body, `value="200"`) {
+		t.Error("settings page doesn't show saved code size threshold")
+	}
+}
+
+// TestSettingsRoutes_Registered verifies settings routes are properly registered
+func TestSettingsRoutes_Registered(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Test that the server handler is properly set up
+	handler := srv.Handler()
+	if handler == nil {
+		t.Fatal("server handler is nil")
+	}
+
+	// Test GET /settings
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+	srv.handleSettings(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Error("GET /settings returned 404")
+	}
+
+	// Test POST /settings
+	req = httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec = httptest.NewRecorder()
+	srv.handleSaveSettings(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Error("POST /settings returned 404")
 	}
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -33,9 +33,10 @@ type Server struct {
 	hub              *Hub
 	syncService      *SyncService
 	rateLimitService *RateLimitService
+	rootDir          string
 }
 
-func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService) (*Server, error) {
+func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService, rootDir string) (*Server, error) {
 	tmpls, err := parseTemplates()
 	if err != nil {
 		return nil, err
@@ -60,6 +61,7 @@ func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *g
 		wizardLLM:   wizardLLM,
 		hub:         hub,
 		syncService: syncService,
+		rootDir:     rootDir,
 	}
 	if s.wizardLLM == "" {
 		s.wizardLLM = DefaultLLMModel
@@ -127,6 +129,13 @@ func parseTemplates() (map[string]*template.Template, error) {
 		tmpls[page] = t
 	}
 
+	// Parse settings template
+	settingsTmpl, err := template.New("").Funcs(funcMap).ParseFS(templateFS, "templates/layout.html", "templates/llm-config.html")
+	if err != nil {
+		return nil, fmt.Errorf("parsing llm-config.html: %w", err)
+	}
+	tmpls["llm-config.html"] = settingsTmpl
+
 	return tmpls, nil
 }
 
@@ -171,6 +180,10 @@ func (s *Server) routes() {
 	// Rate limit endpoints
 	s.mux.HandleFunc("GET /api/rate-limit", s.handleRateLimit)
 	s.mux.HandleFunc("POST /api/rate-limit/refresh", s.handleRateLimitRefresh)
+
+	// Settings routes
+	s.mux.HandleFunc("GET /settings", s.handleSettings)
+	s.mux.HandleFunc("POST /settings", s.handleSaveSettings)
 }
 
 func (s *Server) Start() error {

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -70,6 +70,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
   <span class="logo">ODA</span>
   <div class="links">
     <a href="/" {{if eq .Active "board"}}class="active"{{end}}>Sprint Board</a>
+    <a href="/settings" {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
   </div>
   <div class="nav-actions">
     <a href="/wizard" class="btn btn-primary">+ New Issue</a>

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -1,0 +1,353 @@
+{{define "content"}}
+<div class="settings-container">
+  <h1>LLM Configuration Settings</h1>
+  
+  {{if .SuccessMessage}}
+  <div class="alert alert-success" role="alert">
+    {{.SuccessMessage}}
+  </div>
+  {{end}}
+  
+  {{if .ErrorMessage}}
+  <div class="alert alert-error" role="alert">
+    {{.ErrorMessage}}
+  </div>
+  {{end}}
+  
+  <form method="POST" action="/settings" hx-post="/settings" hx-target="#settings-content" hx-swap="innerHTML">
+    <div id="settings-content">
+      <!-- Development Category -->
+      <section class="config-section">
+        <h2>Development</h2>
+        <div class="model-variants">
+          <div class="variant-box">
+            <h3>Strong Model</h3>
+            <div class="form-group">
+              <label for="development_strong_provider">Provider</label>
+              <input type="text" id="development_strong_provider" name="development_strong_provider" value="{{.Config.Development.Strong.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="development_strong_model">Model</label>
+              <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="development_strong_api_key">API Key (optional)</label>
+              <input type="password" id="development_strong_api_key" name="development_strong_api_key" value="{{.Config.Development.Strong.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="development_strong_base_url">Base URL (optional)</label>
+              <input type="text" id="development_strong_base_url" name="development_strong_base_url" value="{{.Config.Development.Strong.BaseURL}}">
+            </div>
+          </div>
+          
+          <div class="variant-box">
+            <h3>Weak Model</h3>
+            <div class="form-group">
+              <label for="development_weak_provider">Provider</label>
+              <input type="text" id="development_weak_provider" name="development_weak_provider" value="{{.Config.Development.Weak.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="development_weak_model">Model</label>
+              <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="development_weak_api_key">API Key (optional)</label>
+              <input type="password" id="development_weak_api_key" name="development_weak_api_key" value="{{.Config.Development.Weak.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="development_weak_base_url">Base URL (optional)</label>
+              <input type="text" id="development_weak_base_url" name="development_weak_base_url" value="{{.Config.Development.Weak.BaseURL}}">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Planning Category -->
+      <section class="config-section">
+        <h2>Planning</h2>
+        <div class="model-variants">
+          <div class="variant-box">
+            <h3>Strong Model</h3>
+            <div class="form-group">
+              <label for="planning_strong_provider">Provider</label>
+              <input type="text" id="planning_strong_provider" name="planning_strong_provider" value="{{.Config.Planning.Strong.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="planning_strong_model">Model</label>
+              <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="planning_strong_api_key">API Key (optional)</label>
+              <input type="password" id="planning_strong_api_key" name="planning_strong_api_key" value="{{.Config.Planning.Strong.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="planning_strong_base_url">Base URL (optional)</label>
+              <input type="text" id="planning_strong_base_url" name="planning_strong_base_url" value="{{.Config.Planning.Strong.BaseURL}}">
+            </div>
+          </div>
+          
+          <div class="variant-box">
+            <h3>Weak Model</h3>
+            <div class="form-group">
+              <label for="planning_weak_provider">Provider</label>
+              <input type="text" id="planning_weak_provider" name="planning_weak_provider" value="{{.Config.Planning.Weak.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="planning_weak_model">Model</label>
+              <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="planning_weak_api_key">API Key (optional)</label>
+              <input type="password" id="planning_weak_api_key" name="planning_weak_api_key" value="{{.Config.Planning.Weak.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="planning_weak_base_url">Base URL (optional)</label>
+              <input type="text" id="planning_weak_base_url" name="planning_weak_base_url" value="{{.Config.Planning.Weak.BaseURL}}">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Orchestration Category -->
+      <section class="config-section">
+        <h2>Orchestration</h2>
+        <div class="model-variants">
+          <div class="variant-box">
+            <h3>Strong Model</h3>
+            <div class="form-group">
+              <label for="orchestration_strong_provider">Provider</label>
+              <input type="text" id="orchestration_strong_provider" name="orchestration_strong_provider" value="{{.Config.Orchestration.Strong.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="orchestration_strong_model">Model</label>
+              <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="orchestration_strong_api_key">API Key (optional)</label>
+              <input type="password" id="orchestration_strong_api_key" name="orchestration_strong_api_key" value="{{.Config.Orchestration.Strong.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="orchestration_strong_base_url">Base URL (optional)</label>
+              <input type="text" id="orchestration_strong_base_url" name="orchestration_strong_base_url" value="{{.Config.Orchestration.Strong.BaseURL}}">
+            </div>
+          </div>
+          
+          <div class="variant-box">
+            <h3>Weak Model</h3>
+            <div class="form-group">
+              <label for="orchestration_weak_provider">Provider</label>
+              <input type="text" id="orchestration_weak_provider" name="orchestration_weak_provider" value="{{.Config.Orchestration.Weak.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="orchestration_weak_model">Model</label>
+              <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="orchestration_weak_api_key">API Key (optional)</label>
+              <input type="password" id="orchestration_weak_api_key" name="orchestration_weak_api_key" value="{{.Config.Orchestration.Weak.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="orchestration_weak_base_url">Base URL (optional)</label>
+              <input type="text" id="orchestration_weak_base_url" name="orchestration_weak_base_url" value="{{.Config.Orchestration.Weak.BaseURL}}">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Setup Category -->
+      <section class="config-section">
+        <h2>Setup</h2>
+        <div class="model-variants">
+          <div class="variant-box">
+            <h3>Strong Model</h3>
+            <div class="form-group">
+              <label for="setup_strong_provider">Provider</label>
+              <input type="text" id="setup_strong_provider" name="setup_strong_provider" value="{{.Config.Setup.Strong.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="setup_strong_model">Model</label>
+              <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="setup_strong_api_key">API Key (optional)</label>
+              <input type="password" id="setup_strong_api_key" name="setup_strong_api_key" value="{{.Config.Setup.Strong.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="setup_strong_base_url">Base URL (optional)</label>
+              <input type="text" id="setup_strong_base_url" name="setup_strong_base_url" value="{{.Config.Setup.Strong.BaseURL}}">
+            </div>
+          </div>
+          
+          <div class="variant-box">
+            <h3>Weak Model</h3>
+            <div class="form-group">
+              <label for="setup_weak_provider">Provider</label>
+              <input type="text" id="setup_weak_provider" name="setup_weak_provider" value="{{.Config.Setup.Weak.Provider}}" required>
+            </div>
+            <div class="form-group">
+              <label for="setup_weak_model">Model</label>
+              <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required>
+            </div>
+            <div class="form-group">
+              <label for="setup_weak_api_key">API Key (optional)</label>
+              <input type="password" id="setup_weak_api_key" name="setup_weak_api_key" value="{{.Config.Setup.Weak.APIKey}}" placeholder="Uses env var if empty">
+            </div>
+            <div class="form-group">
+              <label for="setup_weak_base_url">Base URL (optional)</label>
+              <input type="text" id="setup_weak_base_url" name="setup_weak_base_url" value="{{.Config.Setup.Weak.BaseURL}}">
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Routing Rules -->
+      <section class="config-section">
+        <h2>Routing Rules</h2>
+        <div class="routing-rules">
+          <div class="form-group">
+            <label for="routing_code_size_threshold">Code Size Threshold (lines)</label>
+            <input type="number" id="routing_code_size_threshold" name="routing_code_size_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.CodeSizeThreshold}}" min="1" required>
+            <small>Number of lines that triggers medium complexity</small>
+          </div>
+          <div class="form-group">
+            <label for="routing_high_complexity_threshold">High Complexity Threshold (lines)</label>
+            <input type="number" id="routing_high_complexity_threshold" name="routing_high_complexity_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.HighComplexityThreshold}}" min="1" required>
+            <small>Number of lines that triggers high complexity</small>
+          </div>
+          <div class="form-group">
+            <label for="routing_file_count_threshold">File Count Threshold</label>
+            <input type="number" id="routing_file_count_threshold" name="routing_file_count_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.FileCountThreshold}}" min="1" required>
+            <small>Number of files that triggers higher complexity</small>
+          </div>
+          <div class="form-group">
+            <label for="routing_force_strong_stages">Force Strong For Stages (comma-separated)</label>
+            <input type="text" id="routing_force_strong_stages" name="routing_force_strong_stages" value="{{.ForceStrongStages}}">
+            <small>Pipeline stages that always use strong models (e.g., plan-review, code-review, merge)</small>
+          </div>
+        </div>
+      </section>
+
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary">Save Settings</button>
+        <a href="/" class="btn">Cancel</a>
+      </div>
+    </div>
+  </form>
+</div>
+
+<style>
+.settings-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.config-section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.config-section h2 {
+  color: var(--text);
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.model-variants {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.variant-box {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.variant-box h3 {
+  color: var(--accent);
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.form-group small {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.routing-rules {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.alert {
+  padding: 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+.alert-success {
+  background: rgba(63, 185, 80, 0.1);
+  border: 1px solid var(--green);
+  color: var(--green);
+}
+
+.alert-error {
+  background: rgba(248, 81, 73, 0.1);
+  border: 1px solid var(--red);
+  color: var(--red);
+}
+
+@media (max-width: 768px) {
+  .model-variants {
+    grid-template-columns: 1fr;
+  }
+  
+  .routing-rules {
+    grid-template-columns: 1fr;
+  }
+}
+</style>
+{{end}}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -578,7 +578,7 @@ func TestDashboardRendering(t *testing.T) {
 		}
 	}
 
-	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil)
+	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil, t.TempDir())
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}
@@ -628,7 +628,7 @@ func TestDashboard_WizardFlow_Integration(t *testing.T) {
 		return []worker.WorkerInfo{}
 	}
 
-	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil)
+	srv, err := dashboard.NewServer(0, store, poolFn, nil, nil, nil, "", nil, nil, t.TempDir())
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -279,7 +279,7 @@ func runServe() error {
 		}
 	}()
 
-	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers, gh, orchestrator, oc, cfg.Planning.LLM, hub, syncService)
+	srv, err := dashboard.NewServer(cfg.Dashboard.Port, store, pool.Workers, gh, orchestrator, oc, cfg.Planning.LLM, hub, syncService, dir)
 	if err != nil {
 		return fmt.Errorf("creating dashboard server: %w", err)
 	}


### PR DESCRIPTION
Closes #241

## Description
The LLM configuration system was implemented in PR #220 but the dashboard UI components are missing. Users cannot view or modify LLM settings through the web interface, making the configuration system inaccessible.

## Tasks
1. Create settings page template at `dashboard/templates/llm-config.html` with forms for 4 configuration categories
2. Add GET /settings route in `dashboard/router.go`
3. Implement `handleSaveSettings` handler in `dashboard/handlers.go` for configuration updates
4. Add settings icon to `dashboard/templates/header.html` linking to /settings
5. Wire up settings route registration in main dashboard initialization

## Files to Modify
- `dashboard/templates/llm-config.html` - Create new settings page template with configuration forms
- `dashboard/router.go` - Add GET /settings route handler
- `dashboard/handlers.go` - Add handleSaveSettings handler for POST requests
- `dashboard/templates/header.html` - Add settings icon navigation link

## Acceptance Criteria
1. Settings page accessible at /settings URL and displays current configuration
2. Settings icon visible in dashboard header and navigates to settings page
3. Users can view and modify LLM configuration for all 4 categories
4. Configuration changes save successfully and persist after page reload
5. Form validation prevents invalid configuration values