### PR TITLE
[Bug] GitHub labels not auto-created at startup

### DIFF
--- a/internal/github/labels.go
+++ b/internal/github/labels.go
@@ -297,11 +297,15 @@ func (c *Client) EnsureLabels() error {
 	}
 
 	if len(missing) == 0 {
+		log.Println("  ✓ all GitHub labels exist")
 		return nil
 	}
 
+	log.Printf("  → creating %d missing label(s)...", len(missing))
+
 	var wg sync.WaitGroup
-	errs := make(chan error, len(missing))
+	errChan := make(chan error, len(missing))
+	createdChan := make(chan string, len(missing))
 
 	for _, l := range missing {
 		wg.Add(1)
@@ -309,17 +313,27 @@ func (c *Client) EnsureLabels() error {
 			defer wg.Done()
 			_, err := c.gh("label", "create", l.Name, "--color", l.Color, "--force")
 			if err != nil {
-				errs <- fmt.Errorf("creating label %s: %w", l.Name, err)
+				errChan <- fmt.Errorf("creating label %s: %w", l.Name, err)
+			} else {
+				createdChan <- l.Name
 			}
 		}(l)
 	}
 
 	wg.Wait()
-	close(errs)
+	close(errChan)
+	close(createdChan)
 
-	for err := range errs {
+	for err := range errChan {
 		return err
 	}
+
+	var created []string
+	for name := range createdChan {
+		created = append(created, name)
+	}
+	log.Printf("  ✓ created %d label(s): %v", len(created), created)
+
 	return nil
 }
 


### PR DESCRIPTION
Closes #258

## Description
The application uses specific GitHub labels (e.g., "stage:done") for issue management, but it doesn't verify or create these labels at startup. This causes issues when labels are missing from the repository. The application should automatically check for and create all required labels during initialization.

## Tasks
1. Search the codebase to identify all GitHub labels used by the application
2. Locate the application startup/initialization code
3. Add a function to check if required labels exist in the configured GitHub repository
4. Implement logic to auto-create any missing labels at startup
5. Add logging for label creation events

## Files to Modify
- `internal/github/` or similar GitHub integration package — add label verification and creation methods
- `cmd/server/main.go` or application entry point — add startup label check
- `internal/config/` or configuration files — ensure GitHub repo/labels config is available

## Acceptance Criteria
1. Application checks for all required GitHub labels at startup
2. Missing labels are automatically created with correct names and colors
3. Startup completes successfully even if labels initially don't exist
4. Logs indicate which labels were created
5. No errors occur when labels already exist