### PR TITLE
[Feature] Add --debug-websocket flag to control websocket logging

### DIFF
--- a/internal/dashboard/sync_test.go
+++ b/internal/dashboard/sync_test.go
@@ -52,7 +52,7 @@ func (m *mockStore) SaveIssueCache(issue github.Issue, milestone string, force b
 func TestNewSyncService(t *testing.T) {
 	gh := &mockGitHubClient{}
 	store := &mockStore{}
-	hub := NewHub()
+	hub := NewHub(false)
 
 	service := NewSyncService(gh, store, hub)
 

--- a/internal/dashboard/websocket.go
+++ b/internal/dashboard/websocket.go
@@ -31,6 +31,9 @@ const (
 	defaultConnectionLimit = 100
 )
 
+// packageDebug controls debug logging for the upgrader (set when first Hub is created)
+var packageDebug bool
+
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
@@ -59,7 +62,9 @@ var upgrader = websocket.Upgrader{
 			}
 		}
 
-		log.Printf("[WebSocket] Rejected connection from origin: %s", origin)
+		if packageDebug {
+			log.Printf("[WebSocket] Rejected connection from origin: %s", origin)
+		}
 		return false
 	},
 }
@@ -123,18 +128,21 @@ type Hub struct {
 	mu         sync.RWMutex
 	maxClients int
 	closed     bool
+	debug      bool
 }
 
 // NewHub creates a new Hub instance
