### PR TITLE
[Feature] Add searchable model dropdown in LLM Configuration Settings

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1822,6 +1822,7 @@ type settingsData struct {
 	ForceStrongStages string
 	Success           bool
 	Errors            []string
+	AvailableModels   []opencode.ProviderModel
 }
 
 // handleSettings renders the LLM configuration settings page
@@ -1842,6 +1843,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 		Active:            "settings",
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
+		AvailableModels:   s.modelsCache,
 	}
 
 	s.render(w, "llm-config.html", data)
@@ -1935,6 +1937,30 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate model selections against available models
+	if len(s.modelsCache) > 0 {
+		modelValidations := []struct {
+			name     string
+			provider string
+			model    string
+		}{
+			{"Development Strong", cfg.LLM.Development.Strong.Provider, cfg.LLM.Development.Strong.Model},
+			{"Development Weak", cfg.LLM.Development.Weak.Provider, cfg.LLM.Development.Weak.Model},
+			{"Planning Strong", cfg.LLM.Planning.Strong.Provider, cfg.LLM.Planning.Strong.Model},
+			{"Planning Weak", cfg.LLM.Planning.Weak.Provider, cfg.LLM.Planning.Weak.Model},
+			{"Orchestration Strong", cfg.LLM.Orchestration.Strong.Provider, cfg.LLM.Orchestration.Strong.Model},
+			{"Orchestration Weak", cfg.LLM.Orchestration.Weak.Provider, cfg.LLM.Orchestration.Weak.Model},
+			{"Setup Strong", cfg.LLM.Setup.Strong.Provider, cfg.LLM.Setup.Strong.Model},
+			{"Setup Weak", cfg.LLM.Setup.Weak.Provider, cfg.LLM.Setup.Weak.Model},
+		}
+
+		for _, mv := range modelValidations {
+			if mv.provider != "" && mv.model != "" && !s.validateModelSelection(mv.provider, mv.model) {
+				errors = append(errors, fmt.Sprintf("%s: Invalid model '%s/%s' - not found in available models", mv.name, mv.provider, mv.model))
+			}
+		}
+	}
+
 	// Parse routing thresholds
 	codeSizeThreshold, err := strconv.Atoi(r.FormValue("routing_code_size_threshold"))
 	if err != nil || codeSizeThreshold < 1 {
@@ -1995,6 +2021,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
 		Success:           true,
+		AvailableModels:   s.modelsCache,
 	}
 
 	s.render(w, "llm-config.html", data)
@@ -2018,7 +2045,22 @@ func (s *Server) renderSettingsWithErrors(w http.ResponseWriter, r *http.Request
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
 		Errors:            errors,
+		AvailableModels:   s.modelsCache,
 	}
 
 	s.render(w, "llm-config.html", data)
+}
+
+// validateModelSelection checks if a model selection is valid against the cached models
+func (s *Server) validateModelSelection(provider, model string) bool {
+	if len(s.modelsCache) == 0 {
+		return true // Skip validation if cache is empty (API unavailable)
+	}
+
+	for _, m := range s.modelsCache {
+		if m.ProviderID == provider && m.ID == model {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/github"
+	"github.com/crazy-goat/one-dev-army/internal/opencode"
 )
 
 // parseTemplatesFromDisk parses templates from disk for testing
@@ -38,6 +40,13 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 				return s
 			}
 			return s[:n] + "\n... (truncated)"
+		},
+		"json": func(v interface{}) string {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return ""
+			}
+			return string(b)
 		},
 	}
 
