### PR TITLE
[Feature] Unify model selection into per-mode dropdowns in settings

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,36 +84,29 @@ func Load(rootDir string) (*Config, error) {
 func (cfg *Config) applyLLMDefaults() {
 	defaults := DefaultLLMConfig()
 
-	// If Development strong model is empty, use defaults
-	if cfg.LLM.Development.Strong.Model == "" {
-		cfg.LLM.Development.Strong = defaults.Development.Strong
-	}
-	if cfg.LLM.Development.Weak.Model == "" {
-		cfg.LLM.Development.Weak = defaults.Development.Weak
+	// If Setup model is empty, use defaults
+	if cfg.LLM.Setup.Model == "" {
+		cfg.LLM.Setup.Model = defaults.Setup.Model
 	}
 
-	// If Planning strong model is empty, use defaults
-	if cfg.LLM.Planning.Strong.Model == "" {
-		cfg.LLM.Planning.Strong = defaults.Planning.Strong
-	}
-	if cfg.LLM.Planning.Weak.Model == "" {
-		cfg.LLM.Planning.Weak = defaults.Planning.Weak
+	// If Planning model is empty, use defaults
+	if cfg.LLM.Planning.Model == "" {
+		cfg.LLM.Planning.Model = defaults.Planning.Model
 	}
 
-	// If Orchestration strong model is empty, use defaults
-	if cfg.LLM.Orchestration.Strong.Model == "" {
-		cfg.LLM.Orchestration.Strong = defaults.Orchestration.Strong
-	}
-	if cfg.LLM.Orchestration.Weak.Model == "" {
-		cfg.LLM.Orchestration.Weak = defaults.Orchestration.Weak
+	// If Orchestration model is empty, use defaults
+	if cfg.LLM.Orchestration.Model == "" {
+		cfg.LLM.Orchestration.Model = defaults.Orchestration.Model
 	}
 
-	// If Setup strong model is empty, use defaults
-	if cfg.LLM.Setup.Strong.Model == "" {
-		cfg.LLM.Setup.Strong = defaults.Setup.Strong
+	// If Code model is empty, use defaults
+	if cfg.LLM.Code.Model == "" {
+		cfg.LLM.Code.Model = defaults.Code.Model
 	}
-	if cfg.LLM.Setup.Weak.Model == "" {
-		cfg.LLM.Setup.Weak = defaults.Setup.Weak
+
+	// If CodeHeavy model is empty, use defaults
+	if cfg.LLM.CodeHeavy.Model == "" {
+		cfg.LLM.CodeHeavy.Model = defaults.CodeHeavy.Model
 	}
 
 	// Apply default complexity if not set

--- a/internal/config/llm.go
+++ b/internal/config/llm.go
@@ -6,7 +6,8 @@ import "strings"
 type TaskCategory string
 
 const (
-	CategoryDevelopment   TaskCategory = "development"   // Complex coding tasks
+	CategoryCode          TaskCategory = "code"          // Complex coding tasks (renamed from development)
+	CategoryCodeHeavy     TaskCategory = "code-heavy"    // Heavy/complex coding tasks
 	CategoryPlanning      TaskCategory = "planning"      // Technical analysis, sprint planning
 	CategoryOrchestration TaskCategory = "orchestration" // Ticket selection, task routing
 	CategorySetup         TaskCategory = "setup"         // CI generation, project setup
@@ -22,6 +23,7 @@ const (
 )
 
 // ModelVariant represents the strength variant for a model
+// Deprecated: No longer used with per-mode model selection
 type ModelVariant string
 
 const (
@@ -62,28 +64,31 @@ func (mc *ModelConfig) GetModelName() string {
 	return model
 }
 
-// CategoryModels holds strong and weak model variants for a category
+// CategoryModels holds the model configuration for a task category
+// Now uses a single model per category instead of strong/weak variants
 type CategoryModels struct {
-	Strong ModelConfig `yaml:"strong"`
-	Weak   ModelConfig `yaml:"weak"`
+	Model string `yaml:"model"`
 }
 
 // LLMConfig holds the multi-model configuration with task-based routing
 type LLMConfig struct {
-	// Categories define models for each task type
-	Development   CategoryModels `yaml:"development"`
+	// Categories define models for each task type (5 independent modes)
+	Setup         CategoryModels `yaml:"setup"`
 	Planning      CategoryModels `yaml:"planning"`
 	Orchestration CategoryModels `yaml:"orchestration"`
-	Setup         CategoryModels `yaml:"setup"`
+	Code          CategoryModels `yaml:"code"`       // renamed from Development
+	CodeHeavy     CategoryModels `yaml:"code-heavy"` // new
 
 	// DefaultComplexity is used when no complexity hint is provided
 	DefaultComplexity ComplexityLevel `yaml:"default_complexity,omitempty"`
 
 	// RoutingRules define when to use strong vs weak models
+	// Deprecated: Complexity-based routing is being phased out in favor of explicit mode selection
 	RoutingRules RoutingConfig `yaml:"routing_rules,omitempty"`
 }
 
 // RoutingConfig defines rules for model selection
+// Deprecated: Being phased out in favor of explicit per-mode model selection
 type RoutingConfig struct {
 	// ComplexityThresholds define when to upgrade to strong model
 	ComplexityThresholds ComplexityThresholds `yaml:"complexity_thresholds,omitempty"`
@@ -93,6 +98,7 @@ type RoutingConfig struct {
 }
 
 // ComplexityThresholds defines thresholds for complexity detection
+// Deprecated: Being phased out in favor of explicit per-mode model selection
 type ComplexityThresholds struct {
 	// CodeSizeThreshold is the number of lines that triggers medium complexity
 	CodeSizeThreshold int `yaml:"code_size_threshold,omitempty"`
@@ -107,37 +113,20 @@ type ComplexityThresholds struct {
 // DefaultLLMConfig returns a default configuration with sensible defaults
 func DefaultLLMConfig() LLMConfig {
 	return LLMConfig{
-		Development: CategoryModels{
-			Strong: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
-			Weak: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
+		Setup: CategoryModels{
+			Model: "nexos-ai/Kimi K2.5",
 		},
 		Planning: CategoryModels{
-			Strong: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
-			Weak: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
+			Model: "nexos-ai/Kimi K2.5",
 		},
 		Orchestration: CategoryModels{
-			Strong: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
-			Weak: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
+			Model: "nexos-ai/Kimi K2.5",
 		},
-		Setup: CategoryModels{
-			Strong: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
-			Weak: ModelConfig{
-				Model: "nexos-ai/Kimi K2.5",
-			},
+		Code: CategoryModels{
+			Model: "nexos-ai/Kimi K2.5",
+		},
+		CodeHeavy: CategoryModels{
+			Model: "nexos-ai/Kimi K2.5",
 		},
 		DefaultComplexity: ComplexityMedium,
 		RoutingRules: RoutingConfig{
@@ -151,32 +140,27 @@ func DefaultLLMConfig() LLMConfig {
 	}
 }
 
-// GetModelForCategory returns the appropriate model config for a category and complexity
+// GetModelForCategory returns the model config for a category
+// Note: complexity parameter is now ignored - each mode has a single model
 func (cfg *LLMConfig) GetModelForCategory(category TaskCategory, complexity ComplexityLevel) ModelConfig {
-	var models CategoryModels
-
 	switch category {
-	case CategoryDevelopment:
-		models = cfg.Development
-	case CategoryPlanning:
-		models = cfg.Planning
-	case CategoryOrchestration:
-		models = cfg.Orchestration
 	case CategorySetup:
-		models = cfg.Setup
+		return ModelConfig{Model: cfg.Setup.Model}
+	case CategoryPlanning:
+		return ModelConfig{Model: cfg.Planning.Model}
+	case CategoryOrchestration:
+		return ModelConfig{Model: cfg.Orchestration.Model}
+	case CategoryCode:
+		return ModelConfig{Model: cfg.Code.Model}
+	case CategoryCodeHeavy:
+		return ModelConfig{Model: cfg.CodeHeavy.Model}
 	default:
-		models = cfg.Development
+		return ModelConfig{Model: cfg.Code.Model}
 	}
-
-	// Use strong model for high complexity or if no weak model configured
-	if complexity == ComplexityHigh || models.Weak.Model == "" {
-		return models.Strong
-	}
-
-	return models.Weak
 }
 
 // ShouldUseStrongModel determines if a task should use the strong model based on complexity
+// Deprecated: No longer relevant with per-mode model selection, kept for backward compatibility
 func (cfg *LLMConfig) ShouldUseStrongModel(complexity ComplexityLevel, stage string) bool {
 	// Check if stage is in force-strong list
 	for _, s := range cfg.RoutingRules.ForceStrongForStages {
@@ -192,4 +176,57 @@ func (cfg *LLMConfig) ShouldUseStrongModel(complexity ComplexityLevel, stage str
 // ToModelRef converts a ModelConfig to a model reference string
 func (mc *ModelConfig) ToModelRef() string {
 	return mc.Model
+}
+
+// LegacyCategoryModels holds strong and weak model variants for a category
+// Used for migration from old config format
+type LegacyCategoryModels struct {
+	Strong ModelConfig `yaml:"strong"`
+	Weak   ModelConfig `yaml:"weak"`
+}
+
+// LegacyLLMConfig represents the old config format with strong/weak variants
+type LegacyLLMConfig struct {
+	Development       LegacyCategoryModels `yaml:"development"`
+	Planning          LegacyCategoryModels `yaml:"planning"`
+	Orchestration     LegacyCategoryModels `yaml:"orchestration"`
+	Setup             LegacyCategoryModels `yaml:"setup"`
+	DefaultComplexity ComplexityLevel      `yaml:"default_complexity,omitempty"`
+	RoutingRules      RoutingConfig        `yaml:"routing_rules,omitempty"`
+}
+
+// MigrateFromLegacy converts old strong/weak format to new single-model format
+// Returns true if migration was performed
+func (cfg *LLMConfig) MigrateFromLegacy(legacy *LegacyLLMConfig) bool {
+	migrated := false
+
+	// Migrate Development -> Code (use strong model)
+	if legacy.Development.Strong.Model != "" {
+		cfg.Code.Model = legacy.Development.Strong.Model
+		migrated = true
+	}
+
+	// Migrate Planning
+	if legacy.Planning.Strong.Model != "" {
+		cfg.Planning.Model = legacy.Planning.Strong.Model
+		migrated = true
+	}
+
+	// Migrate Orchestration
+	if legacy.Orchestration.Strong.Model != "" {
+		cfg.Orchestration.Model = legacy.Orchestration.Strong.Model
+		migrated = true
+	}
+
+	// Migrate Setup
+	if legacy.Setup.Strong.Model != "" {
+		cfg.Setup.Model = legacy.Setup.Strong.Model
+		migrated = true
+	}
+
+	// Copy other settings
+	cfg.DefaultComplexity = legacy.DefaultComplexity
+	cfg.RoutingRules = legacy.RoutingRules
+
+	return migrated
 }

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -556,7 +556,8 @@ func (s *Server) render(w http.ResponseWriter, name string, data any) {
 		execName = "workers.html"
 	}
 	if err := t.ExecuteTemplate(w, execName, data); err != nil {
-		http.Error(w, "template error", http.StatusInternalServerError)
+		log.Printf("[Dashboard] Template execution error: %v", err)
+		http.Error(w, fmt.Sprintf("template error: %v", err), http.StatusInternalServerError)
 	}
 }
 
@@ -1756,44 +1757,30 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	// Parse and validate form data
 	var errors []string
 
-	// Parse Development models
-	cfg.LLM.Development.Strong.Model = r.FormValue("development_strong_model")
-	cfg.LLM.Development.Weak.Model = r.FormValue("development_weak_model")
+	// Parse model selections for each mode (5 independent dropdowns)
+	cfg.LLM.Setup.Model = r.FormValue("setup_model")
+	cfg.LLM.Planning.Model = r.FormValue("planning_model")
+	cfg.LLM.Orchestration.Model = r.FormValue("orchestration_model")
+	cfg.LLM.Code.Model = r.FormValue("code_model")
+	cfg.LLM.CodeHeavy.Model = r.FormValue("code_heavy_model")
 
-	// Parse Planning models
-	cfg.LLM.Planning.Strong.Model = r.FormValue("planning_strong_model")
-	cfg.LLM.Planning.Weak.Model = r.FormValue("planning_weak_model")
-
-	// Parse Orchestration models
-	cfg.LLM.Orchestration.Strong.Model = r.FormValue("orchestration_strong_model")
-	cfg.LLM.Orchestration.Weak.Model = r.FormValue("orchestration_weak_model")
-
-	// Parse Setup models
-	cfg.LLM.Setup.Strong.Model = r.FormValue("setup_strong_model")
-	cfg.LLM.Setup.Weak.Model = r.FormValue("setup_weak_model")
-
-	// Validate required fields
-	categories := []struct {
-		name   string
-		strong config.ModelConfig
-		weak   config.ModelConfig
+	// Validate required fields - 5 single models instead of 4 strong/weak pairs
+	modes := []struct {
+		name  string
+		model string
 	}{
-		{"Development", cfg.LLM.Development.Strong, cfg.LLM.Development.Weak},
-		{"Planning", cfg.LLM.Planning.Strong, cfg.LLM.Planning.Weak},
-		{"Orchestration", cfg.LLM.Orchestration.Strong, cfg.LLM.Orchestration.Weak},
-		{"Setup", cfg.LLM.Setup.Strong, cfg.LLM.Setup.Weak},
+		{"Setup", cfg.LLM.Setup.Model},
+		{"Planning", cfg.LLM.Planning.Model},
+		{"Orchestration", cfg.LLM.Orchestration.Model},
+		{"Code", cfg.LLM.Code.Model},
+		{"Code Heavy", cfg.LLM.CodeHeavy.Model},
 	}
 
-	for _, cat := range categories {
-		if cat.strong.Model == "" {
-			errors = append(errors, fmt.Sprintf("%s Strong: Model is required", cat.name))
-		} else if !validateModelFormat(cat.strong.Model) {
-			errors = append(errors, fmt.Sprintf("%s Strong: Model must be in 'provider/model' format (e.g., 'nexos-ai/Kimi K2.5')", cat.name))
-		}
-		if cat.weak.Model == "" {
-			errors = append(errors, fmt.Sprintf("%s Weak: Model is required", cat.name))
-		} else if !validateModelFormat(cat.weak.Model) {
-			errors = append(errors, fmt.Sprintf("%s Weak: Model must be in 'provider/model' format (e.g., 'nexos-ai/Kimi K2.5')", cat.name))
+	for _, mode := range modes {
+		if mode.model == "" {
+			errors = append(errors, fmt.Sprintf("%s: Model is required", mode.name))
+		} else if !validateModelFormat(mode.model) {
+			errors = append(errors, fmt.Sprintf("%s: Model must be in 'provider/model' format (e.g., 'nexos-ai/Kimi K2.5')", mode.name))
 		}
 	}
 
@@ -1803,14 +1790,11 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 			name  string
 			model string
 		}{
-			{"Development Strong", cfg.LLM.Development.Strong.Model},
-			{"Development Weak", cfg.LLM.Development.Weak.Model},
-			{"Planning Strong", cfg.LLM.Planning.Strong.Model},
-			{"Planning Weak", cfg.LLM.Planning.Weak.Model},
-			{"Orchestration Strong", cfg.LLM.Orchestration.Strong.Model},
-			{"Orchestration Weak", cfg.LLM.Orchestration.Weak.Model},
-			{"Setup Strong", cfg.LLM.Setup.Strong.Model},
-			{"Setup Weak", cfg.LLM.Setup.Weak.Model},
+			{"Setup", cfg.LLM.Setup.Model},
+			{"Planning", cfg.LLM.Planning.Model},
+			{"Orchestration", cfg.LLM.Orchestration.Model},
+			{"Code", cfg.LLM.Code.Model},
+			{"Code Heavy", cfg.LLM.CodeHeavy.Model},
 		}
 
 		for _, mv := range modelValidations {

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -3679,11 +3679,16 @@ func TestHandleSettings(t *testing.T) {
 
 	// Create a minimal config file
 	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
+  code:
+    model: test-provider/test-model
+  code-heavy:
+    model: test-provider/test-model-heavy
+  planning:
+    model: test-provider/test-model-planning
+  orchestration:
+    model: test-provider/test-model-orchestration
+  setup:
+    model: test-provider/test-model-setup
 `
 	configPath := filepath.Join(odaDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -3711,8 +3716,8 @@ func TestHandleSettings(t *testing.T) {
 	if !strings.Contains(body, "LLM Configuration Settings") {
 		t.Error("response should contain 'LLM Configuration Settings' heading")
 	}
-	if !strings.Contains(body, "Development") {
-		t.Error("response should contain 'Development' category")
+	if !strings.Contains(body, "Models") {
+		t.Error("response should contain 'Models' section")
 	}
 	if !strings.Contains(body, "test-provider/test-model") {
 		t.Error("response should contain the model value from config")
@@ -3778,14 +3783,11 @@ func TestHandleSaveSettings(t *testing.T) {
 
 	// Test POST /settings with valid data
 	form := url.Values{}
-	form.Set("development_strong_model", "new-provider/new-model")
-	form.Set("development_weak_model", "new-provider/new-model-weak")
-	form.Set("planning_strong_model", "planning-provider/planning-model")
-	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
-	form.Set("orchestration_strong_model", "orch-provider/orch-model")
-	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
-	form.Set("setup_strong_model", "setup-provider/setup-model")
-	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
+	form.Set("setup_model", "setup-provider/setup-model")
+	form.Set("planning_model", "planning-provider/planning-model")
+	form.Set("orchestration_model", "orch-provider/orch-model")
+	form.Set("code_model", "code-provider/code-model")
+	form.Set("code_heavy_model", "code-heavy-provider/code-heavy-model")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -3815,7 +3817,7 @@ func TestHandleSaveSettings(t *testing.T) {
 	}
 
 	savedContent := string(savedData)
-	if !strings.Contains(savedContent, "new-provider/new-model") {
+	if !strings.Contains(savedContent, "code-provider/code-model") {
 		t.Error("saved config should contain new model")
 	}
 	if !strings.Contains(savedContent, "150") {
@@ -3854,14 +3856,11 @@ func TestHandleSaveSettingsValidation(t *testing.T) {
 
 	// Test POST /settings with invalid data (empty required fields)
 	form := url.Values{}
-	form.Set("development_strong_model", "") // Empty - should fail validation
-	form.Set("development_weak_model", "weak-provider/weak-model")
-	form.Set("planning_strong_model", "planning-provider/planning-model")
-	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
-	form.Set("orchestration_strong_model", "orch-provider/orch-model")
-	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
-	form.Set("setup_strong_model", "setup-provider/setup-model")
-	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
+	form.Set("setup_model", "setup-provider/setup-model")
+	form.Set("planning_model", "planning-provider/planning-model")
+	form.Set("orchestration_model", "orch-provider/orch-model")
+	form.Set("code_model", "") // Empty - should fail validation
+	form.Set("code_heavy_model", "code-heavy-provider/code-heavy-model")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -3915,14 +3914,11 @@ func TestHandleSaveSettingsValidationNegativeThresholds(t *testing.T) {
 
 	// Test POST /settings with negative threshold
 	form := url.Values{}
-	form.Set("development_strong_model", "provider/model")
-	form.Set("development_weak_model", "weak-provider/weak-model")
-	form.Set("planning_strong_model", "planning-provider/planning-model")
-	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
-	form.Set("orchestration_strong_model", "orch-provider/orch-model")
-	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
-	form.Set("setup_strong_model", "setup-provider/setup-model")
-	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
+	form.Set("setup_model", "setup-provider/setup-model")
+	form.Set("planning_model", "planning-provider/planning-model")
+	form.Set("orchestration_model", "orch-provider/orch-model")
+	form.Set("code_model", "code-provider/code-model")
+	form.Set("code_heavy_model", "code-heavy-provider/code-heavy-model")
 	form.Set("routing_code_size_threshold", "-1") // Negative - should fail validation
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -3959,11 +3955,8 @@ func TestSettingsPersistence(t *testing.T) {
 	// Create a minimal config file
 	configPath := filepath.Join(odaDir, "config.yaml")
 	configContent := `llm:
-  development:
-    strong:
-      model: original-provider/original-model
-    weak:
-      model: original-provider/original-model-weak
+  code:
+    model: original-provider/original-model
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -3976,14 +3969,11 @@ func TestSettingsPersistence(t *testing.T) {
 
 	// Save new settings
 	form := url.Values{}
-	form.Set("development_strong_model", "persisted-provider/persisted-model")
-	form.Set("development_weak_model", "persisted-provider/persisted-model-weak")
-	form.Set("planning_strong_model", "planning-provider/planning-model")
-	form.Set("planning_weak_model", "planning-provider/planning-model-weak")
-	form.Set("orchestration_strong_model", "orch-provider/orch-model")
-	form.Set("orchestration_weak_model", "orch-provider/orch-model-weak")
-	form.Set("setup_strong_model", "setup-provider/setup-model")
-	form.Set("setup_weak_model", "setup-provider/setup-model-weak")
+	form.Set("setup_model", "setup-provider/setup-model")
+	form.Set("planning_model", "planning-provider/planning-model")
+	form.Set("orchestration_model", "orch-provider/orch-model")
+	form.Set("code_model", "persisted-provider/persisted-model")
+	form.Set("code_heavy_model", "code-heavy-provider/code-heavy-model")
 	form.Set("routing_code_size_threshold", "200")
 	form.Set("routing_high_complexity_threshold", "700")
 	form.Set("routing_file_count_threshold", "15")
@@ -4006,8 +3996,8 @@ func TestSettingsPersistence(t *testing.T) {
 	}
 
 	// Verify the values were persisted
-	if reloadedCfg.LLM.Development.Strong.Model != "persisted-provider/persisted-model" {
-		t.Errorf("expected model to be 'persisted-provider/persisted-model', got %q", reloadedCfg.LLM.Development.Strong.Model)
+	if reloadedCfg.LLM.Code.Model != "persisted-provider/persisted-model" {
+		t.Errorf("expected model to be 'persisted-provider/persisted-model', got %q", reloadedCfg.LLM.Code.Model)
 	}
 	if reloadedCfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold != 200 {
 		t.Errorf("expected code size threshold to be 200, got %d", reloadedCfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold)
@@ -4030,11 +4020,8 @@ func TestHandleSettings_WithModels(t *testing.T) {
 
 	// Create a minimal config file
 	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
+  code:
+    model: test-provider/test-model
 `
 	configPath := filepath.Join(odaDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -4085,11 +4072,8 @@ func TestHandleSaveSettings_InvalidModel(t *testing.T) {
 	// Create a minimal config file
 	configPath := filepath.Join(odaDir, "config.yaml")
 	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
+  code:
+    model: test-provider/test-model
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4106,14 +4090,11 @@ func TestHandleSaveSettings_InvalidModel(t *testing.T) {
 
 	// Test POST /settings with invalid model
 	form := url.Values{}
-	form.Set("development_strong_model", "openai/invalid-model") // Invalid model
-	form.Set("development_weak_model", "openai/gpt-4")           // Valid model
-	form.Set("planning_strong_model", "openai/gpt-4")
-	form.Set("planning_weak_model", "openai/gpt-4")
-	form.Set("orchestration_strong_model", "openai/gpt-4")
-	form.Set("orchestration_weak_model", "openai/gpt-4")
-	form.Set("setup_strong_model", "openai/gpt-4")
-	form.Set("setup_weak_model", "openai/gpt-4")
+	form.Set("setup_model", "openai/gpt-4")
+	form.Set("planning_model", "openai/gpt-4")
+	form.Set("orchestration_model", "openai/gpt-4")
+	form.Set("code_model", "openai/invalid-model") // Invalid model
+	form.Set("code_heavy_model", "openai/gpt-4")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -4153,11 +4134,8 @@ func TestHandleSaveSettings_ValidModel(t *testing.T) {
 	// Create a minimal config file
 	configPath := filepath.Join(odaDir, "config.yaml")
 	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
+  code:
+    model: test-provider/test-model
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4174,14 +4152,11 @@ func TestHandleSaveSettings_ValidModel(t *testing.T) {
 
 	// Test POST /settings with valid models
 	form := url.Values{}
-	form.Set("development_strong_model", "openai/gpt-4")
-	form.Set("development_weak_model", "anthropic/claude-3")
-	form.Set("planning_strong_model", "openai/gpt-4")
-	form.Set("planning_weak_model", "openai/gpt-4")
-	form.Set("orchestration_strong_model", "openai/gpt-4")
-	form.Set("orchestration_weak_model", "openai/gpt-4")
-	form.Set("setup_strong_model", "openai/gpt-4")
-	form.Set("setup_weak_model", "openai/gpt-4")
+	form.Set("setup_model", "openai/gpt-4")
+	form.Set("planning_model", "openai/gpt-4")
+	form.Set("orchestration_model", "openai/gpt-4")
+	form.Set("code_model", "openai/gpt-4")
+	form.Set("code_heavy_model", "anthropic/claude-3")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")
@@ -4284,11 +4259,8 @@ func TestHandleSaveSettings_EmptyCache(t *testing.T) {
 	// Create a minimal config file
 	configPath := filepath.Join(odaDir, "config.yaml")
 	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
+  code:
+    model: test-provider/test-model
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 		t.Fatalf("failed to write config file: %v", err)
@@ -4302,14 +4274,11 @@ func TestHandleSaveSettings_EmptyCache(t *testing.T) {
 
 	// Test POST /settings with any model (should be allowed when cache is empty)
 	form := url.Values{}
-	form.Set("development_strong_model", "custom-provider/custom-model")
-	form.Set("development_weak_model", "custom-provider/another-custom-model")
-	form.Set("planning_strong_model", "custom-provider/custom-model")
-	form.Set("planning_weak_model", "custom-provider/custom-model")
-	form.Set("orchestration_strong_model", "custom-provider/custom-model")
-	form.Set("orchestration_weak_model", "custom-provider/custom-model")
-	form.Set("setup_strong_model", "custom-provider/custom-model")
-	form.Set("setup_weak_model", "custom-provider/custom-model")
+	form.Set("setup_model", "custom-provider/custom-model")
+	form.Set("planning_model", "custom-provider/custom-model")
+	form.Set("orchestration_model", "custom-provider/custom-model")
+	form.Set("code_model", "custom-provider/custom-model")
+	form.Set("code_heavy_model", "custom-provider/custom-model")
 	form.Set("routing_code_size_threshold", "150")
 	form.Set("routing_high_complexity_threshold", "600")
 	form.Set("routing_file_count_threshold", "10")

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -18,111 +18,54 @@
   
   <form method="post" action="/settings" hx-post="/settings" hx-target=".settings-container" hx-swap="outerHTML">
     
-    <!-- Development Category -->
+    <!-- Models Section - 5 independent mode selectors -->
     <div class="category-section">
-      <h2>Development</h2>
-      <div class="model-variant">
-        <h3>Strong Model</h3>
-        <div class="form-group">
-          <label for="development_strong_model">Model</label>
-          <div class="model-dropdown" data-field="development_strong_model">
-            <input type="text" id="development_strong_model" name="development_strong_model" value="{{.Config.Development.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-development_strong_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
+      <h2>Models</h2>
+      <p class="section-description">Select a model for each operational mode. Each mode uses its own dedicated model.</p>
+      
+      <div class="form-group">
+        <label for="setup_model">Setup</label>
+        <div class="model-dropdown" data-field="setup_model">
+          <input type="text" id="setup_model" name="setup_model" value="{{.Config.Setup.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
+          <div class="model-dropdown-list" id="dropdown-setup_model"></div>
         </div>
+        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
-      <div class="model-variant">
-        <h3>Weak Model</h3>
-        <div class="form-group">
-          <label for="development_weak_model">Model</label>
-          <div class="model-dropdown" data-field="development_weak_model">
-            <input type="text" id="development_weak_model" name="development_weak_model" value="{{.Config.Development.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-development_weak_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
+      
+      <div class="form-group">
+        <label for="planning_model">Planning</label>
+        <div class="model-dropdown" data-field="planning_model">
+          <input type="text" id="planning_model" name="planning_model" value="{{.Config.Planning.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
+          <div class="model-dropdown-list" id="dropdown-planning_model"></div>
         </div>
+        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
-    </div>
-    
-    <!-- Planning Category -->
-    <div class="category-section">
-      <h2>Planning</h2>
-      <div class="model-variant">
-        <h3>Strong Model</h3>
-        <div class="form-group">
-          <label for="planning_strong_model">Model</label>
-          <div class="model-dropdown" data-field="planning_strong_model">
-            <input type="text" id="planning_strong_model" name="planning_strong_model" value="{{.Config.Planning.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-planning_strong_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
+      
+      <div class="form-group">
+        <label for="orchestration_model">Orchestration</label>
+        <div class="model-dropdown" data-field="orchestration_model">
+          <input type="text" id="orchestration_model" name="orchestration_model" value="{{.Config.Orchestration.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
+          <div class="model-dropdown-list" id="dropdown-orchestration_model"></div>
         </div>
+        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
-      <div class="model-variant">
-        <h3>Weak Model</h3>
-        <div class="form-group">
-          <label for="planning_weak_model">Model</label>
-          <div class="model-dropdown" data-field="planning_weak_model">
-            <input type="text" id="planning_weak_model" name="planning_weak_model" value="{{.Config.Planning.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-planning_weak_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
+      
+      <div class="form-group">
+        <label for="code_model">Code</label>
+        <div class="model-dropdown" data-field="code_model">
+          <input type="text" id="code_model" name="code_model" value="{{.Config.Code.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
+          <div class="model-dropdown-list" id="dropdown-code_model"></div>
         </div>
+        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
-    </div>
-    
-    <!-- Orchestration Category -->
-    <div class="category-section">
-      <h2>Orchestration</h2>
-      <div class="model-variant">
-        <h3>Strong Model</h3>
-        <div class="form-group">
-          <label for="orchestration_strong_model">Model</label>
-          <div class="model-dropdown" data-field="orchestration_strong_model">
-            <input type="text" id="orchestration_strong_model" name="orchestration_strong_model" value="{{.Config.Orchestration.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-orchestration_strong_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
+      
+      <div class="form-group">
+        <label for="code_heavy_model">Code Heavy</label>
+        <div class="model-dropdown" data-field="code_heavy_model">
+          <input type="text" id="code_heavy_model" name="code_heavy_model" value="{{.Config.CodeHeavy.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
+          <div class="model-dropdown-list" id="dropdown-code_heavy_model"></div>
         </div>
-      </div>
-      <div class="model-variant">
-        <h3>Weak Model</h3>
-        <div class="form-group">
-          <label for="orchestration_weak_model">Model</label>
-          <div class="model-dropdown" data-field="orchestration_weak_model">
-            <input type="text" id="orchestration_weak_model" name="orchestration_weak_model" value="{{.Config.Orchestration.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-orchestration_weak_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
-        </div>
-      </div>
-    </div>
-    
-    <!-- Setup Category -->
-    <div class="category-section">
-      <h2>Setup</h2>
-      <div class="model-variant">
-        <h3>Strong Model</h3>
-        <div class="form-group">
-          <label for="setup_strong_model">Model</label>
-          <div class="model-dropdown" data-field="setup_strong_model">
-            <input type="text" id="setup_strong_model" name="setup_strong_model" value="{{.Config.Setup.Strong.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-setup_strong_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
-        </div>
-      </div>
-      <div class="model-variant">
-        <h3>Weak Model</h3>
-        <div class="form-group">
-          <label for="setup_weak_model">Model</label>
-          <div class="model-dropdown" data-field="setup_weak_model">
-            <input type="text" id="setup_weak_model" name="setup_weak_model" value="{{.Config.Setup.Weak.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
-            <div class="model-dropdown-list" id="dropdown-setup_weak_model"></div>
-          </div>
-          <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
-        </div>
+        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
     </div>
     
@@ -178,28 +121,16 @@
 
 .category-section h2 {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
   color: var(--accent);
   font-size: 1.2rem;
 }
 
-.model-variant {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 1rem;
-  margin-bottom: 1rem;
-}
-
-.model-variant:last-child {
-  margin-bottom: 0;
-}
-
-.model-variant h3 {
+.section-description {
   margin-top: 0;
-  margin-bottom: 0.75rem;
+  margin-bottom: 1.5rem;
   color: var(--muted);
-  font-size: 1rem;
+  font-size: 0.9rem;
 }
 
 .form-group {
@@ -211,6 +142,7 @@
   margin-bottom: 0.25rem;
   color: var(--text);
   font-size: 0.9rem;
+  font-weight: 500;
 }
 
 .form-group input {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -506,12 +506,7 @@ func TestConfigToProcessorWiring(t *testing.T) {
 		},
 		LLM: config.LLMConfig{
 			Planning: config.CategoryModels{
-				Strong: config.ModelConfig{
-					Model: "custom/custom-model-for-analysis",
-				},
-				Weak: config.ModelConfig{
-					Model: "custom/custom-model-for-analysis",
-				},
+				Model: "custom/custom-model-for-analysis",
 			},
 		},
 	}

--- a/internal/llm/complexity.go
+++ b/internal/llm/complexity.go
@@ -1,10 +1,49 @@
 package llm
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/crazy-goat/one-dev-army/internal/config"
 )
+
+// countLines counts non-empty lines in text
+func countLines(text string) int {
+	if text == "" {
+		return 0
+	}
+
+	lines := strings.Split(text, "\n")
+	count := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// complexityIndicators are patterns that suggest high complexity
+var complexityIndicators = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(refactor|rearchitecture|redesign)\b`),
+	regexp.MustCompile(`(?i)\b(algorithm|complex|optimization)\b`),
+	regexp.MustCompile(`(?i)\b(concurrency|parallel|async|goroutine|thread)\b`),
+	regexp.MustCompile(`(?i)\b(distributed|microservice|service mesh)\b`),
+	regexp.MustCompile(`(?i)\b(critical|security|performance|scalability)\b`),
+	regexp.MustCompile(`(?i)\b(database migration|schema change)\b`),
+	regexp.MustCompile(`(?i)\b(api design|interface design|protocol)\b`),
+}
+
+// countComplexityIndicators counts how many high-complexity patterns are found
+func countComplexityIndicators(text string) int {
+	score := 0
+	for _, re := range complexityIndicators {
+		if re.MatchString(text) {
+			score++
+		}
+	}
+	return score
+}
 
 // ComplexityAnalyzer provides detailed complexity analysis for tasks
 type ComplexityAnalyzer struct {
@@ -213,4 +252,14 @@ func EstimateFromKeywords(text string, keywords TaskKeywords) config.ComplexityL
 	}
 
 	return config.ComplexityLow
+}
+
+// DetectComplexity analyzes context and returns complexity level
+// This is a simplified version that uses default thresholds
+// Deprecated: Complexity-based routing is being phased out
+func DetectComplexity(context string) config.ComplexityLevel {
+	thresholds := config.DefaultLLMConfig().RoutingRules.ComplexityThresholds
+	analyzer := NewComplexityAnalyzer(thresholds)
+	report := analyzer.AnalyzeTask(context, []string{}, nil)
+	return report.Complexity
 }

--- a/internal/llm/router.go
+++ b/internal/llm/router.go
@@ -3,15 +3,13 @@ package llm
 import (
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/config"
 )
 
-// Router provides intelligent model selection based on task category and complexity
+// Router provides intelligent model selection based on task category
 type Router struct {
 	cfg      *config.LLMConfig
 	mu       sync.RWMutex
@@ -27,39 +25,28 @@ func NewRouter(cfg *config.LLMConfig) *Router {
 }
 
 // SelectModel returns the appropriate model reference for a task
+// The complexity parameter is kept for backward compatibility but is now ignored
+// Each task category has a single dedicated model
 func (r *Router) SelectModel(category config.TaskCategory, complexity config.ComplexityLevel, hints map[string]any) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// Check for stage override in hints
-	if stage, ok := hints["stage"].(string); ok {
-		if r.cfg.ShouldUseStrongModel(complexity, stage) {
-			return r.getStrongModel(category)
-		}
-	}
-
-	// Use complexity-based selection
+	// Get model for category (each mode has a single model now)
 	modelCfg := r.cfg.GetModelForCategory(category, complexity)
 	return modelCfg.ToModelRef()
 }
 
 // SelectModelForStage returns the appropriate model for a pipeline stage
+// Uses the new per-mode model selection
 func (r *Router) SelectModelForStage(stage string, context string) string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// Detect complexity from context
-	complexity := DetectComplexity(context, r.cfg.RoutingRules.ComplexityThresholds)
-
 	// Determine category based on stage
 	category := r.categoryForStage(stage)
 
-	// Check if stage should always use strong model
-	if r.cfg.ShouldUseStrongModel(complexity, stage) {
-		return r.getStrongModel(category)
-	}
-
-	modelCfg := r.cfg.GetModelForCategory(category, complexity)
+	// Get model for category (complexity is now ignored)
+	modelCfg := r.cfg.GetModelForCategory(category, config.ComplexityMedium)
 	return modelCfg.ToModelRef()
 }
 
@@ -68,32 +55,21 @@ func (r *Router) categoryForStage(stage string) config.TaskCategory {
 	switch stage {
 	case "analysis", "planning", "plan-review":
 		return config.CategoryPlanning
-	case "coding", "testing":
-		return config.CategoryDevelopment
-	case "code-review":
-		return config.CategoryDevelopment
+	case "coding", "testing", "code-review":
+		return config.CategoryCode
+	case "orchestration", "ticket-selection":
+		return config.CategoryOrchestration
+	case "setup", "ci-generation", "project-setup":
+		return config.CategorySetup
 	default:
-		return config.CategoryDevelopment
+		return config.CategoryCode
 	}
 }
 
-// getStrongModel returns the strong model reference for a category
-func (r *Router) getStrongModel(category config.TaskCategory) string {
-	var modelCfg config.ModelConfig
-
-	switch category {
-	case config.CategoryDevelopment:
-		modelCfg = r.cfg.Development.Strong
-	case config.CategoryPlanning:
-		modelCfg = r.cfg.Planning.Strong
-	case config.CategoryOrchestration:
-		modelCfg = r.cfg.Orchestration.Strong
-	case config.CategorySetup:
-		modelCfg = r.cfg.Setup.Strong
-	default:
-		modelCfg = r.cfg.Development.Strong
-	}
-
+// getModelForCategory returns the model for a specific category
+// This replaces the old getStrongModel function
+func (r *Router) getModelForCategory(category config.TaskCategory) string {
+	modelCfg := r.cfg.GetModelForCategory(category, config.ComplexityMedium)
 	return modelCfg.ToModelRef()
 }
 
@@ -126,115 +102,14 @@ func (r *Router) GetConfig() config.LLMConfig {
 	return *r.cfg
 }
 
-// ComplexityDetector provides utilities for detecting task complexity
-type ComplexityDetector struct {
-	thresholds config.ComplexityThresholds
-}
-
-// NewComplexityDetector creates a new complexity detector
-func NewComplexityDetector(thresholds config.ComplexityThresholds) *ComplexityDetector {
-	return &ComplexityDetector{
-		thresholds: thresholds,
-	}
-}
-
-// DetectComplexity analyzes context and returns complexity level
-func DetectComplexity(context string, thresholds config.ComplexityThresholds) config.ComplexityLevel {
-	if thresholds.CodeSizeThreshold == 0 {
-		thresholds = config.DefaultLLMConfig().RoutingRules.ComplexityThresholds
-	}
-
-	// Count lines of code/context
-	lines := countLines(context)
-
-	// Check for high complexity indicators
-	highComplexityScore := 0
-
-	// Large code size
-	if lines > thresholds.HighComplexityThreshold {
-		highComplexityScore += 3
-	} else if lines > thresholds.CodeSizeThreshold {
-		highComplexityScore += 1
-	}
-
-	// Complex patterns
-	highComplexityScore += countComplexityIndicators(context)
-
-	// File references
-	fileCount := countFileReferences(context)
-	if fileCount > thresholds.FileCountThreshold {
-		highComplexityScore += 2
-	} else if fileCount > 2 {
-		highComplexityScore += 1
-	}
-
-	// Determine complexity level
-	if highComplexityScore >= 4 {
-		return config.ComplexityHigh
-	} else if highComplexityScore >= 2 {
-		return config.ComplexityMedium
-	}
-
-	return config.ComplexityLow
-}
-
-// countLines counts non-empty lines in text
-func countLines(text string) int {
-	if text == "" {
-		return 0
-	}
-
-	lines := strings.Split(text, "\n")
-	count := 0
-	for _, line := range lines {
-		if strings.TrimSpace(line) != "" {
-			count++
-		}
-	}
-	return count
-}
-
-// complexityIndicators are patterns that suggest high complexity
-var complexityIndicators = []*regexp.Regexp{
-	regexp.MustCompile(`(?i)\b(refactor|rearchitecture|redesign)\b`),
-	regexp.MustCompile(`(?i)\b(algorithm|complex|optimization)\b`),
-	regexp.MustCompile(`(?i)\b(concurrency|parallel|async|goroutine|thread)\b`),
-	regexp.MustCompile(`(?i)\b(distributed|microservice|service mesh)\b`),
-	regexp.MustCompile(`(?i)\b(critical|security|performance|scalability)\b`),
-	regexp.MustCompile(`(?i)\b(database migration|schema change)\b`),
-	regexp.MustCompile(`(?i)\b(api design|interface design|protocol)\b`),
-}
-
-// countComplexityIndicators counts how many high-complexity patterns are found
-func countComplexityIndicators(text string) int {
-	score := 0
-	for _, re := range complexityIndicators {
-		if re.MatchString(text) {
-			score++
-		}
-	}
-	return score
-}
-
-// fileReferencePattern matches file path references
-var fileReferencePattern = regexp.MustCompile(`[a-zA-Z0-9_/-]+\.[a-zA-Z0-9]+`)
-
-// countFileReferences counts unique file references in text
-func countFileReferences(text string) int {
-	matches := fileReferencePattern.FindAllString(text, -1)
-	unique := make(map[string]bool)
-	for _, m := range matches {
-		unique[m] = true
-	}
-	return len(unique)
-}
-
 // RoutingHints provides a builder for routing hints
+// Deprecated: Hints are no longer used for model selection
 type RoutingHints struct {
 	hints map[string]any
 }
 
 // NewRoutingHints creates a new routing hints builder
+// Deprecated: Hints are no longer used for model selection
 func NewRoutingHints() *RoutingHints {
 	return &RoutingHints{
 		hints: make(map[string]any),

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -18,14 +18,14 @@ func TestRouter_SelectModel(t *testing.T) {
 		wantNonEmpty bool
 	}{
 		{
-			name:         "development low complexity",
-			category:     config.CategoryDevelopment,
+			name:         "code low complexity",
+			category:     config.CategoryCode,
 			complexity:   config.ComplexityLow,
 			wantNonEmpty: true,
 		},
 		{
-			name:         "development high complexity",
-			category:     config.CategoryDevelopment,
+			name:         "code high complexity",
+			category:     config.CategoryCode,
 			complexity:   config.ComplexityHigh,
 			wantNonEmpty: true,
 		},
@@ -111,14 +111,14 @@ func TestRouter_UpdateConfig(t *testing.T) {
 
 	// Test that config can be updated
 	newCfg := config.DefaultLLMConfig()
-	newCfg.Development.Strong.Model = "new-strong-model"
+	newCfg.Code.Model = "new-code-model"
 
 	router.UpdateConfig(&newCfg)
 
 	// Verify the update
 	updatedCfg := router.GetConfig()
-	if updatedCfg.Development.Strong.Model != "new-strong-model" {
-		t.Errorf("UpdateConfig() failed, model = %q, want %q", updatedCfg.Development.Strong.Model, "new-strong-model")
+	if updatedCfg.Code.Model != "new-code-model" {
+		t.Errorf("UpdateConfig() failed, model = %q, want %q", updatedCfg.Code.Model, "new-code-model")
 	}
 }
 
@@ -142,55 +142,6 @@ func TestRouter_OnReload(t *testing.T) {
 		// This is expected since the callback runs in a goroutine
 		// In a real scenario, you'd wait for it
 		t.Log("Reload callback registered (may not have executed yet due to goroutine)")
-	}
-}
-
-func TestDetectComplexity(t *testing.T) {
-	thresholds := config.ComplexityThresholds{
-		CodeSizeThreshold:       100,
-		HighComplexityThreshold: 500,
-		FileCountThreshold:      5,
-	}
-
-	tests := []struct {
-		name     string
-		context  string
-		expected config.ComplexityLevel
-	}{
-		{
-			name:     "empty context",
-			context:  "",
-			expected: config.ComplexityLow,
-		},
-		{
-			name:     "simple task",
-			context:  "Fix typo in README",
-			expected: config.ComplexityLow,
-		},
-		{
-			name:     "medium complexity indicators",
-			context:  "Implement new feature with API endpoint and validation",
-			expected: config.ComplexityLow, // Scoring gives 1 point, which is low
-		},
-		{
-			name:     "high complexity indicators",
-			context:  "Refactor the authentication system with microservices architecture and distributed database",
-			expected: config.ComplexityMedium, // Scoring gives 3 points (refactor=1, microservices=1, distributed=1), which is medium
-		},
-		{
-			name:     "large code size",
-			context:  generateLargeContext(600),
-			expected: config.ComplexityMedium, // 600 lines gives 3 points, which is medium (need 4+ for high)
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := llm.DetectComplexity(tt.context, thresholds)
-			if got != tt.expected {
-				t.Errorf("DetectComplexity() = %v, want %v", got, tt.expected)
-			}
-		})
 	}
 }
 

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -450,11 +450,11 @@ func (w *Worker) implement(ctx context.Context, task *Task, planStr string) erro
 	}
 	prompt := fmt.Sprintf(implementationPrompt, task.Issue.Number, task.Issue.Title, planStr, task.Worktree, testCmd)
 
-	// Use router to select model for development category with complexity detection
+	// Use router to select model for code category with complexity detection
 	llmModel := w.cfg.EpicAnalysis.LLM
 	if w.router != nil {
-		complexity := llm.DetectComplexity(planStr, w.router.GetConfig().RoutingRules.ComplexityThresholds)
-		llmModel = w.router.SelectModel(config.CategoryDevelopment, complexity, nil)
+		complexity := llm.DetectComplexity(planStr)
+		llmModel = w.router.SelectModel(config.CategoryCode, complexity, nil)
 	}
 
 	_, err = w.llmStep(ctx, task, "implement", prompt, llmModel)
@@ -486,10 +486,10 @@ func (w *Worker) fixFromReview(ctx context.Context, task *Task, review string) e
 	}
 	prompt := fmt.Sprintf(fixFromReviewPrompt, task.Issue.Number, task.Issue.Title, task.Worktree, testCmd, review)
 
-	// Use router to select model for development category
+	// Use router to select model for code category
 	llmModel := w.cfg.EpicAnalysis.LLM
 	if w.router != nil {
-		llmModel = w.router.SelectModel(config.CategoryDevelopment, config.ComplexityMedium, nil)
+		llmModel = w.router.SelectModel(config.CategoryCode, config.ComplexityMedium, nil)
 	}
 
 	_, err := w.llmStep(ctx, task, "fix-from-review", prompt, llmModel)
@@ -546,11 +546,11 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string) (appr
 		}
 	}
 
-	// Use router to select model for development category with high complexity (code review is important)
+	// Use router to select model for code category with high complexity (code review is important)
 	llmModel := w.cfg.Planning.LLM
 	if w.router != nil {
 		hints := map[string]any{"stage": "code-review"}
-		llmModel = w.router.SelectModel(config.CategoryDevelopment, config.ComplexityHigh, hints)
+		llmModel = w.router.SelectModel(config.CategoryCode, config.ComplexityHigh, hints)
 	}
 
 	model := opencode.ParseModelRef(llmModel)

--- a/internal/scheduler/epic.go
+++ b/internal/scheduler/epic.go
@@ -43,7 +43,7 @@ func (ea *EpicAnalyzer) Analyze(description string) ([]TaskSpec, error) {
 	// Use router to select model for planning category with complexity detection
 	llmModel := ea.cfg.EpicAnalysis.LLM
 	if ea.router != nil {
-		complexity := llm.DetectComplexity(description, ea.router.GetConfig().RoutingRules.ComplexityThresholds)
+		complexity := llm.DetectComplexity(description)
 		routerModel := ea.router.SelectModel(config.CategoryPlanning, complexity, nil)
 		if routerModel != "" {
 			llmModel = routerModel

--- a/main.go
+++ b/main.go
@@ -413,15 +413,12 @@ func collectConfigModels(cfg *config.Config) []opencode.ModelRef {
 	add(cfg.Planning.LLM)
 	add(cfg.EpicAnalysis.LLM)
 
-	// Add models from new LLM config
-	add(cfg.LLM.Development.Strong.ToModelRef())
-	add(cfg.LLM.Development.Weak.ToModelRef())
-	add(cfg.LLM.Planning.Strong.ToModelRef())
-	add(cfg.LLM.Planning.Weak.ToModelRef())
-	add(cfg.LLM.Orchestration.Strong.ToModelRef())
-	add(cfg.LLM.Orchestration.Weak.ToModelRef())
-	add(cfg.LLM.Setup.Strong.ToModelRef())
-	add(cfg.LLM.Setup.Weak.ToModelRef())
+	// Add models from new LLM config (5 independent modes)
+	add(cfg.LLM.Setup.Model)
+	add(cfg.LLM.Planning.Model)
+	add(cfg.LLM.Orchestration.Model)
+	add(cfg.LLM.Code.Model)
+	add(cfg.LLM.CodeHeavy.Model)
 
 	return models
 }


### PR DESCRIPTION
Closes #265

## Description
Refactor the settings UI to replace the current "Strong Model" and "Weak Model" separation with a unified model selection interface. Each operational mode (Setup, Planning, Orchestration, Code, Code Heavy) will have its own independent model dropdown selector, providing more granular control over model selection.

## Tasks
1. Locate the settings page/component that currently displays "Strong Model" and "Weak Model" dropdowns
2. Remove the existing dual-model layout and replace with a single "Models" section
3. Add five model dropdown selectors labeled: Setup, Planning, Orchestration, Code, Code Heavy
4. Update the settings data structure to store model selection per mode instead of strong/weak
5. Ensure selected models persist correctly in settings storage
6. Update any validation logic that references strong/weak model configuration

## Files to Modify
- `internal/dashboard/settings.go` or equivalent settings UI component - Replace dual-model layout with per-mode model selectors
- Settings configuration struct - Change from StrongModel/WeakModel fields to ModeModels map or individual mode fields
- Settings persistence layer - Update save/load logic for new model configuration format

## Acceptance Criteria
- [ ] Settings page displays a "Models" section with 5 dropdown selectors (Setup, Planning, Orchestration, Code, Code Heavy)
- [ ] Each dropdown shows available models and allows selection
- [ ] Selected models are saved and persist across application restarts
- [ ] No references to "Strong Model" or "Weak Model" remain in the UI
- [ ] Existing settings migrate gracefully or reset to defaults without errors