### PR TITLE
[Bug] Task page not showing complete chat history from worker

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -796,6 +796,28 @@ func (s *Server) handleTaskStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	// Send chat history first if available
+	if task.ChatHistory != nil && !task.ChatHistory.IsEmpty() {
+		messages := task.ChatHistory.GetMessages()
+		historyJSON, err := json.Marshal(map[string]any{
+			"history": messages,
+		})
+		if err == nil {
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", historyJSON)
+			flusher.Flush()
+		}
+	}
+
 	opencodeURL := s.orchestrator.OpenCodeURL() + "/event"
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, opencodeURL, nil)
 	if err != nil {
@@ -811,16 +833,6 @@ func (s *Server) handleTaskStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "streaming not supported", http.StatusInternalServerError)
-		return
-	}
-
-	w.Header().Set("Content-Type", "text/event-stream")
-	w.Header().Set("Cache-Control", "no-cache")
-	w.Header().Set("Connection", "keep-alive")
 
 	scanner := bufio.NewScanner(resp.Body)
 	scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)

--- a/internal/dashboard/templates/task.html
+++ b/internal/dashboard/templates/task.html
@@ -85,8 +85,54 @@
   if (streamBoxes.length === 0) return;
   var box = streamBoxes[streamBoxes.length - 1];
   var es = new EventSource('/api/task/{{.IssueNumber}}/stream');