@@ -3933,6 +3942,368 @@ func TestSettingsPersistence(t *testing.T) {
 	}
 	if len(reloadedCfg.LLM.RoutingRules.ForceStrongForStages) != 1 || reloadedCfg.LLM.RoutingRules.ForceStrongForStages[0] != "test-stage" {
 		t.Errorf("expected force strong stages to be ['test-stage'], got %v", reloadedCfg.LLM.RoutingRules.ForceStrongForStages)
+	}
+}
+
+// TestHandleSettings_WithModels verifies that available models are passed to the template
+func TestHandleSettings_WithModels(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a minimal config file
+	configContent := `llm:
+  development:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model-weak
+`
+	configPath := filepath.Join(odaDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates and mock models cache
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	srv.modelsCache = []opencode.ProviderModel{
+		{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
+		{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test GET /settings
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleSettings(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	// Verify response contains model data (as JSON in the script)
+	body := rec.Body.String()
+	if !strings.Contains(body, "gpt-4") {
+		t.Error("response should contain model data (gpt-4)")
+	}
+	if !strings.Contains(body, "claude-3") {
+		t.Error("response should contain model data (claude-3)")
+	}
+}
+
+// TestHandleSaveSettings_InvalidModel verifies that validation rejects invalid models
+func TestHandleSaveSettings_InvalidModel(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a minimal config file
+	configPath := filepath.Join(odaDir, "config.yaml")
+	configContent := `llm:
+  development:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model-weak
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates and mock models cache
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	srv.modelsCache = []opencode.ProviderModel{
+		{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
+		{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test POST /settings with invalid model
+	form := url.Values{}
+	form.Set("development_strong_provider", "openai")
+	form.Set("development_strong_model", "invalid-model") // Invalid model
+	form.Set("development_weak_provider", "openai")
+	form.Set("development_weak_model", "gpt-4") // Valid model
+	form.Set("planning_strong_provider", "openai")
+	form.Set("planning_strong_model", "gpt-4")
+	form.Set("planning_weak_provider", "openai")
+	form.Set("planning_weak_model", "gpt-4")
+	form.Set("orchestration_strong_provider", "openai")
+	form.Set("orchestration_strong_model", "gpt-4")
+	form.Set("orchestration_weak_provider", "openai")
+	form.Set("orchestration_weak_model", "gpt-4")
+	form.Set("setup_strong_provider", "openai")
+	form.Set("setup_strong_model", "gpt-4")
+	form.Set("setup_weak_provider", "openai")
+	form.Set("setup_weak_model", "gpt-4")
+	form.Set("routing_code_size_threshold", "150")
+	form.Set("routing_high_complexity_threshold", "600")
+	form.Set("routing_file_count_threshold", "10")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should return 200 OK but with error message
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	// Verify error message about invalid model
+	body := rec.Body.String()
+	if !strings.Contains(body, "Invalid model") {
+		t.Error("response should contain validation error for invalid model")
+	}
+	if !strings.Contains(body, "invalid-model") {
+		t.Error("response should mention the invalid model name")
+	}
+}
+
+// TestHandleSaveSettings_ValidModel verifies that validation accepts valid models
+func TestHandleSaveSettings_ValidModel(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a minimal config file
+	configPath := filepath.Join(odaDir, "config.yaml")
+	configContent := `llm:
+  development:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model-weak
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates and mock models cache
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	srv.modelsCache = []opencode.ProviderModel{
+		{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
+		{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+	}
+	defer srv.wizardStore.Stop()
+
+	// Test POST /settings with valid models
+	form := url.Values{}
+	form.Set("development_strong_provider", "openai")
+	form.Set("development_strong_model", "gpt-4")
+	form.Set("development_weak_provider", "anthropic")
+	form.Set("development_weak_model", "claude-3")
+	form.Set("planning_strong_provider", "openai")
+	form.Set("planning_strong_model", "gpt-4")
+	form.Set("planning_weak_provider", "openai")
+	form.Set("planning_weak_model", "gpt-4")
+	form.Set("orchestration_strong_provider", "openai")
+	form.Set("orchestration_strong_model", "gpt-4")
+	form.Set("orchestration_weak_provider", "openai")
+	form.Set("orchestration_weak_model", "gpt-4")
+	form.Set("setup_strong_provider", "openai")
+	form.Set("setup_strong_model", "gpt-4")
+	form.Set("setup_weak_provider", "openai")
+	form.Set("setup_weak_model", "gpt-4")
+	form.Set("routing_code_size_threshold", "150")
+	form.Set("routing_high_complexity_threshold", "600")
+	form.Set("routing_file_count_threshold", "10")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should return 200 OK with success message
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify success message
+	body := rec.Body.String()
+	if !strings.Contains(body, "Settings saved successfully") {
+		t.Error("response should contain success message")
+	}
+
+	// Verify no error about invalid models
+	if strings.Contains(body, "Invalid model") {
+		t.Error("response should NOT contain invalid model error for valid models")
+	}
+}
+
+// TestValidateModelSelection tests the validateModelSelection helper method
+func TestValidateModelSelection(t *testing.T) {
+	srv := &Server{
+		modelsCache: []opencode.ProviderModel{
+			{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
+			{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+			{ID: "gpt-3.5", ProviderID: "openai", Name: "GPT-3.5"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		want     bool
+	}{
+		{
+			name:     "valid model - openai/gpt-4",
+			provider: "openai",
+			model:    "gpt-4",
+			want:     true,
+		},
+		{
+			name:     "valid model - anthropic/claude-3",
+			provider: "anthropic",
+			model:    "claude-3",
+			want:     true,
+		},
+		{
+			name:     "invalid model - wrong provider",
+			provider: "anthropic",
+			model:    "gpt-4",
+			want:     false,
+		},
+		{
+			name:     "invalid model - nonexistent",
+			provider: "openai",
+			model:    "nonexistent-model",
+			want:     false,
+		},
+		{
+			name:     "invalid model - wrong provider for claude",
+			provider: "openai",
+			model:    "claude-3",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := srv.validateModelSelection(tt.provider, tt.model)
+			if got != tt.want {
+				t.Errorf("validateModelSelection(%q, %q) = %v, want %v", tt.provider, tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateModelSelection_EmptyCache tests that validation passes when cache is empty
+func TestValidateModelSelection_EmptyCache(t *testing.T) {
+	srv := &Server{
+		modelsCache: []opencode.ProviderModel{}, // Empty cache
+	}
+
+	// Should return true (skip validation) when cache is empty
+	got := srv.validateModelSelection("any-provider", "any-model")
+	if !got {
+		t.Error("validateModelSelection should return true when cache is empty (skip validation)")
+	}
+}
+
+// TestHandleSaveSettings_EmptyCache allows any model when cache is empty
+func TestHandleSaveSettings_EmptyCache(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a minimal config file
+	configPath := filepath.Join(odaDir, "config.yaml")
+	configContent := `llm:
+  development:
+    strong:
+      provider: test-provider
+      model: test-model
+    weak:
+      provider: test-provider
+      model: test-model-weak
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates but EMPTY models cache
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	srv.modelsCache = []opencode.ProviderModel{} // Empty cache
+	defer srv.wizardStore.Stop()
+
+	// Test POST /settings with any model (should be allowed when cache is empty)
+	form := url.Values{}
+	form.Set("development_strong_provider", "custom-provider")
+	form.Set("development_strong_model", "custom-model")
+	form.Set("development_weak_provider", "custom-provider")
+	form.Set("development_weak_model", "another-custom-model")
+	form.Set("planning_strong_provider", "custom-provider")
+	form.Set("planning_strong_model", "custom-model")
+	form.Set("planning_weak_provider", "custom-provider")
+	form.Set("planning_weak_model", "custom-model")
+	form.Set("orchestration_strong_provider", "custom-provider")
+	form.Set("orchestration_strong_model", "custom-model")
+	form.Set("orchestration_weak_provider", "custom-provider")
+	form.Set("orchestration_weak_model", "custom-model")
+	form.Set("setup_strong_provider", "custom-provider")
+	form.Set("setup_strong_model", "custom-model")
+	form.Set("setup_weak_provider", "custom-provider")
+	form.Set("setup_weak_model", "custom-model")
+	form.Set("routing_code_size_threshold", "150")
+	form.Set("routing_high_complexity_threshold", "600")
+	form.Set("routing_file_count_threshold", "10")
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should return 200 OK with success message (no validation errors)
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify success message
+	body := rec.Body.String()
+	if !strings.Contains(body, "Settings saved successfully") {
+		t.Error("response should contain success message when cache is empty")
+	}
+
+	// Verify no validation errors about invalid models
+	if strings.Contains(body, "Invalid model") {
+		t.Error("response should NOT contain invalid model error when cache is empty")
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -3,8 +3,10 @@ package dashboard
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
+	"log"
 	"net/http"
 	"time"
 
@@ -34,6 +36,7 @@ type Server struct {
 	syncService      *SyncService
 	rateLimitService *RateLimitService
 	rootDir          string
+	modelsCache      []opencode.ProviderModel
 }
 
 func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService, rootDir string) (*Server, error) {
@@ -73,7 +76,44 @@ func NewServer(port int, store *db.Store, pool func() []worker.WorkerInfo, gh *g
 	s.rateLimitService.Start()
 
 	s.routes()
+
+	// Load available models from opencode API
+	if err := s.LoadModels(); err != nil {
+		log.Printf("[Dashboard] Warning: failed to load models: %v", err)
+	}
+
 	return s, nil
+}
+
+// LoadModels fetches and caches available models from the opencode API
+func (s *Server) LoadModels() error {
+	if s.oc == nil {
+		return fmt.Errorf("opencode client not configured")
+	}
+
+	providers, err := s.oc.ListProviders()
+	if err != nil {
+		return fmt.Errorf("loading providers: %w", err)
+	}
+
+	var models []opencode.ProviderModel
+	connectedSet := make(map[string]bool)
+	for _, id := range providers.Connected {
+		connectedSet[id] = true
+	}
+
+	for _, p := range providers.All {
+		if !connectedSet[p.ID] {
+			continue
+		}
+		for _, model := range p.Models {
+			models = append(models, model)
+		}
+	}
+
+	s.modelsCache = models
+	log.Printf("[Dashboard] Loaded %d models from %d connected providers", len(models), len(providers.Connected))
+	return nil
 }
 
 func parseTemplates() (map[string]*template.Template, error) {
@@ -95,6 +135,13 @@ func parseTemplates() (map[string]*template.Template, error) {
 				return s
 			}
 			return s[:n] + "\n... (truncated)"
+		},
+		"json": func(v interface{}) string {
+			b, err := json.Marshal(v)
+			if err != nil {
+				return ""
+			}
+			return string(b)
 		},
 	}
 

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -29,7 +29,10 @@
         </div>
         <div class="form-group">
           <label for="development_strong_model">Model</label>
-          <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required>
+          <div class="model-dropdown" data-field="development_strong_model">
+            <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-development_strong_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="development_strong_api_key">API Key (optional)</label>
@@ -48,7 +51,10 @@
         </div>
         <div class="form-group">
           <label for="development_weak_model">Model</label>
-          <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required>
+          <div class="model-dropdown" data-field="development_weak_model">
+            <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-development_weak_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="development_weak_api_key">API Key (optional)</label>
@@ -72,7 +78,10 @@
         </div>
         <div class="form-group">
           <label for="planning_strong_model">Model</label>
-          <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required>
+          <div class="model-dropdown" data-field="planning_strong_model">
+            <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-planning_strong_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="planning_strong_api_key">API Key (optional)</label>
@@ -91,7 +100,10 @@
         </div>
         <div class="form-group">
           <label for="planning_weak_model">Model</label>
-          <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required>
+          <div class="model-dropdown" data-field="planning_weak_model">
+            <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-planning_weak_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="planning_weak_api_key">API Key (optional)</label>
@@ -115,7 +127,10 @@
         </div>
         <div class="form-group">
           <label for="orchestration_strong_model">Model</label>
-          <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required>
+          <div class="model-dropdown" data-field="orchestration_strong_model">
+            <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-orchestration_strong_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="orchestration_strong_api_key">API Key (optional)</label>
@@ -134,7 +149,10 @@
         </div>
         <div class="form-group">
           <label for="orchestration_weak_model">Model</label>
-          <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required>
+          <div class="model-dropdown" data-field="orchestration_weak_model">
+            <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-orchestration_weak_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="orchestration_weak_api_key">API Key (optional)</label>
@@ -158,7 +176,10 @@
         </div>
         <div class="form-group">
           <label for="setup_strong_model">Model</label>
-          <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required>
+          <div class="model-dropdown" data-field="setup_strong_model">
+            <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-setup_strong_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="setup_strong_api_key">API Key (optional)</label>
@@ -177,7 +198,10 @@
         </div>
         <div class="form-group">
           <label for="setup_weak_model">Model</label>
-          <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required>
+          <div class="model-dropdown" data-field="setup_weak_model">
+            <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <div class="model-dropdown-list" id="dropdown-setup_weak_model"></div>
+          </div>
         </div>
         <div class="form-group">
           <label for="setup_weak_api_key">API Key (optional)</label>
@@ -335,5 +359,268 @@
 .alert li:last-child {
   margin-bottom: 0;
 }
+
+/* Model Dropdown Styles */
+.model-dropdown {
+  position: relative;
+  width: 100%;
+}
+
+.model-dropdown-input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.model-dropdown-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.model-dropdown-list {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 250px;
+  overflow-y: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  z-index: 1000;
+  display: none;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.model-dropdown-list.visible {
+  display: block;
+}
+
+.model-dropdown-item {
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+
+.model-dropdown-item:last-child {
+  border-bottom: none;
+}
+
+.model-dropdown-item:hover,
+.model-dropdown-item.selected {
+  background: var(--accent);
+  color: white;
+}
+
+.model-dropdown-item .model-name {
+  font-weight: 500;
+}
+
+.model-dropdown-item .model-provider {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.model-dropdown-group {
+  padding: 0.25rem 0.75rem;
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.model-dropdown-no-results {
+  padding: 0.75rem;
+  color: var(--muted);
+  font-style: italic;
+  text-align: center;
+}
 </style>
+
+<script>
+// Model data from server
+const availableModels = {{if .AvailableModels}}[
+  {{range .AvailableModels}}
+  { id: {{.ID | json}}, providerID: {{.ProviderID | json}}, name: {{.Name | json}} },
+  {{end}}
+]{{else}}[]{{end}};
+
+// Initialize dropdowns when DOM is ready
+document.addEventListener('DOMContentLoaded', function() {
+  initializeModelDropdowns();
+});
+
+// Also initialize when HTMX swaps content
+document.addEventListener('htmx:afterSwap', function() {
+  initializeModelDropdowns();
+});
+
+function initializeModelDropdowns() {
+  const dropdowns = document.querySelectorAll('.model-dropdown');
+  
+  dropdowns.forEach(function(dropdown) {
+    const input = dropdown.querySelector('.model-dropdown-input');
+    const list = dropdown.querySelector('.model-dropdown-list');
+    const fieldName = dropdown.getAttribute('data-field');
+    
+    if (!input || !list) return;
+    
+    // Remove existing event listeners by cloning
+    const newInput = input.cloneNode(true);
+    input.parentNode.replaceChild(newInput, input);
+    
+    let selectedIndex = -1;
+    let filteredModels = [];
+    
+    // Focus event - show all models
+    newInput.addEventListener('focus', function() {
+      filteredModels = filterModels('');
+      renderDropdown(filteredModels, list, '');
+      list.classList.add('visible');
+      selectedIndex = -1;
+    });
+    
+    // Input event - filter models
+    newInput.addEventListener('input', function() {
+      const query = this.value.toLowerCase();
+      filteredModels = filterModels(query);
+      renderDropdown(filteredModels, list, query);
+      list.classList.add('visible');
+      selectedIndex = -1;
+    });
+    
+    // Keyboard navigation
+    newInput.addEventListener('keydown', function(e) {
+      if (!list.classList.contains('visible')) return;
+      
+      switch(e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          selectedIndex = Math.min(selectedIndex + 1, filteredModels.length - 1);
+          updateSelection(list, selectedIndex);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          selectedIndex = Math.max(selectedIndex - 1, -1);
+          updateSelection(list, selectedIndex);
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (selectedIndex >= 0 && filteredModels[selectedIndex]) {
+            selectModel(filteredModels[selectedIndex], newInput, list);
+          }
+          break;
+        case 'Escape':
+          list.classList.remove('visible');
+          selectedIndex = -1;
+          break;
+      }
+    });
+    
+    // Click outside to close
+    document.addEventListener('click', function(e) {
+      if (!dropdown.contains(e.target)) {
+        list.classList.remove('visible');
+      }
+    });
+  });
+}
+
+function filterModels(query) {
+  if (!availableModels || availableModels.length === 0) {
+    return [];
+  }
+  
+  if (!query) {
+    return availableModels;
+  }
+  
+  return availableModels.filter(function(model) {
+    return model.name.toLowerCase().includes(query) ||
+           model.id.toLowerCase().includes(query) ||
+           model.providerID.toLowerCase().includes(query);
+  });
+}
+
+function renderDropdown(models, list, query) {
+  list.innerHTML = '';
+  
+  if (models.length === 0) {
+    list.innerHTML = '<div class="model-dropdown-no-results">No models found</div>';
+    return;
+  }
+  
+  // Group models by provider
+  const grouped = {};
+  models.forEach(function(model) {
+    if (!grouped[model.providerID]) {
+      grouped[model.providerID] = [];
+    }
+    grouped[model.providerID].push(model);
+  });
+  
+  // Render grouped models
+  Object.keys(grouped).sort().forEach(function(provider) {
+    const groupHeader = document.createElement('div');
+    groupHeader.className = 'model-dropdown-group';
+    groupHeader.textContent = provider;
+    list.appendChild(groupHeader);
+    
+    grouped[provider].forEach(function(model) {
+      const item = document.createElement('div');
+      item.className = 'model-dropdown-item';
+      item.setAttribute('data-model-id', model.id);
+      item.setAttribute('data-provider-id', model.providerID);
+      item.innerHTML = '<div class="model-name">' + escapeHtml(model.name) + '</div>' +
+                      '<div class="model-provider">' + escapeHtml(model.id) + '</div>';
+      
+      item.addEventListener('click', function() {
+        selectModel(model, list.previousElementSibling, list);
+      });
+      
+      list.appendChild(item);
+    });
+  });
+}
+
+function updateSelection(list, selectedIndex) {
+  const items = list.querySelectorAll('.model-dropdown-item');
+  items.forEach(function(item, index) {
+    if (index === selectedIndex) {
+      item.classList.add('selected');
+      item.scrollIntoView({ block: 'nearest' });
+    } else {
+      item.classList.remove('selected');
+    }
+  });
+}
+
+function selectModel(model, input, list) {
+  input.value = model.id;
+  list.classList.remove('visible');
+  
+  // Update the provider field if it exists
+  const fieldName = input.getAttribute('name');
+  if (fieldName) {
+    const providerFieldName = fieldName.replace('_model', '_provider');
+    const providerInput = document.querySelector('input[name="' + providerFieldName + '"]');
+    if (providerInput) {
+      providerInput.value = model.providerID;
+    }
+  }
+}
+
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+</script>
 {{end}}


### PR DESCRIPTION
Closes #251

## Description
Replace free-text model input fields in LLM Configuration Settings with searchable dropdowns populated from the `opencode models` command. The model list is already fetched at application startup, so this change improves user experience by preventing typos and showing only available models.

## Tasks
1. Locate the LLM Configuration Settings UI component in the dashboard package
2. Identify where the model list from `opencode models` is stored after startup
3. Replace text input fields for model selection with searchable dropdown components
4. Apply the dropdown to each LLM mode configuration (chat, completion, etc.)
5. Add validation to ensure only valid models can be selected
6. Test the dropdown functionality in all LLM configuration modes

## Files to Modify
- `internal/dashboard/settings.go` or similar - UI component for LLM settings
- `internal/opencode/client.go` or similar - ensure model list is accessible
- `internal/dashboard/templates/` - update HTML templates if applicable

## Acceptance Criteria
1. Model selection fields display as searchable dropdowns instead of text inputs
2. Dropdown options are populated from the `opencode models` command output
3. User can type to filter models in the dropdown
4. Each LLM mode (chat, completion, etc.) has its own model dropdown
5. Invalid model names cannot be entered or saved