### PR TITLE
[Bug] Remove redundant Provider, API key, and Base URL from settings

### DIFF
--- a/.oda/config.yaml
+++ b/.oda/config.yaml
@@ -25,32 +25,24 @@ sprint:
 llm:
     development:
         strong:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
         weak:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
     planning:
         strong:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
         weak:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
     orchestration:
         strong:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
         weak:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
     setup:
         strong:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
         weak:
-            provider: nexos-ai
-            model: Kimi K2.5
+            model: nexos-ai/Kimi K2.5
     default_complexity: medium
     routing_rules:
         complexity_thresholds:

--- a/internal/config/llm.go
+++ b/internal/config/llm.go
@@ -1,5 +1,7 @@
 package config
 
+import "strings"
+
 // TaskCategory represents the type of task for LLM routing
 type TaskCategory string
 
@@ -29,10 +31,35 @@ const (
 
 // ModelConfig represents a single LLM model configuration
 type ModelConfig struct {
-	Provider string `yaml:"provider"`           // e.g., "openai", "anthropic", "local"
-	Model    string `yaml:"model"`              // e.g., "gpt-4", "claude-3-opus"
-	APIKey   string `yaml:"api_key,omitempty"`  // Optional API key (can use env var)
-	BaseURL  string `yaml:"base_url,omitempty"` // Optional custom base URL
+	Model string `yaml:"model"` // e.g., "nexos-ai/Kimi K2.5" (format: "provider/model")
+}
+
+// ParseModel extracts the provider and model name from the Model field
+// Expected format: "provider/model" (e.g., "nexos-ai/Kimi K2.5")
+func (mc *ModelConfig) ParseModel() (provider, model string) {
+	if mc.Model == "" {
+		return "", ""
+	}
+
+	parts := strings.SplitN(mc.Model, "/", 2)
+	if len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+
+	// If no slash found, return empty provider and full string as model
+	return "", mc.Model
+}
+
+// GetProvider returns the provider from the Model field
+func (mc *ModelConfig) GetProvider() string {
+	provider, _ := mc.ParseModel()
+	return provider
+}
+
+// GetModelName returns the model name from the Model field
+func (mc *ModelConfig) GetModelName() string {
+	_, model := mc.ParseModel()
+	return model
 }
 
 // CategoryModels holds strong and weak model variants for a category
@@ -82,42 +109,34 @@ func DefaultLLMConfig() LLMConfig {
 	return LLMConfig{
 		Development: CategoryModels{
 			Strong: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 			Weak: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 		},
 		Planning: CategoryModels{
 			Strong: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 			Weak: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 		},
 		Orchestration: CategoryModels{
 			Strong: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 			Weak: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 		},
 		Setup: CategoryModels{
 			Strong: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 			Weak: ModelConfig{
-				Provider: "nexos-ai",
-				Model:    "Kimi K2.5",
+				Model: "nexos-ai/Kimi K2.5",
 			},
 		},
 		DefaultComplexity: ComplexityMedium,
@@ -172,8 +191,5 @@ func (cfg *LLMConfig) ShouldUseStrongModel(complexity ComplexityLevel, stage str
 
 // ToModelRef converts a ModelConfig to a model reference string
 func (mc *ModelConfig) ToModelRef() string {
-	if mc.Provider == "" || mc.Model == "" {
-		return ""
-	}
-	return mc.Provider + "/" + mc.Model
+	return mc.Model
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1757,48 +1757,20 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	var errors []string
 
 	// Parse Development models
-	cfg.LLM.Development.Strong.Provider = r.FormValue("development_strong_provider")
 	cfg.LLM.Development.Strong.Model = r.FormValue("development_strong_model")
-	cfg.LLM.Development.Strong.APIKey = r.FormValue("development_strong_api_key")
-	cfg.LLM.Development.Strong.BaseURL = r.FormValue("development_strong_base_url")
-
-	cfg.LLM.Development.Weak.Provider = r.FormValue("development_weak_provider")
 	cfg.LLM.Development.Weak.Model = r.FormValue("development_weak_model")
-	cfg.LLM.Development.Weak.APIKey = r.FormValue("development_weak_api_key")
-	cfg.LLM.Development.Weak.BaseURL = r.FormValue("development_weak_base_url")
 
 	// Parse Planning models
-	cfg.LLM.Planning.Strong.Provider = r.FormValue("planning_strong_provider")
 	cfg.LLM.Planning.Strong.Model = r.FormValue("planning_strong_model")
-	cfg.LLM.Planning.Strong.APIKey = r.FormValue("planning_strong_api_key")
-	cfg.LLM.Planning.Strong.BaseURL = r.FormValue("planning_strong_base_url")
-
-	cfg.LLM.Planning.Weak.Provider = r.FormValue("planning_weak_provider")
 	cfg.LLM.Planning.Weak.Model = r.FormValue("planning_weak_model")
-	cfg.LLM.Planning.Weak.APIKey = r.FormValue("planning_weak_api_key")
-	cfg.LLM.Planning.Weak.BaseURL = r.FormValue("planning_weak_base_url")
 
 	// Parse Orchestration models
-	cfg.LLM.Orchestration.Strong.Provider = r.FormValue("orchestration_strong_provider")
 	cfg.LLM.Orchestration.Strong.Model = r.FormValue("orchestration_strong_model")
-	cfg.LLM.Orchestration.Strong.APIKey = r.FormValue("orchestration_strong_api_key")
-	cfg.LLM.Orchestration.Strong.BaseURL = r.FormValue("orchestration_strong_base_url")
-
-	cfg.LLM.Orchestration.Weak.Provider = r.FormValue("orchestration_weak_provider")
 	cfg.LLM.Orchestration.Weak.Model = r.FormValue("orchestration_weak_model")
-	cfg.LLM.Orchestration.Weak.APIKey = r.FormValue("orchestration_weak_api_key")
-	cfg.LLM.Orchestration.Weak.BaseURL = r.FormValue("orchestration_weak_base_url")
 
 	// Parse Setup models
-	cfg.LLM.Setup.Strong.Provider = r.FormValue("setup_strong_provider")
 	cfg.LLM.Setup.Strong.Model = r.FormValue("setup_strong_model")
-	cfg.LLM.Setup.Strong.APIKey = r.FormValue("setup_strong_api_key")
-	cfg.LLM.Setup.Strong.BaseURL = r.FormValue("setup_strong_base_url")
-
-	cfg.LLM.Setup.Weak.Provider = r.FormValue("setup_weak_provider")
 	cfg.LLM.Setup.Weak.Model = r.FormValue("setup_weak_model")
-	cfg.LLM.Setup.Weak.APIKey = r.FormValue("setup_weak_api_key")
-	cfg.LLM.Setup.Weak.BaseURL = r.FormValue("setup_weak_base_url")
 
 	// Validate required fields
 	categories := []struct {
@@ -1813,40 +1785,37 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, cat := range categories {
-		if cat.strong.Provider == "" {
-			errors = append(errors, fmt.Sprintf("%s Strong: Provider is required", cat.name))
-		}
 		if cat.strong.Model == "" {
 			errors = append(errors, fmt.Sprintf("%s Strong: Model is required", cat.name))
-		}
-		if cat.weak.Provider == "" {
-			errors = append(errors, fmt.Sprintf("%s Weak: Provider is required", cat.name))
+		} else if !validateModelFormat(cat.strong.Model) {
+			errors = append(errors, fmt.Sprintf("%s Strong: Model must be in 'provider/model' format (e.g., 'nexos-ai/Kimi K2.5')", cat.name))
 		}
 		if cat.weak.Model == "" {
 			errors = append(errors, fmt.Sprintf("%s Weak: Model is required", cat.name))
+		} else if !validateModelFormat(cat.weak.Model) {
+			errors = append(errors, fmt.Sprintf("%s Weak: Model must be in 'provider/model' format (e.g., 'nexos-ai/Kimi K2.5')", cat.name))
 		}
 	}
 
 	// Validate model selections against available models
 	if len(s.modelsCache) > 0 {
 		modelValidations := []struct {
-			name     string
-			provider string
-			model    string
+			name  string
+			model string
 		}{
-			{"Development Strong", cfg.LLM.Development.Strong.Provider, cfg.LLM.Development.Strong.Model},
-			{"Development Weak", cfg.LLM.Development.Weak.Provider, cfg.LLM.Development.Weak.Model},
-			{"Planning Strong", cfg.LLM.Planning.Strong.Provider, cfg.LLM.Planning.Strong.Model},
-			{"Planning Weak", cfg.LLM.Planning.Weak.Provider, cfg.LLM.Planning.Weak.Model},
-			{"Orchestration Strong", cfg.LLM.Orchestration.Strong.Provider, cfg.LLM.Orchestration.Strong.Model},
-			{"Orchestration Weak", cfg.LLM.Orchestration.Weak.Provider, cfg.LLM.Orchestration.Weak.Model},
-			{"Setup Strong", cfg.LLM.Setup.Strong.Provider, cfg.LLM.Setup.Strong.Model},
-			{"Setup Weak", cfg.LLM.Setup.Weak.Provider, cfg.LLM.Setup.Weak.Model},
+			{"Development Strong", cfg.LLM.Development.Strong.Model},
+			{"Development Weak", cfg.LLM.Development.Weak.Model},
+			{"Planning Strong", cfg.LLM.Planning.Strong.Model},
+			{"Planning Weak", cfg.LLM.Planning.Weak.Model},
+			{"Orchestration Strong", cfg.LLM.Orchestration.Strong.Model},
+			{"Orchestration Weak", cfg.LLM.Orchestration.Weak.Model},
+			{"Setup Strong", cfg.LLM.Setup.Strong.Model},
+			{"Setup Weak", cfg.LLM.Setup.Weak.Model},
 		}
 
 		for _, mv := range modelValidations {
-			if mv.provider != "" && mv.model != "" && !s.validateModelSelection(mv.provider, mv.model) {
-				errors = append(errors, fmt.Sprintf("%s: Invalid model '%s/%s' - not found in available models", mv.name, mv.provider, mv.model))
+			if mv.model != "" && !s.validateModelSelection(mv.model) {
+				errors = append(errors, fmt.Sprintf("%s: Invalid model '%s' - not found in available models", mv.name, mv.model))
 			}
 		}
 	}
@@ -1943,14 +1912,23 @@ func (s *Server) renderSettingsWithErrors(w http.ResponseWriter, r *http.Request
 	s.render(w, "llm-config.html", data)
 }
 
+// validateModelFormat checks if the model string is in the correct "provider/model" format
+func validateModelFormat(model string) bool {
+	if model == "" {
+		return false
+	}
+	parts := strings.Split(model, "/")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+}
+
 // validateModelSelection checks if a model selection is valid against the cached models
-func (s *Server) validateModelSelection(provider, model string) bool {
+func (s *Server) validateModelSelection(model string) bool {
 	if len(s.modelsCache) == 0 {
 		return true // Skip validation if cache is empty (API unavailable)
 	}
 
 	for _, m := range s.modelsCache {
-		if m.ProviderID == provider && m.ID == model {
+		if m.ID == model {
 			return true
 		}
 	}

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -3681,11 +3681,9 @@ func TestHandleSettings(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	configPath := filepath.Join(odaDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -3716,8 +3714,8 @@ func TestHandleSettings(t *testing.T) {
 	if !strings.Contains(body, "Development") {
 		t.Error("response should contain 'Development' category")
 	}
-	if !strings.Contains(body, "test-provider") {
-		t.Error("response should contain the provider value from config")
+	if !strings.Contains(body, "test-provider/test-model") {
+		t.Error("response should contain the model value from config")
 	}
 }
 
@@ -3764,11 +3762,9 @@ func TestHandleSaveSettings(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: old-provider
-      model: old-model
+      model: test-provider/test-model
     weak:
-      provider: old-provider
-      model: old-model-weak
+      model: test-provider/test-model-weak
 `
 	configPath := filepath.Join(odaDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -3782,24 +3778,14 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	// Test POST /settings with valid data
 	form := url.Values{}
-	form.Set("development_strong_provider", "new-provider")
-	form.Set("development_strong_model", "new-model")
-	form.Set("development_strong_api_key", "new-api-key")
-	form.Set("development_strong_base_url", "https://new-api.example.com")
-	form.Set("development_weak_provider", "new-provider")
-	form.Set("development_weak_model", "new-model-weak")
-	form.Set("planning_strong_provider", "planning-provider")
-	form.Set("planning_strong_model", "planning-model")
-	form.Set("planning_weak_provider", "planning-provider")
-	form.Set("planning_weak_model", "planning-model-weak")
-	form.Set("orchestration_strong_provider", "orch-provider")
-	form.Set("orchestration_strong_model", "orch-model")
-	form.Set("orchestration_weak_provider", "orch-provider")
-	form.Set("orchestration_weak_model", "orch-model-weak")
-	form.Set("setup_strong_provider", "setup-provider")
-	form.Set("setup_strong_model", "setup-model")
-	form.Set("setup_weak_provider", "setup-provider")
-	form.Set("setup_weak_model", "setup-model-weak")
+	form.Set("development_strong_model", "new-provider/new-model")
+	form.Set("development_weak_model", "new-provider/new-model-weak")
+	form.Set("planning_strong_model", "planning-provider/planning-model")
+	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
+	form.Set("orchestration_strong_model", "orch-provider/orch-model")
+	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
+	form.Set("setup_strong_model", "setup-provider/setup-model")
+	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -3829,10 +3815,7 @@ func TestHandleSaveSettings(t *testing.T) {
 	}
 
 	savedContent := string(savedData)
-	if !strings.Contains(savedContent, "new-provider") {
-		t.Error("saved config should contain new provider")
-	}
-	if !strings.Contains(savedContent, "new-model") {
+	if !strings.Contains(savedContent, "new-provider/new-model") {
 		t.Error("saved config should contain new model")
 	}
 	if !strings.Contains(savedContent, "150") {
@@ -3856,11 +3839,9 @@ func TestHandleSaveSettingsValidation(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -3873,22 +3854,14 @@ func TestHandleSaveSettingsValidation(t *testing.T) {
 
 	// Test POST /settings with invalid data (empty required fields)
 	form := url.Values{}
-	form.Set("development_strong_provider", "") // Empty - should fail validation
-	form.Set("development_strong_model", "new-model")
-	form.Set("development_weak_provider", "weak-provider")
-	form.Set("development_weak_model", "weak-model")
-	form.Set("planning_strong_provider", "planning-provider")
-	form.Set("planning_strong_model", "planning-model")
-	form.Set("planning_weak_provider", "planning-provider")
-	form.Set("planning_weak_model", "planning-model-weak")
-	form.Set("orchestration_strong_provider", "orch-provider")
-	form.Set("orchestration_strong_model", "orch-model")
-	form.Set("orchestration_weak_provider", "orch-provider")
-	form.Set("orchestration_weak_model", "orch-model-weak")
-	form.Set("setup_strong_provider", "setup-provider")
-	form.Set("setup_strong_model", "setup-model")
-	form.Set("setup_weak_provider", "setup-provider")
-	form.Set("setup_weak_model", "setup-model-weak")
+	form.Set("development_strong_model", "") // Empty - should fail validation
+	form.Set("development_weak_model", "weak-provider/weak-model")
+	form.Set("planning_strong_model", "planning-provider/planning-model")
+	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
+	form.Set("orchestration_strong_model", "orch-provider/orch-model")
+	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
+	form.Set("setup_strong_model", "setup-provider/setup-model")
+	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -3906,8 +3879,8 @@ func TestHandleSaveSettingsValidation(t *testing.T) {
 
 	// Verify error message
 	body := rec.Body.String()
-	if !strings.Contains(body, "Provider is required") {
-		t.Error("response should contain validation error for empty provider")
+	if !strings.Contains(body, "Model is required") {
+		t.Error("response should contain validation error for empty model")
 	}
 }
 
@@ -3927,11 +3900,9 @@ func TestHandleSaveSettingsValidationNegativeThresholds(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -3944,22 +3915,14 @@ func TestHandleSaveSettingsValidationNegativeThresholds(t *testing.T) {
 
 	// Test POST /settings with negative threshold
 	form := url.Values{}
-	form.Set("development_strong_provider", "provider")
-	form.Set("development_strong_model", "model")
-	form.Set("development_weak_provider", "weak-provider")
-	form.Set("development_weak_model", "weak-model")
-	form.Set("planning_strong_provider", "planning-provider")
-	form.Set("planning_strong_model", "planning-model")
-	form.Set("planning_weak_provider", "planning-provider")
-	form.Set("planning_weak_model", "planning-model-weak")
-	form.Set("orchestration_strong_provider", "orch-provider")
-	form.Set("orchestration_strong_model", "orch-model")
-	form.Set("orchestration_weak_provider", "orch-provider")
-	form.Set("orchestration_weak_model", "orch-model-weak")
-	form.Set("setup_strong_provider", "setup-provider")
-	form.Set("setup_strong_model", "setup-model")
-	form.Set("setup_weak_provider", "setup-provider")
-	form.Set("setup_weak_model", "setup-model-weak")
+	form.Set("development_strong_model", "provider/model")
+	form.Set("development_weak_model", "weak-provider/weak-model")
+	form.Set("planning_strong_model", "planning-provider/planning-model")
+	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
+	form.Set("orchestration_strong_model", "orch-provider/orch-model")
+	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
+	form.Set("setup_strong_model", "setup-provider/setup-model")
+	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
 	form.Set("routing_code_size_threshold", "-1") // Negative - should fail validation
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -3998,11 +3961,9 @@ func TestSettingsPersistence(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: original-provider
-      model: original-model
+      model: original-provider/original-model
     weak:
-      provider: original-provider
-      model: original-model-weak
+      model: original-provider/original-model-weak
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4015,24 +3976,14 @@ func TestSettingsPersistence(t *testing.T) {
 
 	// Save new settings
 	form := url.Values{}
-	form.Set("development_strong_provider", "persisted-provider")
-	form.Set("development_strong_model", "persisted-model")
-	form.Set("development_strong_api_key", "persisted-key")
-	form.Set("development_strong_base_url", "https://persisted.example.com")
-	form.Set("development_weak_provider", "persisted-provider")
-	form.Set("development_weak_model", "persisted-model-weak")
-	form.Set("planning_strong_provider", "planning-provider")
-	form.Set("planning_strong_model", "planning-model")
-	form.Set("planning_weak_provider", "planning-provider")
-	form.Set("planning_weak_model", "planning-model-weak")
-	form.Set("orchestration_strong_provider", "orch-provider")
-	form.Set("orchestration_strong_model", "orch-model")
-	form.Set("orchestration_weak_provider", "orch-provider")
-	form.Set("orchestration_weak_model", "orch-model-weak")
-	form.Set("setup_strong_provider", "setup-provider")
-	form.Set("setup_strong_model", "setup-model")
-	form.Set("setup_weak_provider", "setup-provider")
-	form.Set("setup_weak_model", "setup-model-weak")
+	form.Set("development_strong_model", "persisted-provider/persisted-model")
+	form.Set("development_weak_model", "persisted-provider/persisted-model-weak")
+	form.Set("planning_strong_model", "planning-provider/planning-model")
+	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
+	form.Set("orchestration_strong_model", "orch-provider/orch-model")
+	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
+	form.Set("setup_strong_model", "setup-provider/setup-model")
+	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
 	form.Set("routing_code_size_threshold", "200")
 	form.Set("routing_high_complexity_threshold", "700")
 	form.Set("routing_file_count_threshold", "15")
@@ -4055,17 +4006,8 @@ func TestSettingsPersistence(t *testing.T) {
 	}
 
 	// Verify the values were persisted
-	if reloadedCfg.LLM.Development.Strong.Provider != "persisted-provider" {
-		t.Errorf("expected provider to be 'persisted-provider', got %q", reloadedCfg.LLM.Development.Strong.Provider)
-	}
-	if reloadedCfg.LLM.Development.Strong.Model != "persisted-model" {
-		t.Errorf("expected model to be 'persisted-model', got %q", reloadedCfg.LLM.Development.Strong.Model)
-	}
-	if reloadedCfg.LLM.Development.Strong.APIKey != "persisted-key" {
-		t.Errorf("expected API key to be 'persisted-key', got %q", reloadedCfg.LLM.Development.Strong.APIKey)
-	}
-	if reloadedCfg.LLM.Development.Strong.BaseURL != "https://persisted.example.com" {
-		t.Errorf("expected base URL to be 'https://persisted.example.com', got %q", reloadedCfg.LLM.Development.Strong.BaseURL)
+	if reloadedCfg.LLM.Development.Strong.Model != "persisted-provider/persisted-model" {
+		t.Errorf("expected model to be 'persisted-provider/persisted-model', got %q", reloadedCfg.LLM.Development.Strong.Model)
 	}
 	if reloadedCfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold != 200 {
 		t.Errorf("expected code size threshold to be 200, got %d", reloadedCfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold)
@@ -4090,11 +4032,9 @@ func TestHandleSettings_WithModels(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	configPath := filepath.Join(odaDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -4105,8 +4045,8 @@ func TestHandleSettings_WithModels(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	srv.rootDir = tmpDir
 	srv.modelsCache = []opencode.ProviderModel{
-		{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
-		{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+		{ID: "openai/gpt-4", ProviderID: "openai", Name: "GPT-4"},
+		{ID: "anthropic/claude-3", ProviderID: "anthropic", Name: "Claude 3"},
 	}
 	defer srv.wizardStore.Stop()
 
@@ -4147,11 +4087,9 @@ func TestHandleSaveSettings_InvalidModel(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4161,29 +4099,21 @@ func TestHandleSaveSettings_InvalidModel(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	srv.rootDir = tmpDir
 	srv.modelsCache = []opencode.ProviderModel{
-		{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
-		{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+		{ID: "openai/gpt-4", ProviderID: "openai", Name: "GPT-4"},
+		{ID: "anthropic/claude-3", ProviderID: "anthropic", Name: "Claude 3"},
 	}
 	defer srv.wizardStore.Stop()
 
 	// Test POST /settings with invalid model
 	form := url.Values{}
-	form.Set("development_strong_provider", "openai")
-	form.Set("development_strong_model", "invalid-model") // Invalid model
-	form.Set("development_weak_provider", "openai")
-	form.Set("development_weak_model", "gpt-4") // Valid model
-	form.Set("planning_strong_provider", "openai")
-	form.Set("planning_strong_model", "gpt-4")
-	form.Set("planning_weak_provider", "openai")
-	form.Set("planning_weak_model", "gpt-4")
-	form.Set("orchestration_strong_provider", "openai")
-	form.Set("orchestration_strong_model", "gpt-4")
-	form.Set("orchestration_weak_provider", "openai")
-	form.Set("orchestration_weak_model", "gpt-4")
-	form.Set("setup_strong_provider", "openai")
-	form.Set("setup_strong_model", "gpt-4")
-	form.Set("setup_weak_provider", "openai")
-	form.Set("setup_weak_model", "gpt-4")
+	form.Set("development_strong_model", "openai/invalid-model") // Invalid model
+	form.Set("development_weak_model", "openai/gpt-4")           // Valid model
+	form.Set("planning_strong_model", "openai/gpt-4")
+	form.Set("planning_weak_model", "openai/gpt-4")
+	form.Set("orchestration_strong_model", "openai/gpt-4")
+	form.Set("orchestration_weak_model", "openai/gpt-4")
+	form.Set("setup_strong_model", "openai/gpt-4")
+	form.Set("setup_weak_model", "openai/gpt-4")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -4225,11 +4155,9 @@ func TestHandleSaveSettings_ValidModel(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4239,29 +4167,21 @@ func TestHandleSaveSettings_ValidModel(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	srv.rootDir = tmpDir
 	srv.modelsCache = []opencode.ProviderModel{
-		{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
-		{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+		{ID: "openai/gpt-4", ProviderID: "openai", Name: "GPT-4"},
+		{ID: "anthropic/claude-3", ProviderID: "anthropic", Name: "Claude 3"},
 	}
 	defer srv.wizardStore.Stop()
 
 	// Test POST /settings with valid models
 	form := url.Values{}
-	form.Set("development_strong_provider", "openai")
-	form.Set("development_strong_model", "gpt-4")
-	form.Set("development_weak_provider", "anthropic")
-	form.Set("development_weak_model", "claude-3")
-	form.Set("planning_strong_provider", "openai")
-	form.Set("planning_strong_model", "gpt-4")
-	form.Set("planning_weak_provider", "openai")
-	form.Set("planning_weak_model", "gpt-4")
-	form.Set("orchestration_strong_provider", "openai")
-	form.Set("orchestration_strong_model", "gpt-4")
-	form.Set("orchestration_weak_provider", "openai")
-	form.Set("orchestration_weak_model", "gpt-4")
-	form.Set("setup_strong_provider", "openai")
-	form.Set("setup_strong_model", "gpt-4")
-	form.Set("setup_weak_provider", "openai")
-	form.Set("setup_weak_model", "gpt-4")
+	form.Set("development_strong_model", "openai/gpt-4")
+	form.Set("development_weak_model", "anthropic/claude-3")
+	form.Set("planning_strong_model", "openai/gpt-4")
+	form.Set("planning_weak_model", "openai/gpt-4")
+	form.Set("orchestration_strong_model", "openai/gpt-4")
+	form.Set("orchestration_weak_model", "openai/gpt-4")
+	form.Set("setup_strong_model", "openai/gpt-4")
+	form.Set("setup_weak_model", "openai/gpt-4")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -4273,12 +4193,13 @@ func TestHandleSaveSettings_ValidModel(t *testing.T) {
 	srv.handleSaveSettings(rec, req)
 
 	// Should return 200 OK with success message
+	body := rec.Body.String()
+	t.Logf("Status: %d, Body: %s", rec.Code, body)
 	if rec.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+		t.Errorf("expected status 200, got %d: %s", rec.Code, body)
 	}
 
 	// Verify success message
-	body := rec.Body.String()
 	if !strings.Contains(body, "Settings saved successfully") {
 		t.Error("response should contain success message")
 	}
@@ -4293,55 +4214,44 @@ func TestHandleSaveSettings_ValidModel(t *testing.T) {
 func TestValidateModelSelection(t *testing.T) {
 	srv := &Server{
 		modelsCache: []opencode.ProviderModel{
-			{ID: "gpt-4", ProviderID: "openai", Name: "GPT-4"},
-			{ID: "claude-3", ProviderID: "anthropic", Name: "Claude 3"},
-			{ID: "gpt-3.5", ProviderID: "openai", Name: "GPT-3.5"},
+			{ID: "openai/gpt-4", ProviderID: "openai", Name: "GPT-4"},
+			{ID: "anthropic/claude-3", ProviderID: "anthropic", Name: "Claude 3"},
+			{ID: "openai/gpt-3.5", ProviderID: "openai", Name: "GPT-3.5"},
 		},
 	}
 
 	tests := []struct {
-		name     string
-		provider string
-		model    string
-		want     bool
+		name  string
+		model string
+		want  bool
 	}{
 		{
-			name:     "valid model - openai/gpt-4",
-			provider: "openai",
-			model:    "gpt-4",
-			want:     true,
+			name:  "valid model - openai/gpt-4",
+			model: "openai/gpt-4",
+			want:  true,
 		},
 		{
-			name:     "valid model - anthropic/claude-3",
-			provider: "anthropic",
-			model:    "claude-3",
-			want:     true,
+			name:  "valid model - anthropic/claude-3",
+			model: "anthropic/claude-3",
+			want:  true,
 		},
 		{
-			name:     "invalid model - wrong provider",
-			provider: "anthropic",
-			model:    "gpt-4",
-			want:     false,
+			name:  "invalid model - nonexistent",
+			model: "openai/nonexistent-model",
+			want:  false,
 		},
 		{
-			name:     "invalid model - nonexistent",
-			provider: "openai",
-			model:    "nonexistent-model",
-			want:     false,
-		},
-		{
-			name:     "invalid model - wrong provider for claude",
-			provider: "openai",
-			model:    "claude-3",
-			want:     false,
+			name:  "invalid model - wrong format",
+			model: "gpt-4",
+			want:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := srv.validateModelSelection(tt.provider, tt.model)
+			got := srv.validateModelSelection(tt.model)
 			if got != tt.want {
-				t.Errorf("validateModelSelection(%q, %q) = %v, want %v", tt.provider, tt.model, got, tt.want)
+				t.Errorf("validateModelSelection(%q) = %v, want %v", tt.model, got, tt.want)
 			}
 		})
 	}
@@ -4354,7 +4264,7 @@ func TestValidateModelSelection_EmptyCache(t *testing.T) {
 	}
 
 	// Should return true (skip validation) when cache is empty
-	got := srv.validateModelSelection("any-provider", "any-model")
+	got := srv.validateModelSelection("any-provider/any-model")
 	if !got {
 		t.Error("validateModelSelection should return true when cache is empty (skip validation)")
 	}
@@ -4376,11 +4286,9 @@ func TestHandleSaveSettings_EmptyCache(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4394,22 +4302,14 @@ func TestHandleSaveSettings_EmptyCache(t *testing.T) {
 
 	// Test POST /settings with any model (should be allowed when cache is empty)
 	form := url.Values{}
-	form.Set("development_strong_provider", "custom-provider")
-	form.Set("development_strong_model", "custom-model")
-	form.Set("development_weak_provider", "custom-provider")
-	form.Set("development_weak_model", "another-custom-model")
-	form.Set("planning_strong_provider", "custom-provider")
-	form.Set("planning_strong_model", "custom-model")
-	form.Set("planning_weak_provider", "custom-provider")
-	form.Set("planning_weak_model", "custom-model")
-	form.Set("orchestration_strong_provider", "custom-provider")
-	form.Set("orchestration_strong_model", "custom-model")
-	form.Set("orchestration_weak_provider", "custom-provider")
-	form.Set("orchestration_weak_model", "custom-model")
-	form.Set("setup_strong_provider", "custom-provider")
-	form.Set("setup_strong_model", "custom-model")
-	form.Set("setup_weak_provider", "custom-provider")
-	form.Set("setup_weak_model", "custom-model")
+	form.Set("development_strong_model", "custom-provider/custom-model")
+	form.Set("development_weak_model", "custom-provider/another-custom-model")
+	form.Set("planning_strong_model", "custom-provider/custom-model")
+	form.Set("planning_weak_model", "custom-provider/custom-model")
+	form.Set("orchestration_strong_model", "custom-provider/custom-model")
+	form.Set("orchestration_weak_model", "custom-provider/custom-model")
+	form.Set("setup_strong_model", "custom-provider/custom-model")
+	form.Set("setup_weak_model", "custom-provider/custom-model")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -4427,8 +4327,9 @@ func TestHandleSaveSettings_EmptyCache(t *testing.T) {
 
 	// Verify success message
 	body := rec.Body.String()
+	t.Logf("Response body: %s", body)
 	if !strings.Contains(body, "Settings saved successfully") {
-		t.Error("response should contain success message when cache is empty")
+		t.Error("response should contain success message")
 	}
 
 	// Verify no validation errors about invalid models
@@ -4452,11 +4353,9 @@ func TestHandleSettingsTemplateData(t *testing.T) {
 	configContent := `llm:
   development:
     strong:
-      provider: test-provider
-      model: test-model
+      model: test-provider/test-model
     weak:
-      provider: test-provider
-      model: test-model-weak
+      model: test-provider/test-model-weak
   routing_rules:
     force_strong_for_stages:
       - stage1

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -24,45 +24,23 @@
       <div class="model-variant">
         <h3>Strong Model</h3>
         <div class="form-group">
-          <label for="development_strong_provider">Provider</label>
-          <input type="text" id="development_strong_provider" name="development_strong_provider" value="{{.Config.Development.Strong.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="development_strong_model">Model</label>
           <div class="model-dropdown" data-field="development_strong_model">
-            <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-development_strong_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="development_strong_api_key">API Key (optional)</label>
-          <input type="password" id="development_strong_api_key" name="development_strong_api_key" value="{{.Config.Development.Strong.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="development_strong_base_url">Base URL (optional)</label>
-          <input type="text" id="development_strong_base_url" name="development_strong_base_url" value="{{.Config.Development.Strong.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
       <div class="model-variant">
         <h3>Weak Model</h3>
         <div class="form-group">
-          <label for="development_weak_provider">Provider</label>
-          <input type="text" id="development_weak_provider" name="development_weak_provider" value="{{.Config.Development.Weak.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="development_weak_model">Model</label>
           <div class="model-dropdown" data-field="development_weak_model">
-            <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-development_weak_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="development_weak_api_key">API Key (optional)</label>
-          <input type="password" id="development_weak_api_key" name="development_weak_api_key" value="{{.Config.Development.Weak.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="development_weak_base_url">Base URL (optional)</label>
-          <input type="text" id="development_weak_base_url" name="development_weak_base_url" value="{{.Config.Development.Weak.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
     </div>
@@ -73,45 +51,23 @@
       <div class="model-variant">
         <h3>Strong Model</h3>
         <div class="form-group">
-          <label for="planning_strong_provider">Provider</label>
-          <input type="text" id="planning_strong_provider" name="planning_strong_provider" value="{{.Config.Planning.Strong.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="planning_strong_model">Model</label>
           <div class="model-dropdown" data-field="planning_strong_model">
-            <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-planning_strong_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="planning_strong_api_key">API Key (optional)</label>
-          <input type="password" id="planning_strong_api_key" name="planning_strong_api_key" value="{{.Config.Planning.Strong.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="planning_strong_base_url">Base URL (optional)</label>
-          <input type="text" id="planning_strong_base_url" name="planning_strong_base_url" value="{{.Config.Planning.Strong.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
       <div class="model-variant">
         <h3>Weak Model</h3>
         <div class="form-group">
-          <label for="planning_weak_provider">Provider</label>
-          <input type="text" id="planning_weak_provider" name="planning_weak_provider" value="{{.Config.Planning.Weak.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="planning_weak_model">Model</label>
           <div class="model-dropdown" data-field="planning_weak_model">
-            <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-planning_weak_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="planning_weak_api_key">API Key (optional)</label>
-          <input type="password" id="planning_weak_api_key" name="planning_weak_api_key" value="{{.Config.Planning.Weak.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="planning_weak_base_url">Base URL (optional)</label>
-          <input type="text" id="planning_weak_base_url" name="planning_weak_base_url" value="{{.Config.Planning.Weak.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
     </div>
@@ -122,45 +78,23 @@
       <div class="model-variant">
         <h3>Strong Model</h3>
         <div class="form-group">
-          <label for="orchestration_strong_provider">Provider</label>
-          <input type="text" id="orchestration_strong_provider" name="orchestration_strong_provider" value="{{.Config.Orchestration.Strong.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="orchestration_strong_model">Model</label>
           <div class="model-dropdown" data-field="orchestration_strong_model">
-            <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-orchestration_strong_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="orchestration_strong_api_key">API Key (optional)</label>
-          <input type="password" id="orchestration_strong_api_key" name="orchestration_strong_api_key" value="{{.Config.Orchestration.Strong.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="orchestration_strong_base_url">Base URL (optional)</label>
-          <input type="text" id="orchestration_strong_base_url" name="orchestration_strong_base_url" value="{{.Config.Orchestration.Strong.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
       <div class="model-variant">
         <h3>Weak Model</h3>
         <div class="form-group">
-          <label for="orchestration_weak_provider">Provider</label>
-          <input type="text" id="orchestration_weak_provider" name="orchestration_weak_provider" value="{{.Config.Orchestration.Weak.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="orchestration_weak_model">Model</label>
           <div class="model-dropdown" data-field="orchestration_weak_model">
-            <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-orchestration_weak_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="orchestration_weak_api_key">API Key (optional)</label>
-          <input type="password" id="orchestration_weak_api_key" name="orchestration_weak_api_key" value="{{.Config.Orchestration.Weak.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="orchestration_weak_base_url">Base URL (optional)</label>
-          <input type="text" id="orchestration_weak_base_url" name="orchestration_weak_base_url" value="{{.Config.Orchestration.Weak.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
     </div>
@@ -171,45 +105,23 @@
       <div class="model-variant">
         <h3>Strong Model</h3>
         <div class="form-group">
-          <label for="setup_strong_provider">Provider</label>
-          <input type="text" id="setup_strong_provider" name="setup_strong_provider" value="{{.Config.Setup.Strong.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="setup_strong_model">Model</label>
           <div class="model-dropdown" data-field="setup_strong_model">
-            <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-setup_strong_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="setup_strong_api_key">API Key (optional)</label>
-          <input type="password" id="setup_strong_api_key" name="setup_strong_api_key" value="{{.Config.Setup.Strong.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="setup_strong_base_url">Base URL (optional)</label>
-          <input type="text" id="setup_strong_base_url" name="setup_strong_base_url" value="{{.Config.Setup.Strong.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
       <div class="model-variant">
         <h3>Weak Model</h3>
         <div class="form-group">
-          <label for="setup_weak_provider">Provider</label>
-          <input type="text" id="setup_weak_provider" name="setup_weak_provider" value="{{.Config.Setup.Weak.Provider}}" required>
-        </div>
-        <div class="form-group">
           <label for="setup_weak_model">Model</label>
           <div class="model-dropdown" data-field="setup_weak_model">
-            <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="Type to search models...">
+            <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
             <div class="model-dropdown-list" id="dropdown-setup_weak_model"></div>
           </div>
-        </div>
-        <div class="form-group">
-          <label for="setup_weak_api_key">API Key (optional)</label>
-          <input type="password" id="setup_weak_api_key" name="setup_weak_api_key" value="{{.Config.Setup.Weak.APIKey}}" placeholder="Leave empty to use env var">
-        </div>
-        <div class="form-group">
-          <label for="setup_weak_base_url">Base URL (optional)</label>
-          <input type="text" id="setup_weak_base_url" name="setup_weak_base_url" value="{{.Config.Setup.Weak.BaseURL}}" placeholder="https://api.example.com">
+          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
         </div>
       </div>
     </div>
@@ -605,16 +517,6 @@ function updateSelection(list, selectedIndex) {
 function selectModel(model, input, list) {
   input.value = model.id;
   list.classList.remove('visible');
-  
-  // Update the provider field if it exists
-  const fieldName = input.getAttribute('name');
-  if (fieldName) {
-    const providerFieldName = fieldName.replace('_model', '_provider');
-    const providerInput = document.querySelector('input[name="' + providerFieldName + '"]');
-    if (providerInput) {
-      providerInput.value = model.providerID;
-    }
-  }
 }
 
 function escapeHtml(text) {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -507,12 +507,10 @@ func TestConfigToProcessorWiring(t *testing.T) {
 		LLM: config.LLMConfig{
 			Planning: config.CategoryModels{
 				Strong: config.ModelConfig{
-					Provider: "custom",
-					Model:    "custom-model-for-analysis",
+					Model: "custom/custom-model-for-analysis",
 				},
 				Weak: config.ModelConfig{
-					Provider: "custom",
-					Model:    "custom-model-for-analysis",
+					Model: "custom/custom-model-for-analysis",
 				},
 			},
 		},


### PR DESCRIPTION
Closes #263

## Description
The settings currently require separate Provider, API key, and Base URL key fields, but these are redundant when the model is already specified in "provider -> name" format. The configuration should be simplified to only require the model identifier.

## Tasks
1. Identify all settings files and configuration structs that define Provider, API key, and Base URL key fields
2. Remove the Provider field from settings - derive it from the model name format
3. Remove the API key field from settings - it should be handled elsewhere
4. Remove the Base URL key field from settings - it should be handled elsewhere
5. Update any validation logic that checks for these removed fields
6. Update default configuration templates to reflect the simplified structure
7. Test that settings load correctly with only the model field

## Files to Modify
- `internal/config/settings.go` or equivalent - Remove Provider, API key, and Base URL key fields from settings struct
- `internal/config/validation.go` or equivalent - Remove validation rules for the removed fields
- Configuration template files - Update to show only model field
- Any wizard or UI code that collects these settings - Remove input fields for Provider, API key, Base URL key

## Acceptance Criteria
1. Settings can be configured with only the model field in "provider -> name" format
2. Provider, API key, and Base URL key fields are no longer required or present in settings
3. Existing configurations without these fields load without errors
4. The application functions correctly with the simplified settings structure