### PR TITLE
[Bug] Settings save fails with invalid model error for unavailable model

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ type Sprint struct {
 	TasksPerSprint int `yaml:"tasks_per_sprint"`
 }
 
-func Load(rootDir string) (*Config, error) {
+func Load(rootDir string, availableModels ...string) (*Config, error) {
 	path := filepath.Join(rootDir, ".oda", "config.yaml")
 
 	data, err := os.ReadFile(path)
@@ -76,6 +76,11 @@ func Load(rootDir string) (*Config, error) {
 
 	// Apply default LLM config if not fully specified
 	cfg.applyLLMDefaults()
+
+	// Validate and fallback models if available list provided
+	if len(availableModels) > 0 {
+		cfg.LLM.ValidateAndFallbackModels(availableModels)
+	}
 
 	return &cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -163,3 +163,173 @@ func TestLoad_InvalidYAML(t *testing.T) {
 		t.Fatal("expected error for invalid YAML, got nil")
 	}
 }
+
+func TestLoad_WithModelValidation(t *testing.T) {
+	configWithModels := `llm:
+  setup:
+    model: "nexos-ai/Invalid-Model"
+  planning:
+    model: "nexos-ai/Kimi K2.5"
+  orchestration:
+    model: ""
+  code:
+    model: "nexos-ai/Another-Invalid"
+  code-heavy:
+    model: "nexos-ai/Kimi K2.5"
+`
+	dir := setupConfigDir(t, configWithModels)
+
+	availableModels := []string{"nexos-ai/Kimi K2.5", "nexos-ai/Claude-3-Opus"}
+
+	cfg, err := config.Load(dir, availableModels...)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Invalid models should fallback to first available
+	if cfg.LLM.Setup.Model != "nexos-ai/Kimi K2.5" {
+		t.Errorf("setup model should fallback to first available, got %q", cfg.LLM.Setup.Model)
+	}
+
+	// Valid model should remain unchanged
+	if cfg.LLM.Planning.Model != "nexos-ai/Kimi K2.5" {
+		t.Errorf("planning model should remain unchanged, got %q", cfg.LLM.Planning.Model)
+	}
+
+	// Empty model should fallback to first available
+	if cfg.LLM.Orchestration.Model != "nexos-ai/Kimi K2.5" {
+		t.Errorf("orchestration model should fallback to first available, got %q", cfg.LLM.Orchestration.Model)
+	}
+
+	// Another invalid model should fallback
+	if cfg.LLM.Code.Model != "nexos-ai/Kimi K2.5" {
+		t.Errorf("code model should fallback to first available, got %q", cfg.LLM.Code.Model)
+	}
+}
+
+func TestLoad_WithEmptyAvailableModels(t *testing.T) {
+	configWithModels := `llm:
+  setup:
+    model: "nexos-ai/Some-Model"
+  planning:
+    model: "nexos-ai/Another-Model"
+`
+	dir := setupConfigDir(t, configWithModels)
+
+	// Pass empty available models - should skip validation
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Models should remain as configured when no validation is performed
+	if cfg.LLM.Setup.Model != "nexos-ai/Some-Model" {
+		t.Errorf("setup model should remain unchanged, got %q", cfg.LLM.Setup.Model)
+	}
+}
+
+func TestValidateAndFallbackModels(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupModel      string
+		planningModel   string
+		availableModels []string
+		wantSetup       string
+		wantPlanning    string
+		wantReplaced    bool
+	}{
+		{
+			name:            "all valid models",
+			setupModel:      "provider/model1",
+			planningModel:   "provider/model2",
+			availableModels: []string{"provider/model1", "provider/model2"},
+			wantSetup:       "provider/model1",
+			wantPlanning:    "provider/model2",
+			wantReplaced:    false,
+		},
+		{
+			name:            "one invalid model",
+			setupModel:      "provider/invalid",
+			planningModel:   "provider/model2",
+			availableModels: []string{"provider/model1", "provider/model2"},
+			wantSetup:       "provider/model1",
+			wantPlanning:    "provider/model2",
+			wantReplaced:    true,
+		},
+		{
+			name:            "empty available models",
+			setupModel:      "provider/model1",
+			planningModel:   "provider/model2",
+			availableModels: []string{},
+			wantSetup:       "provider/model1",
+			wantPlanning:    "provider/model2",
+			wantReplaced:    false,
+		},
+		{
+			name:            "empty model falls back",
+			setupModel:      "",
+			planningModel:   "provider/model2",
+			availableModels: []string{"provider/model1", "provider/model2"},
+			wantSetup:       "provider/model1",
+			wantPlanning:    "provider/model2",
+			wantReplaced:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.LLMConfig{
+				Setup:         config.CategoryModels{Model: tt.setupModel},
+				Planning:      config.CategoryModels{Model: tt.planningModel},
+				Orchestration: config.CategoryModels{Model: tt.setupModel},
+				Code:          config.CategoryModels{Model: tt.setupModel},
+				CodeHeavy:     config.CategoryModels{Model: tt.setupModel},
+			}
+
+			result := cfg.ValidateAndFallbackModels(tt.availableModels)
+
+			if cfg.Setup.Model != tt.wantSetup {
+				t.Errorf("setup model = %q, want %q", cfg.Setup.Model, tt.wantSetup)
+			}
+			if cfg.Planning.Model != tt.wantPlanning {
+				t.Errorf("planning model = %q, want %q", cfg.Planning.Model, tt.wantPlanning)
+			}
+			if result.HasReplacements != tt.wantReplaced {
+				t.Errorf("HasReplacements = %v, want %v", result.HasReplacements, tt.wantReplaced)
+			}
+		})
+	}
+}
+
+func TestGetFirstAvailableModel(t *testing.T) {
+	tests := []struct {
+		name            string
+		availableModels []string
+		want            string
+	}{
+		{
+			name:            "has models",
+			availableModels: []string{"model1", "model2"},
+			want:            "model1",
+		},
+		{
+			name:            "empty list",
+			availableModels: []string{},
+			want:            "",
+		},
+		{
+			name:            "nil list",
+			availableModels: nil,
+			want:            "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.GetFirstAvailableModel(tt.availableModels)
+			if got != tt.want {
+				t.Errorf("GetFirstAvailableModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/llm.go
+++ b/internal/config/llm.go
@@ -230,3 +230,78 @@ func (cfg *LLMConfig) MigrateFromLegacy(legacy *LegacyLLMConfig) bool {
 
 	return migrated
 }
+
+// ModelValidationResult tracks which models were replaced during validation
+type ModelValidationResult struct {
+	ReplacedModels map[string]struct {
+		OldModel string
+		NewModel string
+	}
+	HasReplacements bool
+}
+
+// ValidateAndFallbackModels validates all models against available models and falls back to first available if invalid
+// Returns a result indicating which models were replaced
+func (cfg *LLMConfig) ValidateAndFallbackModels(availableModels []string) ModelValidationResult {
+	result := ModelValidationResult{
+		ReplacedModels: make(map[string]struct {
+			OldModel string
+			NewModel string
+		}),
+	}
+
+	// If no available models, skip validation (API might be unavailable)
+	if len(availableModels) == 0 {
+		return result
+	}
+
+	// Build set of available models for O(1) lookup
+	availableSet := make(map[string]bool)
+	for _, m := range availableModels {
+		availableSet[m] = true
+	}
+
+	// Get first available model as fallback
+	fallbackModel := availableModels[0]
+
+	// Validate and fallback each model
+	modes := []struct {
+		name      string
+		model     *string
+		defaultTo string
+	}{
+		{"Setup", &cfg.Setup.Model, fallbackModel},
+		{"Planning", &cfg.Planning.Model, fallbackModel},
+		{"Orchestration", &cfg.Orchestration.Model, fallbackModel},
+		{"Code", &cfg.Code.Model, fallbackModel},
+		{"CodeHeavy", &cfg.CodeHeavy.Model, fallbackModel},
+	}
+
+	for _, mode := range modes {
+		if *mode.model == "" || !availableSet[*mode.model] {
+			oldModel := *mode.model
+			if oldModel == "" {
+				oldModel = "(empty)"
+			}
+			*mode.model = mode.defaultTo
+			result.ReplacedModels[mode.name] = struct {
+				OldModel string
+				NewModel string
+			}{
+				OldModel: oldModel,
+				NewModel: mode.defaultTo,
+			}
+			result.HasReplacements = true
+		}
+	}
+
+	return result
+}
+
+// GetFirstAvailableModel returns the first available model from the list, or empty if none available
+func GetFirstAvailableModel(availableModels []string) string {
+	if len(availableModels) > 0 {
+		return availableModels[0]
+	}
+	return ""
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1682,8 +1682,9 @@ type settingsData struct {
 
 // handleSettings renders the LLM configuration settings page
 func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
-	// Load current config
-	cfg, err := config.Load(s.rootDir)
+	// Load current config with model validation and fallback
+	availableModels := s.GetAvailableModelIDs()
+	cfg, err := config.Load(s.rootDir, availableModels...)
 	if err != nil {
 		log.Printf("[Dashboard] Error loading config: %v", err)
 		// Use default config if load fails
@@ -1721,6 +1722,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Parse and validate form data
 	var errors []string
+	var warnings []string
 
 	// Parse model selections for each mode (5 independent dropdowns)
 	cfg.LLM.Setup.Model = r.FormValue("setup_model")
@@ -1749,22 +1751,25 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Validate model selections against available models
-	if len(s.modelsCache) > 0 {
-		modelValidations := []struct {
-			name  string
-			model string
-		}{
-			{"Setup", cfg.LLM.Setup.Model},
-			{"Planning", cfg.LLM.Planning.Model},
-			{"Orchestration", cfg.LLM.Orchestration.Model},
-			{"Code", cfg.LLM.Code.Model},
-			{"Code Heavy", cfg.LLM.CodeHeavy.Model},
-		}
+	// If there are format errors, stop here
+	if len(errors) > 0 {
+		s.renderSettingsWithErrors(w, r, errors)
+		return
+	}
 
-		for _, mv := range modelValidations {
-			if mv.model != "" && !s.validateModelSelection(mv.model) {
-				errors = append(errors, fmt.Sprintf("%s: Invalid model '%s' - not found in available models", mv.name, mv.model))
+	// Validate and fallback models against available models
+	availableModels := s.GetAvailableModelIDs()
+	if len(availableModels) > 0 {
+		validationResult := cfg.LLM.ValidateAndFallbackModels(availableModels)
+
+		// Add warnings for replaced models instead of errors
+		if validationResult.HasReplacements {
+			for modeName, replacement := range validationResult.ReplacedModels {
+				if replacement.OldModel == "(empty)" {
+					warnings = append(warnings, fmt.Sprintf("%s: No model was selected, defaulted to '%s'", modeName, replacement.NewModel))
+				} else {
+					warnings = append(warnings, fmt.Sprintf("%s: Model '%s' is not available, fell back to '%s'", modeName, replacement.OldModel, replacement.NewModel))
+				}
 			}
 		}
 	}
@@ -1822,7 +1827,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[Dashboard] LLM configuration saved successfully")
 
-	// Re-render with success message
+	// Re-render with success message and any warnings
 	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ")
 	data := settingsData{
 		Active:            "settings",
@@ -1830,6 +1835,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
 		Success:           true,
+		Errors:            warnings, // Show warnings as info messages
 		AvailableModels:   s.modelsCache,
 	}
 

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -4059,7 +4059,7 @@ func TestHandleSettings_WithModels(t *testing.T) {
 	}
 }
 
-// TestHandleSaveSettings_InvalidModel verifies that validation rejects invalid models
+// TestHandleSaveSettings_InvalidModel verifies that invalid models are replaced with fallback
 func TestHandleSaveSettings_InvalidModel(t *testing.T) {
 	// Create a temporary directory for config
 	tmpDir := t.TempDir()
@@ -4106,18 +4106,20 @@ func TestHandleSaveSettings_InvalidModel(t *testing.T) {
 
 	srv.handleSaveSettings(rec, req)
 
-	// Should return 200 OK but with error message
+	// Should return 200 OK (success with fallback)
 	if rec.Code != http.StatusOK {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	// Verify error message about invalid model
+	// Verify success message (not error)
 	body := rec.Body.String()
-	if !strings.Contains(body, "Invalid model") {
-		t.Error("response should contain validation error for invalid model")
+	if !strings.Contains(body, "saved successfully") {
+		t.Errorf("response should contain success message, got: %s", body)
 	}
-	if !strings.Contains(body, "invalid-model") {
-		t.Error("response should mention the invalid model name")
+
+	// Verify warning about model fallback
+	if !strings.Contains(body, "not available") && !strings.Contains(body, "fell back") {
+		t.Error("response should contain warning about model fallback")
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -267,6 +267,19 @@ func (s *Server) Hub() *Hub {
 	return s.hub
 }
 
+// GetAvailableModelIDs returns a list of available model IDs from the cache
+func (s *Server) GetAvailableModelIDs() []string {
+	if len(s.modelsCache) == 0 {
+		return nil
+	}
+
+	ids := make([]string, len(s.modelsCache))
+	for i, m := range s.modelsCache {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
 // handleWebSocket handles WebSocket upgrade requests
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	ServeWs(s.hub, w, r)


### PR DESCRIPTION
Closes #268

## Description
When users click "Save" in settings without making any changes, an error appears stating "Invalid model 'nexos-ai/Kimi K2.5' - not found in available models" across all agent types (Setup, Planning, Orchestration, Code, Code Heavy). This suggests the saved model configuration contains a model that is no longer available in the system, and the validation is failing on save.

## Tasks
1. Locate the settings save handler and model validation logic
2. Identify where the model 'nexos-ai/Kimi K2.5' is being referenced in saved configurations
3. Add validation to check if saved models exist in the available models list before attempting to use them
4. Implement fallback logic to select a default valid model when a saved model is no longer available
5. Update error handling to provide clearer messaging about which specific model is invalid

## Files to Modify
- `internal/dashboard/settings.go` or similar - settings save handler and validation logic
- `internal/llm/models.go` or similar - available models list and validation functions
- Configuration storage files where model preferences are persisted

## Acceptance Criteria
1. Users can save settings without errors even if their previously selected model is no longer available
2. The system gracefully falls back to a valid default model when a saved model is invalid
3. Clear error messages indicate which specific model is unavailable and what model was selected as fallback
4. The fix handles all agent types (Setup, Planning, Orchestration, Code, Code Heavy) consistently