### PR TITLE
[Bug] Remove redundant Workers tab when only one worker exists

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -39,6 +39,7 @@ type taskCard struct {
 type boardData struct {
 	Active         string
 	OpenCodePort   int
+	WorkerCount    int
 	SprintName     string
 	Paused         bool
 	Processing     bool
@@ -66,9 +67,14 @@ func (s *Server) handleBoardData(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) buildBoardData(_ *http.Request) boardData {
+	workerCount := 0
+	if s.pool != nil {
+		workerCount = len(s.pool())
+	}
 	data := boardData{
 		Active:       "board",
 		OpenCodePort: s.webPort,
+		WorkerCount:  workerCount,
 		Paused:       true,
 	}
 
@@ -703,6 +709,7 @@ func (s *Server) handleSprintClose(w http.ResponseWriter, r *http.Request) {
 type taskDetailData struct {
 	Active       string
 	OpenCodePort int
+	WorkerCount  int
 	IssueNumber  int
 	IssueTitle   string
 	Steps        []db.TaskStep
@@ -748,9 +755,14 @@ func (s *Server) handleTaskDetail(w http.ResponseWriter, r *http.Request) {
 		issueTitle = fmt.Sprintf("Issue #%d", issueNum)
 	}
 
+	workerCount := 0
+	if s.pool != nil {
+		workerCount = len(s.pool())
+	}
 	data := taskDetailData{
 		Active:       "task",
 		OpenCodePort: s.webPort,
+		WorkerCount:  workerCount,
 		IssueNumber:  issueNum,
 		IssueTitle:   issueTitle,
 		Steps:        steps,
@@ -763,15 +775,20 @@ func (s *Server) handleTaskDetail(w http.ResponseWriter, r *http.Request) {
 type workersData struct {
 	Active       string
 	OpenCodePort int
+	WorkerCount  int
 	Workers      []worker.WorkerInfo
 }
 
 func (s *Server) handleWorkers(w http.ResponseWriter, _ *http.Request) {
-	workers := s.pool()
+	workers := []worker.WorkerInfo{}
+	if s.pool != nil {
+		workers = s.pool()
+	}
 
 	data := workersData{
 		Active:       "workers",
 		OpenCodePort: s.webPort,
+		WorkerCount:  len(workers),
 		Workers:      workers,
 	}
 	s.render(w, "workers.html", data)
@@ -1441,9 +1458,14 @@ func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	workerCount := 0
+	if s.pool != nil {
+		workerCount = len(s.pool())
+	}
 	data := struct {
 		Active             string
 		OpenCodePort       int
+		WorkerCount        int
 		Type               string
 		SessionID          string
 		CurrentStep        int
@@ -1453,6 +1475,7 @@ func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
 	}{
 		Active:             "wizard",
 		OpenCodePort:       s.webPort,
+		WorkerCount:        workerCount,
 		Type:               wizardType,
 		SessionID:          "",
 		CurrentStep:        1,
@@ -1703,6 +1726,7 @@ func (s *Server) handleRateLimitRefresh(w http.ResponseWriter, r *http.Request) 
 type settingsData struct {
 	Active            string
 	OpenCodePort      int
+	WorkerCount       int
 	Config            config.LLMConfig
 	ForceStrongStages string
 	Success           bool
@@ -1725,9 +1749,14 @@ func (s *Server) handleSettings(w http.ResponseWriter, _ *http.Request) {
 	// Build comma-separated list of forced strong stages
 	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ") //nolint:staticcheck // deprecated but kept for backward compatibility
 
+	workerCount := 0
+	if s.pool != nil {
+		workerCount = len(s.pool())
+	}
 	data := settingsData{
 		Active:            "settings",
 		OpenCodePort:      s.webPort,
+		WorkerCount:       workerCount,
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
 		AvailableModels:   s.modelsCache,
@@ -1859,9 +1888,14 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 
 	// Re-render with success message and any warnings
 	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ") //nolint:staticcheck // deprecated but kept for backward compatibility
+	workerCount := 0
+	if s.pool != nil {
+		workerCount = len(s.pool())
+	}
 	data := settingsData{
 		Active:            "settings",
 		OpenCodePort:      s.webPort,
+		WorkerCount:       workerCount,
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
 		Success:           true,
@@ -1885,9 +1919,14 @@ func (s *Server) renderSettingsWithErrors(w http.ResponseWriter, r *http.Request
 	// This is a simplified approach - in production, you'd want to preserve all form values
 	forceStrongStages := r.FormValue("routing_force_strong_stages")
 
+	workerCount := 0
+	if s.pool != nil {
+		workerCount = len(s.pool())
+	}
 	data := settingsData{
 		Active:            "settings",
 		OpenCodePort:      s.webPort,
+		WorkerCount:       workerCount,
 		Config:            cfg.LLM,
 		ForceStrongStages: forceStrongStages,
 		Errors:            errors,

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -1042,9 +1042,11 @@ func TestLayoutNavigationButtons(t *testing.T) {
 	data := struct {
 		Active       string
 		OpenCodePort int
+		WorkerCount  int
 	}{
 		Active:       "board",
 		OpenCodePort: 8081,
+		WorkerCount:  1,
 	}
 
 	// We need to define a content template for the layout to work
@@ -1084,6 +1086,60 @@ func TestLayoutNavigationButtons(t *testing.T) {
 	// Check for nav-actions container
 	if !strings.Contains(output, "nav-actions") {
 		t.Error("layout template missing nav-actions container div")
+	}
+}
+
+// TestWorkersTab_ConditionalRendering verifies the Workers tab is hidden when <= 1 worker
+func TestWorkersTab_ConditionalRendering(t *testing.T) {
+	tests := []struct {
+		name          string
+		workerCount   int
+		shouldShowTab bool
+	}{
+		{"0 workers - tab hidden", 0, false},
+		{"1 worker - tab hidden", 1, false},
+		{"2 workers - tab shown", 2, true},
+		{"3 workers - tab shown", 3, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpl, err := template.ParseFiles("templates/layout.html")
+			if err != nil {
+				t.Fatalf("failed to parse layout template: %v", err)
+			}
+
+			var buf strings.Builder
+			data := struct {
+				Active       string
+				OpenCodePort int
+				WorkerCount  int
+			}{
+				Active:       "board",
+				OpenCodePort: 8081,
+				WorkerCount:  tt.workerCount,
+			}
+
+			tmpl, err = tmpl.New("content").Parse("<div>Test Content</div>")
+			if err != nil {
+				t.Fatalf("failed to parse content template: %v", err)
+			}
+
+			err = tmpl.ExecuteTemplate(&buf, "layout", data)
+			if err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			output := buf.String()
+			hasWorkersLink := strings.Contains(output, `href="/workers"`)
+
+			if tt.shouldShowTab && !hasWorkersLink {
+				t.Errorf("expected Workers tab to be shown for %d workers, but it was hidden", tt.workerCount)
+			}
+			if !tt.shouldShowTab && hasWorkersLink {
+				t.Errorf("expected Workers tab to be hidden for %d workers, but it was shown", tt.workerCount)
+			}
+		})
 	}
 }
 

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -89,7 +89,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
   <span class="logo">ODA</span>
   <div class="links">
     <a href="/" {{if eq .Active "board"}}class="active"{{end}}>Sprint Board</a>
-    <a href="/workers" {{if eq .Active "workers"}}class="active"{{end}}>Workers</a>
+    {{if gt .WorkerCount 1}}<a href="/workers" {{if eq .Active "workers"}}class="active"{{end}}>Workers</a>{{end}}
     <a href="/settings" {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
   </div>
   <div class="nav-actions">


### PR DESCRIPTION
Closes #280

## Description
The Workers tab is currently displayed in the dashboard even when only a single worker exists. This creates unnecessary UI clutter and confusion for users since the tab serves no purpose with just one worker.

## Tasks
1. Locate the Workers tab component in the dashboard UI code
2. Add conditional logic to hide the tab when the worker count is less than or equal to 1
3. Verify the tab remains visible when 2 or more workers are present
4. Test that navigation and routing work correctly after the change

## Files to Modify
- `internal/dashboard/ui/components/tabs.go` or similar — Add conditional rendering logic for Workers tab based on worker count
- `internal/dashboard/ui/views/dashboard.go` — Update tab visibility check

## Acceptance Criteria
- [ ] Workers tab is hidden when only 1 worker exists
- [ ] Workers tab is visible when 2 or more workers exist
- [ ] No console errors or navigation issues when tab is hidden
- [ ] Existing functionality for single worker remains unchanged