-func NewHub() *Hub {
-	return NewHubWithLimit(defaultConnectionLimit)
+func NewHub(debug bool) *Hub {
+	return NewHubWithLimit(defaultConnectionLimit, debug)
 }
 
 // NewHubWithLimit creates a new Hub with a specific connection limit
-func NewHubWithLimit(limit int) *Hub {
+func NewHubWithLimit(limit int, debug bool) *Hub {
 	if limit <= 0 {
 		limit = defaultConnectionLimit
 	}
+	// Set package-level debug flag for upgrader
+	packageDebug = debug
 	return &Hub{
 		clients:    make(map[*Client]bool),
 		broadcast:  make(chan []byte),
@@ -142,6 +150,14 @@ func NewHubWithLimit(limit int) *Hub {
 		unregister: make(chan *Client),
 		maxClients: limit,
 		closed:     false,
+		debug:      debug,
+	}
+}
+
+// logf logs a message if debug mode is enabled
+func (h *Hub) logf(format string, v ...interface{}) {
+	if h.debug {
+		log.Printf("[WebSocket] "+format, v...)
 	}
 }
 
@@ -158,7 +174,7 @@ func (h *Hub) Run() {
 			}
 			if len(h.clients) >= h.maxClients {
 				h.mu.Unlock()
-				log.Printf("[WebSocket] Connection limit reached (%d), rejecting client", h.maxClients)
+				h.logf("Connection limit reached (%d), rejecting client", h.maxClients)
 				close(client.send)
 				client.conn.Close()
 				continue
@@ -166,7 +182,7 @@ func (h *Hub) Run() {
 			h.clients[client] = true
 			clientCount := len(h.clients)
 			h.mu.Unlock()
-			log.Printf("[WebSocket] Client registered. Total clients: %d", clientCount)
+			h.logf("Client registered. Total clients: %d", clientCount)
 
 		case client := <-h.unregister:
 			h.mu.Lock()
@@ -175,7 +191,7 @@ func (h *Hub) Run() {
 				close(client.send)
 				clientCount := len(h.clients)
 				h.mu.Unlock()
-				log.Printf("[WebSocket] Client unregistered. Total clients: %d", clientCount)
+				h.logf("Client unregistered. Total clients: %d", clientCount)
 			} else {
 				h.mu.Unlock()
 			}
@@ -218,7 +234,7 @@ func (h *Hub) Stop() {
 		delete(h.clients, client)
 	}
 
-	log.Printf("[WebSocket] Hub stopped, all clients disconnected")
+	h.logf("Hub stopped, all clients disconnected")
 }
 
 // ClientCount returns the current number of connected clients
@@ -233,7 +249,7 @@ func (h *Hub) Broadcast(message []byte) {
 	select {
 	case h.broadcast <- message:
 	default:
-		log.Printf("[WebSocket] Broadcast channel full, message dropped")
+		h.logf("Broadcast channel full, message dropped")
 	}
 }
 
@@ -250,7 +266,7 @@ func (h *Hub) BroadcastIssueUpdate(issue github.Issue) {
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[WebSocket] Error marshaling issue update payload: %v", err)
+		h.logf("Error marshaling issue update payload: %v", err)
 		return
 	}
 
@@ -261,12 +277,12 @@ func (h *Hub) BroadcastIssueUpdate(issue github.Issue) {
 
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
-		log.Printf("[WebSocket] Error marshaling issue update message: %v", err)
+		h.logf("Error marshaling issue update message: %v", err)
 		return
 	}
 
 	h.Broadcast(msgBytes)
-	log.Printf("[WebSocket] Broadcast issue update for #%d to %d clients", issue.Number, h.ClientCount())
+	h.logf("Broadcast issue update for #%d to %d clients", issue.Number, h.ClientCount())
 }
 
 // BroadcastSyncComplete sends a sync completion message to all clients
@@ -277,7 +293,7 @@ func (h *Hub) BroadcastSyncComplete(count int) {
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[WebSocket] Error marshaling sync complete payload: %v", err)
+		h.logf("Error marshaling sync complete payload: %v", err)
 		return
 	}
 
@@ -288,12 +304,12 @@ func (h *Hub) BroadcastSyncComplete(count int) {
 
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
-		log.Printf("[WebSocket] Error marshaling sync complete message: %v", err)
+		h.logf("Error marshaling sync complete message: %v", err)
 		return
 	}
 
 	h.Broadcast(msgBytes)
-	log.Printf("[WebSocket] Broadcast sync complete (count=%d) to %d clients", count, h.ClientCount())
+	h.logf("Broadcast sync complete (count=%d) to %d clients", count, h.ClientCount())
 }
 
 // BroadcastWorkerUpdate sends a worker status update to all clients
@@ -309,7 +325,7 @@ func (h *Hub) BroadcastWorkerUpdate(workerID, status string, taskID int, taskTit
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("[WebSocket] Error marshaling worker update payload: %v", err)
+		h.logf("Error marshaling worker update payload: %v", err)
 		return
 	}
 
@@ -320,12 +336,12 @@ func (h *Hub) BroadcastWorkerUpdate(workerID, status string, taskID int, taskTit
 
 	msgBytes, err := json.Marshal(msg)
 	if err != nil {
-		log.Printf("[WebSocket] Error marshaling worker update message: %v", err)
+		h.logf("Error marshaling worker update message: %v", err)
 		return
 	}
 
 	h.Broadcast(msgBytes)
-	log.Printf("[WebSocket] Broadcast worker update (worker=%s, task=#%d, stage=%s) to %d clients", workerID, taskID, stage, h.ClientCount())
+	h.logf("Broadcast worker update (worker=%s, task=#%d, stage=%s) to %d clients", workerID, taskID, stage, h.ClientCount())
 }
 
 // readPump pumps messages from the WebSocket connection to the hub
@@ -346,7 +362,7 @@ func (c *Client) readPump() {
 		_, message, err := c.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				log.Printf("[WebSocket] Read error: %v", err)
+				c.hub.logf("Read error: %v", err)
 			}
 			break
 		}
@@ -405,7 +421,7 @@ func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	if authToken != "" {
 		queryToken := r.URL.Query().Get("token")
 		if queryToken != authToken {
-			log.Printf("[WebSocket] Authentication failed: invalid or missing token from %s", r.RemoteAddr)
+			hub.logf("Authentication failed: invalid or missing token from %s", r.RemoteAddr)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -413,7 +429,7 @@ func ServeWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Printf("[WebSocket] Upgrade error: %v", err)
+		hub.logf("Upgrade error: %v", err)
 		return
 	}
 

--- a/internal/dashboard/websocket_test.go
+++ b/internal/dashboard/websocket_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewHub(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	if hub == nil {
 		t.Fatal("NewHub() returned nil")
 	}
@@ -23,6 +23,9 @@ func TestNewHub(t *testing.T) {
 	}
 	if hub.closed {
 		t.Error("New hub should not be closed")
+	}
+	if hub.debug {
+		t.Error("New hub should have debug disabled by default")
 	}
 }
 
@@ -39,7 +42,7 @@ func TestNewHubWithLimit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hub := NewHubWithLimit(tt.limit)
+			hub := NewHubWithLimit(tt.limit, false)
 			if hub.maxClients != tt.expected {
 				t.Errorf("Expected maxClients to be %d, got %d", tt.expected, hub.maxClients)
 			}
@@ -48,7 +51,7 @@ func TestNewHubWithLimit(t *testing.T) {
 }
 
 func TestHubClientCount(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -59,7 +62,7 @@ func TestHubClientCount(t *testing.T) {
 }
 
 func TestHubRegisterUnregister(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -96,7 +99,7 @@ func TestHubRegisterUnregister(t *testing.T) {
 }
 
 func TestHubBroadcast(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -143,7 +146,7 @@ func TestHubBroadcast(t *testing.T) {
 }
 
 func TestHubBroadcastIssueUpdate(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -205,7 +208,7 @@ func TestHubBroadcastIssueUpdate(t *testing.T) {
 }
 
 func TestHubBroadcastSyncComplete(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -256,7 +259,7 @@ func TestHubBroadcastSyncComplete(t *testing.T) {
 }
 
 func TestHubBroadcastWorkerUpdate(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -362,7 +365,7 @@ func TestWorkerUpdatePayloadMarshal(t *testing.T) {
 }
 
 func TestHubConnectionLimit(t *testing.T) {
-	hub := NewHubWithLimit(2)
+	hub := NewHubWithLimit(2, false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -415,7 +418,7 @@ func TestHubConnectionLimit(t *testing.T) {
 }
 
 func TestHubConcurrentClients(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 
@@ -470,7 +473,7 @@ func TestHubConcurrentClients(t *testing.T) {
 }
 
 func TestHubStop(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 
 	// Create a test server
@@ -592,7 +595,7 @@ func TestSyncCompletePayloadMarshal(t *testing.T) {
 }
 
 func TestClientPingPong(t *testing.T) {
-	hub := NewHub()
+	hub := NewHub(false)
 	go hub.Run()
 	defer hub.Stop()
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -25,8 +26,21 @@ import (
 )
 
 func main() {
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
+	// Define flags
+	var debugWebSocket bool
+	flag.BoolVar(&debugWebSocket, "debug-websocket", false, "Enable WebSocket debug logging")
+
+	// Custom usage message
+	flag.Usage = printUsage
+
+	// Parse flags
+	flag.Parse()
+
+	// Get remaining args after flag parsing
+	args := flag.Args()
+
+	if len(args) > 0 {
+		switch args[0] {
 		case "init":
 			if err := runInit(); err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -37,13 +51,13 @@ func main() {
 			printUsage()
 			return
 		default:
-			fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", os.Args[1])
+			fmt.Fprintf(os.Stderr, "unknown command: %s\n\n", args[0])
 			printUsage()
 			os.Exit(1)
 		}
 	}
 
-	if err := runServe(); err != nil {
+	if err := runServe(debugWebSocket); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -51,12 +65,15 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Println("Usage: oda [command]")
+	fmt.Println("Usage: oda [options] [command]")
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  (none)    Start the ODA agent and dashboard")
 	fmt.Println("  init      Initialize a new ODA project in the current directory")
 	fmt.Println("  help      Show this help message")
+	fmt.Println()
+	fmt.Println("Options:")
+	fmt.Println("  --debug-websocket    Enable WebSocket debug logging")
 }
 
 func runInit() error {
@@ -73,7 +90,7 @@ func runInit() error {
 	return i.Run()
 }
 
-func runServe() error {
+func runServe(debugWebSocket bool) error {
 	dir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)
@@ -236,7 +253,7 @@ func runServe() error {
 
 	// Step 6: Create WebSocket hub
 	fmt.Println("Creating WebSocket hub...")
-	hub := dashboard.NewHub()
+	hub := dashboard.NewHub(debugWebSocket)
 	go hub.Run()
 	fmt.Println("  ✓ WebSocket hub started")
 


### PR DESCRIPTION
Closes #242

## Description
When running the ODA service, the logs are flooded with verbose websocket connection messages that make it difficult to read other important log entries. A command-line flag `--debug-websocket` should be added to control when these websocket logs are displayed.

## Tasks
1. Add `--debug-websocket` boolean flag to the CLI argument parser in `cmd/oda/main.go`
2. Pass the flag value to the websocket handler initialization
3. Wrap existing websocket log statements with conditional checks for the debug flag
4. Update help text to document the new flag

## Files to Modify
- `cmd/oda/main.go` — Add `--debug-websocket` flag definition and pass to websocket config
- `internal/dashboard/websocket.go` — Add conditional logging based on debug flag
- `internal/dashboard/handler.go` — Update handler to receive and use debug configuration

## Acceptance Criteria
1. Running `oda` without `--debug-websocket` shows no websocket connection logs
2. Running `oda --debug-websocket` displays all websocket connection and message logs
3. The `--help` output includes documentation for the new flag
4. Other application logs (non-websocket) continue to display normally regardless of the flag