+  var historyLoaded = false;
+  
   es.onmessage = function(e) {
     var data = JSON.parse(e.data);
+    
+    // Handle historical messages on first load
+    if (!historyLoaded && data.history) {
+      historyLoaded = true;
+      // Clear existing content
+      box.innerHTML = '';
+      
+      // Render historical messages
+      data.history.forEach(function(msg) {
+        var roleClass = msg.role === 'user' ? 'user-message' : 'assistant-message';
+        var roleLabel = msg.role === 'user' ? 'User' : 'Assistant';
+        
+        var msgDiv = document.createElement('div');
+        msgDiv.className = 'chat-message ' + roleClass;
+        msgDiv.style.marginBottom = '0.5rem';
+        msgDiv.style.padding = '0.5rem';
+        msgDiv.style.borderRadius = '4px';
+        msgDiv.style.background = msg.role === 'user' ? 'rgba(255,255,255,0.05)' : 'transparent';
+        
+        var roleSpan = document.createElement('span');
+        roleSpan.style.fontWeight = 'bold';
+        roleSpan.style.color = msg.role === 'user' ? '#64b5f6' : '#81c784';
+        roleSpan.textContent = roleLabel + ': ';
+        
+        msgDiv.appendChild(roleSpan);
+        msgDiv.appendChild(document.createTextNode(msg.content));
+        box.appendChild(msgDiv);
+      });
+      
+      // Add separator
+      var sep = document.createElement('div');
+      sep.style.borderTop = '1px solid var(--border)';
+      sep.style.margin = '0.5rem 0';
+      box.appendChild(sep);
+      
+      // Add cursor for live streaming
+      var cursor = document.createElement('span');
+      cursor.className = 'stream-cursor';
+      box.appendChild(cursor);
+      
+      box.scrollTop = box.scrollHeight;
+      return;
+    }
+    
     if (data.done) {
       es.close();
       setTimeout(function(){ location.reload(); }, 1000);

--- a/internal/mvp/task.go
+++ b/internal/mvp/task.go
@@ -7,6 +7,100 @@ import (
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
 
+// ChatMessage represents a single message in the chat history
+type ChatMessage struct {
+	Role      string    `json:"role"`
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// ChatHistory stores chat messages for a task with thread-safe access
+// It implements a ring buffer with a maximum size to prevent unbounded memory growth
+type ChatHistory struct {
+	mu       sync.RWMutex
+	messages []ChatMessage
+	maxSize  int
+}
+
+// NewChatHistory creates a new ChatHistory with the specified maximum size
+func NewChatHistory(maxSize int) *ChatHistory {
+	if maxSize <= 0 {
+		maxSize = 1000 // Default max size
+	}
+	return &ChatHistory{
+		messages: make([]ChatMessage, 0, maxSize),
+		maxSize:  maxSize,
+	}
+}
+
+// AddMessage adds a new message to the chat history
+// If the history exceeds maxSize, oldest messages are removed
+func (ch *ChatHistory) AddMessage(role, content string) {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	msg := ChatMessage{
+		Role:      role,
+		Content:   content,
+		Timestamp: time.Now(),
+	}
+
+	// If at capacity, remove oldest message
+	if len(ch.messages) >= ch.maxSize {
+		ch.messages = ch.messages[1:]
+	}
+
+	ch.messages = append(ch.messages, msg)
+}
+
+// GetMessages returns a copy of all messages in the chat history
+func (ch *ChatHistory) GetMessages() []ChatMessage {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	result := make([]ChatMessage, len(ch.messages))
+	copy(result, ch.messages)
+	return result
+}
+
+// GetMessagesSince returns messages added after the given timestamp
+func (ch *ChatHistory) GetMessagesSince(since time.Time) []ChatMessage {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	var result []ChatMessage
+	for _, msg := range ch.messages {
+		if msg.Timestamp.After(since) {
+			result = append(result, msg)
+		}
+	}
+	return result
+}
+
+// Clear removes all messages from the chat history
+func (ch *ChatHistory) Clear() {
+	ch.mu.Lock()
+	defer ch.mu.Unlock()
+
+	ch.messages = ch.messages[:0]
+}
+
+// Len returns the number of messages in the chat history
+func (ch *ChatHistory) Len() int {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	return len(ch.messages)
+}
+
+// IsEmpty returns true if the chat history has no messages
+func (ch *ChatHistory) IsEmpty() bool {
+	ch.mu.RLock()
+	defer ch.mu.RUnlock()
+
+	return len(ch.messages) == 0
+}
+
 type TaskStatus string
 
 const (
@@ -23,13 +117,14 @@ const (
 )
 
 type Task struct {
-	Issue     github.Issue
-	Milestone string
-	Branch    string
-	Worktree  string
-	Status    TaskStatus
-	Result    *TaskResult
-	StartTime time.Time
+	Issue       github.Issue
+	Milestone   string
+	Branch      string
+	Worktree    string
+	Status      TaskStatus
+	Result      *TaskResult
+	StartTime   time.Time
+	ChatHistory *ChatHistory
 
 	mu        sync.Mutex
 	sessionID string
@@ -39,6 +134,11 @@ func (t *Task) SetSessionID(id string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.sessionID = id
+
+	// Clear chat history when session is cleared (task stage completes)
+	if id == "" && t.ChatHistory != nil {
+		t.ChatHistory.Clear()
+	}
 }
 
 func (t *Task) SessionID() string {

--- a/internal/mvp/task_test.go
+++ b/internal/mvp/task_test.go
@@ -2,6 +2,7 @@ package mvp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
@@ -99,5 +100,210 @@ func TestTaskResult(t *testing.T) {
 	}
 	if result.Summary != "Implemented feature X" {
 		t.Errorf("Summary = %q, want %q", result.Summary, "Implemented feature X")
+	}
+}
+
+// ChatHistory tests
+
+func TestNewChatHistory(t *testing.T) {
+	ch := NewChatHistory(100)
+	if ch == nil {
+		t.Fatal("NewChatHistory returned nil")
+	}
+	if ch.maxSize != 100 {
+		t.Errorf("expected maxSize 100, got %d", ch.maxSize)
+	}
+	if !ch.IsEmpty() {
+		t.Error("new ChatHistory should be empty")
+	}
+}
+
+func TestNewChatHistory_DefaultSize(t *testing.T) {
+	ch := NewChatHistory(0)
+	if ch.maxSize != 1000 {
+		t.Errorf("expected default maxSize 1000, got %d", ch.maxSize)
+	}
+	ch = NewChatHistory(-1)
+	if ch.maxSize != 1000 {
+		t.Errorf("expected default maxSize 1000 for negative input, got %d", ch.maxSize)
+	}
+}
+
+func TestChatHistory_AddMessage(t *testing.T) {
+	ch := NewChatHistory(10)
+
+	ch.AddMessage("user", "Hello")
+	ch.AddMessage("assistant", "Hi there!")
+
+	if ch.Len() != 2 {
+		t.Errorf("expected 2 messages, got %d", ch.Len())
+	}
+
+	msgs := ch.GetMessages()
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages from GetMessages, got %d", len(msgs))
+	}
+
+	if msgs[0].Role != "user" || msgs[0].Content != "Hello" {
+		t.Errorf("first message mismatch: %+v", msgs[0])
+	}
+	if msgs[1].Role != "assistant" || msgs[1].Content != "Hi there!" {
+		t.Errorf("second message mismatch: %+v", msgs[1])
+	}
+}
+
+func TestChatHistory_MaxSize(t *testing.T) {
+	ch := NewChatHistory(3)
+
+	ch.AddMessage("user", "msg1")
+	ch.AddMessage("assistant", "msg2")
+	ch.AddMessage("user", "msg3")
+	ch.AddMessage("assistant", "msg4") // Should evict msg1
+
+	if ch.Len() != 3 {
+		t.Errorf("expected 3 messages (at max), got %d", ch.Len())
+	}
+
+	msgs := ch.GetMessages()
+	if msgs[0].Content != "msg2" {
+		t.Errorf("expected oldest message to be 'msg2', got '%s'", msgs[0].Content)
+	}
+	if msgs[2].Content != "msg4" {
+		t.Errorf("expected newest message to be 'msg4', got '%s'", msgs[2].Content)
+	}
+}
+
+func TestChatHistory_GetMessagesSince(t *testing.T) {
+	ch := NewChatHistory(10)
+
+	before := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	ch.AddMessage("user", "msg1")
+	time.Sleep(10 * time.Millisecond)
+
+	middle := time.Now()
+	time.Sleep(10 * time.Millisecond)
+
+	ch.AddMessage("assistant", "msg2")
+	time.Sleep(10 * time.Millisecond)
+
+	after := time.Now()
+
+	// Get messages since before - should return both
+	msgs := ch.GetMessagesSince(before)
+	if len(msgs) != 2 {
+		t.Errorf("expected 2 messages since before, got %d", len(msgs))
+	}
+
+	// Get messages since middle - should return only msg2
+	msgs = ch.GetMessagesSince(middle)
+	if len(msgs) != 1 {
+		t.Errorf("expected 1 message since middle, got %d", len(msgs))
+	}
+	if msgs[0].Content != "msg2" {
+		t.Errorf("expected 'msg2', got '%s'", msgs[0].Content)
+	}
+
+	// Get messages since after - should return none
+	msgs = ch.GetMessagesSince(after)
+	if len(msgs) != 0 {
+		t.Errorf("expected 0 messages since after, got %d", len(msgs))
+	}
+}
+
+func TestChatHistory_Clear(t *testing.T) {
+	ch := NewChatHistory(10)
+
+	ch.AddMessage("user", "Hello")
+	ch.AddMessage("assistant", "Hi!")
+
+	if ch.Len() != 2 {
+		t.Errorf("expected 2 messages before clear, got %d", ch.Len())
+	}
+
+	ch.Clear()
+
+	if ch.Len() != 0 {
+		t.Errorf("expected 0 messages after clear, got %d", ch.Len())
+	}
+
+	if !ch.IsEmpty() {
+		t.Error("ChatHistory should be empty after Clear()")
+	}
+}
+
+func TestChatHistory_ConcurrentAccess(t *testing.T) {
+	ch := NewChatHistory(100)
+
+	// Concurrent writes
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 10; j++ {
+				ch.AddMessage("user", "msg")
+			}
+			done <- true
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < 5; i++ {
+		go func() {
+			for j := 0; j < 20; j++ {
+				_ = ch.GetMessages()
+				_ = ch.Len()
+				_ = ch.IsEmpty()
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 15; i++ {
+		<-done
+	}
+
+	// Verify final state
+	if ch.Len() != 100 { // Max size reached
+		t.Errorf("expected 100 messages (max), got %d", ch.Len())
+	}
+}
+
+func TestChatMessage_Timestamp(t *testing.T) {
+	ch := NewChatHistory(10)
+
+	before := time.Now()
+	ch.AddMessage("user", "test")
+	after := time.Now()
+
+	msgs := ch.GetMessages()
+	if len(msgs) != 1 {
+		t.Fatal("expected 1 message")
+	}
+
+	if msgs[0].Timestamp.Before(before) || msgs[0].Timestamp.After(after) {
+		t.Error("message timestamp is outside expected range")
+	}
+}
+
+func TestTask_SetSessionID_ClearsChatHistory(t *testing.T) {
+	task := &Task{
+		ChatHistory: NewChatHistory(100),
+	}
+
+	// Add some messages
+	task.ChatHistory.AddMessage("user", "Hello")
+	task.ChatHistory.AddMessage("assistant", "Hi!")
+
+	if task.ChatHistory.Len() != 2 {
+		t.Errorf("expected 2 messages, got %d", task.ChatHistory.Len())
+	}
+
+	// Set session ID to empty string should clear chat history
+	task.SetSessionID("")
+
+	if !task.ChatHistory.IsEmpty() {
+		t.Error("chat history should be empty after SetSessionID(\"\")")
 	}
 }

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -632,6 +632,11 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string) (appr
 		}
 	}()
 
+	// Initialize chat history if not already present
+	if task.ChatHistory == nil {
+		task.ChatHistory = NewChatHistory(1000)
+	}
+
 	var stepID int64
 	if w.store != nil {
 		id, sErr := w.store.InsertStep(task.Issue.Number, "code-review", prompt, session.ID)
@@ -641,6 +646,9 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string) (appr
 			stepID = id
 		}
 	}
+
+	// Capture user prompt in chat history
+	task.ChatHistory.AddMessage("user", prompt)
 
 	// Use router to select model for code category with high complexity (code review is important)
 	llmModel := w.cfg.Planning.LLM
@@ -660,6 +668,9 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string) (appr
 
 	reviewJSON, _ := json.Marshal(result)
 	review = string(reviewJSON)
+
+	// Capture assistant response in chat history
+	task.ChatHistory.AddMessage("assistant", review)
 
 	if w.store != nil && stepID > 0 {
 		_ = w.store.FinishStep(stepID, review)
@@ -736,6 +747,11 @@ func (w *Worker) llmStep(ctx context.Context, task *Task, stepName, prompt, llm 
 		}
 	}()
 
+	// Initialize chat history if not already present
+	if task.ChatHistory == nil {
+		task.ChatHistory = NewChatHistory(1000)
+	}
+
 	var stepID int64
 	if w.store != nil {
 		id, sErr := w.store.InsertStep(task.Issue.Number, stepName, prompt, session.ID)
@@ -745,6 +761,9 @@ func (w *Worker) llmStep(ctx context.Context, task *Task, stepName, prompt, llm 
 			stepID = id
 		}
 	}
+
+	// Capture user prompt in chat history
+	task.ChatHistory.AddMessage("user", prompt)
 
 	model := opencode.ParseModelRef(llm)
 	msg, err := w.oc.SendMessage(session.ID, prompt, model, nil)
@@ -756,6 +775,10 @@ func (w *Worker) llmStep(ctx context.Context, task *Task, stepName, prompt, llm 
 	}
 
 	response := extractText(msg)
+
+	// Capture assistant response in chat history
+	task.ChatHistory.AddMessage("assistant", response)
+
 	if w.store != nil && stepID > 0 {
 		_ = w.store.FinishStep(stepID, response)
 	}


### PR DESCRIPTION
Closes #282

## Description
The task detail page at `/task/{id}` does not display the complete chat history. The worker process needs to persist the active chat stream in memory so that when users navigate to a task page, they can see the full conversation history instead of a partial or empty chat view.

## Tasks
1. Identify where the worker process handles chat stream data
2. Add in-memory storage mechanism for active chat streams in the worker
3. Update the task handler to retrieve and return the full chat history from memory
4. Verify the `/task/{id}` endpoint returns complete chat data

## Files to Modify
- `internal/worker/worker.go` or similar - Add chat stream storage in memory
- `internal/dashboard/task_handler.go` or similar - Retrieve full chat history for task page
- `internal/dashboard/chat_stream.go` or similar - Chat stream data structure if not exists

## Acceptance Criteria
- [ ] Navigating to `/task/{id}` displays the complete chat history for that task
- [ ] Chat messages are persisted in worker memory while the task is active
- [ ] No chat messages are lost when refreshing the task page
- [ ] Memory usage remains reasonable (old chats are cleaned up appropriately)