### PR TITLE
[Feature] Isolate opencode.Client per worker to fix race condition

### DIFF
--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -70,7 +70,7 @@ func NewOrchestrator(cfg *config.Config, gh *github.Client, oc *opencode.Client,
 		router: router,
 		paused: true,
 	}
-	o.worker = NewWorker(1, cfg, oc, gh, brMgr, store, o, router)
+	o.worker = NewWorker(1, cfg, oc.Clone(), gh, brMgr, store, o, router)
 	return o
 }
 

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -523,7 +523,6 @@ func parseTechnicalPlanningResponse(response string) (analysis, plan string) {
 
 func (w *Worker) implement(ctx context.Context, task *Task, planStr string) error {
 	w.oc.SetDirectory(task.Worktree)
-	defer w.oc.SetDirectory("")
 
 	// Fetch all comments from GitHub issue to find technical planning
 	comments, err := w.gh.ListComments(task.Issue.Number)
@@ -576,7 +575,6 @@ func (w *Worker) ensureCommit(task *Task) {
 
 func (w *Worker) fixFromReview(ctx context.Context, task *Task, review string) error {
 	w.oc.SetDirectory(task.Worktree)
-	defer w.oc.SetDirectory("")
 
 	testCmd := w.cfg.Tools.TestCmd
 	if testCmd == "" {

--- a/internal/opencode/client.go
+++ b/internal/opencode/client.go
@@ -136,6 +136,13 @@ func (c *Client) BaseURL() string {
 	return c.baseURL
 }
 
+func (c *Client) Clone() *Client {
+	return &Client{
+		baseURL:    c.baseURL,
+		httpClient: c.httpClient,
+	}
+}
+
 func (c *Client) SetDirectory(dir string) {
 	c.directory = dir
 }

--- a/internal/opencode/client_test.go
+++ b/internal/opencode/client_test.go
@@ -432,3 +432,37 @@ func TestSendMessageStream_WithToolCalls(t *testing.T) {
 		t.Errorf("parts[2].tool_result.output = %q, should contain 'total 32'", msg.Parts[2].ToolResult.Output)
 	}
 }
+
+func TestClientClone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(opencode.Session{
+			ID:    "sess-clone-test",
+			Title: "clone-test",
+		})
+	}))
+	defer srv.Close()
+
+	original := opencode.NewClient(srv.URL)
+	original.SetDirectory("/original/path")
+
+	cloned := original.Clone()
+
+	if cloned.BaseURL() != original.BaseURL() {
+		t.Errorf("cloned.BaseURL() = %q, want %q", cloned.BaseURL(), original.BaseURL())
+	}
+
+	session, err := cloned.CreateSession("clone-test")
+	if err != nil {
+		t.Fatalf("unexpected error creating session with cloned client: %v", err)
+	}
+	if session.ID != "sess-clone-test" {
+		t.Errorf("session.ID = %q, want %q", session.ID, "sess-clone-test")
+	}
+
+	cloned.SetDirectory("/cloned/path")
+
+	if original.BaseURL() != srv.URL {
+		t.Errorf("original.BaseURL() changed after cloning: got %q, want %q", original.BaseURL(), srv.URL)
+	}
+}


### PR DESCRIPTION
Closes #272

## Description
Multiple workers currently share a single opencode.Client instance, causing a race condition where workers overwrite each other's working directory. When Worker A sets its worktree directory and Worker B subsequently sets a different directory, Worker A's subsequent requests will use Worker B's directory, leading to code changes being applied to the wrong worktree. This blocks the implementation of parallel worker processing.

## Tasks
1. Modify `internal/mvp/orchestrator.go` to create a separate opencode.Client instance for each worker instead of sharing one client
2. Add a method or constructor in `internal/opencode/client.go` to create a new client instance with the same base URL configuration
3. Update `internal/mvp/worker.go` to remove the `defer w.oc.SetDirectory("")` cleanup if using dedicated clients
4. Verify that each worker operates in isolation without directory conflicts

## Files to Modify
- `internal/mvp/orchestrator.go` - Create separate opencode.Client for each worker in the worker pool
- `internal/opencode/client.go` - Add constructor/method to clone client with same base URL
- `internal/mvp/worker.go` - Remove directory cleanup defer if client is no longer shared

## Acceptance Criteria
1. Each worker has its own isolated opencode.Client instance
2. Workers can run in parallel without interfering with each other's working directory
3. No race condition warnings when running with `-race` flag
4. Parallel worker execution produces correct results in respective worktrees