### PR TITLE
[Bug] Orchestrator ignores local cache, reprocesses closed tickets due to Git...

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -571,6 +571,21 @@ func (s *Store) GetIssuesCacheByMilestone(milestone string) ([]github.Issue, err
 	return s.scanIssues(rows)
 }
 
+// GetOpenIssuesCacheByMilestone retrieves only open cached issues for a specific milestone
+func (s *Store) GetOpenIssuesCacheByMilestone(milestone string) ([]github.Issue, error) {
+	rows, err := s.db.Query(
+		`SELECT issue_number, title, body, state, labels, assignee, milestone, updated_at, cached_at, pr_merged, merged_at
+		 FROM issue_cache WHERE milestone = ? AND state = 'open' ORDER BY issue_number`,
+		milestone,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying open issues by milestone: %w", err)
+	}
+	defer rows.Close()
+
+	return s.scanIssues(rows)
+}
+
 // GetAllCachedIssues retrieves all cached issues
 func (s *Store) GetAllCachedIssues() ([]github.Issue, error) {
 	rows, err := s.db.Query(

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -361,6 +361,62 @@ func TestGetIssuesCacheByMilestone(t *testing.T) {
 	}
 }
 
+func TestGetOpenIssuesCacheByMilestone(t *testing.T) {
+	store := openTestStore(t)
+
+	issues := []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open", Labels: nil, Assignees: nil},
+		{Number: 2, Title: "Issue 2", State: "closed", Labels: nil, Assignees: nil},
+		{Number: 3, Title: "Issue 3", State: "open", Labels: nil, Assignees: nil},
+		{Number: 4, Title: "Issue 4", State: "closed", Labels: nil, Assignees: nil},
+	}
+
+	for _, issue := range issues {
+		milestone := "v1.0"
+		if issue.Number == 3 || issue.Number == 4 {
+			milestone = "v2.0"
+		}
+		if err := store.SaveIssueCache(issue, milestone, true); err != nil {
+			t.Fatalf("saving issue cache: %v", err)
+		}
+	}
+
+	// Test v1.0 milestone - should only return open issues
+	got, err := store.GetOpenIssuesCacheByMilestone("v1.0")
+	if err != nil {
+		t.Fatalf("getting open issues by milestone: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Errorf("got %d open issues for v1.0, want 1", len(got))
+	}
+	if len(got) > 0 && got[0].Number != 1 {
+		t.Errorf("expected issue #1, got issue #%d", got[0].Number)
+	}
+
+	// Test v2.0 milestone - should only return open issues
+	got, err = store.GetOpenIssuesCacheByMilestone("v2.0")
+	if err != nil {
+		t.Fatalf("getting open issues by milestone: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Errorf("got %d open issues for v2.0, want 1", len(got))
+	}
+	if len(got) > 0 && got[0].Number != 3 {
+		t.Errorf("expected issue #3, got issue #%d", got[0].Number)
+	}
+
+	// Test non-existent milestone
+	got, err = store.GetOpenIssuesCacheByMilestone("v3.0")
+	if err != nil {
+		t.Fatalf("getting open issues for non-existent milestone: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d issues for non-existent milestone, want 0", len(got))
+	}
+}
+
 func TestGetAllCachedIssues(t *testing.T) {
 	store := openTestStore(t)
 

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -159,9 +159,9 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		}
 
 		log.Printf("[Orchestrator] Fetching issues for milestone %q...", milestone.Title)
-		issues, err := o.gh.ListIssuesForMilestone(milestone.Title)
+		issues, err := o.store.GetOpenIssuesCacheByMilestone(milestone.Title)
 		if err != nil {
-			log.Printf("[Orchestrator] Error listing issues: %v", err)
+			log.Printf("[Orchestrator] Error listing issues from cache: %v", err)
 			o.sleep(ctx, 30*time.Second)
 			continue
 		}


### PR DESCRIPTION
Closes #246

## Description
The orchestrator currently queries GitHub API directly for open tickets on every loop iteration, ignoring the local SQLite cache. This causes a race condition where GitHub's eventual consistency (CDN cache delays) returns recently-closed tickets as still open, leading the orchestrator to reprocess completed work. The local cache (issue_cache table) is maintained by SyncService and is immediately updated after every action with force=true, making it more reliable than GitHub API for this use case.

## Tasks
1. Read `/home/decodo/work/one-dev-army/internal/orchestrator/orchestrator.go` around line 162 to understand current implementation
2. Examine the SQLite cache schema in `/home/decodo/work/one-dev-army/internal/db/` to understand issue_cache table structure
3. Add a method to query issues from local SQLite cache filtered by milestone and open status
4. Modify orchestrator.go line 162 to use the local cache method instead of `o.gh.ListIssuesForMilestone()`
5. Ensure the cache query returns the same data structure as the GitHub API call
6. Test that orchestrator correctly reads from cache and doesn't reprocess closed tickets

## Files to Modify
- `internal/orchestrator/orchestrator.go` - Replace GitHub API call with local cache query at line 162
- `internal/db/` (relevant cache query file) - Add method to query open issues by milestone from issue_cache table

## Acceptance Criteria
1. Orchestrator reads ticket list from local SQLite cache instead of GitHub API
2. No regression in orchestrator functionality - all existing milestone and issue filtering still works
3. After a ticket is closed via PR merge, orchestrator does not reprocess it in subsequent iterations
4. Cache is queried with proper filtering for open status and milestone association