### PR TITLE
[Bug] Remove non-functional "View Backlog" button from wizard completion step

### DIFF
--- a/internal/dashboard/templates/wizard_create.html
+++ b/internal/dashboard/templates/wizard_create.html
@@ -61,7 +61,6 @@
     {{if .IsPage}}
     <a href="/" class="btn btn-primary">Close Wizard</a>
     <a href="/wizard?type={{.Type}}" class="btn btn-success">+ Create Another</a>
-    <a href="/backlog" class="btn">View Backlog →</a>
     {{else}}
     <button type="button" class="btn btn-primary" onclick="closeWizardModal()">
       Close Wizard
@@ -69,7 +68,6 @@
     <button type="button" class="btn btn-success" onclick="closeWizardModal(); window.location.href='/wizard?type={{.Type}}'">
       + Create Another
     </button>
-    <a href="/backlog" class="btn" onclick="closeWizardModal()">View Backlog →</a>
     {{end}}
   </div>
 </div>


### PR DESCRIPTION
Closes #281

## Description
The wizard completion step displays a "View Backlog →" button that links to `/backlog`, but the backlog feature does not exist in the application. This button appears in both the page and modal versions of the wizard, leading to a broken link and confusing user experience.

## Tasks
1. Open `internal/dashboard/templates/wizard_create.html`
2. Remove line 64: `<a href="/backlog" class="btn">View Backlog →</a>`
3. Remove line 72: `<a href="/backlog" class="btn" onclick="closeWizardModal()">View Backlog →</a>`
4. Verify the wizard completion step displays only "Close Wizard" and "Create Another" buttons

## Files to Modify
- `internal/dashboard/templates/wizard_create.html` - Remove two "View Backlog" button elements (lines 64 and 72)

## Acceptance Criteria
- [ ] The "View Backlog →" button no longer appears in the wizard page version
- [ ] The "View Backlog →" button no longer appears in the wizard modal version  
- [ ] Only "Close Wizard" and "Create Another" buttons remain in the completion step
- [ ] No broken links or 404 errors when completing the wizard