### PR TITLE
[Feature] Add yolo-mode config option to skip user approval

### DIFF
--- a/.oda/config.yaml
+++ b/.oda/config.yaml
@@ -20,6 +20,7 @@ epic_analysis:
     llm: nexos-ai/Kimi K2.5
 sprint:
     tasks_per_sprint: 10
+yolo_mode: false
 
 # Multi-model LLM configuration with task-based routing
 llm:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	EpicAnalysis EpicAnalysis `yaml:"epic_analysis"`
 	Sprint       Sprint       `yaml:"sprint"`
 	LLM          LLMConfig    `yaml:"llm"`
+	YoloMode     bool         `yaml:"yolo_mode"`
 }
 
 type GitHub struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -301,6 +301,55 @@ func TestValidateAndFallbackModels(t *testing.T) {
 	}
 }
 
+func TestLoad_YoloMode(t *testing.T) {
+	configWithYoloTrue := `github:
+  repo: "owner/repo"
+yolo_mode: true
+`
+	configWithYoloFalse := `github:
+  repo: "owner/repo"
+yolo_mode: false
+`
+	configWithoutYolo := `github:
+  repo: "owner/repo"
+`
+
+	tests := []struct {
+		name         string
+		config       string
+		wantYoloMode bool
+	}{
+		{
+			name:         "yolo_mode explicitly true",
+			config:       configWithYoloTrue,
+			wantYoloMode: true,
+		},
+		{
+			name:         "yolo_mode explicitly false",
+			config:       configWithYoloFalse,
+			wantYoloMode: false,
+		},
+		{
+			name:         "yolo_mode not specified (default false)",
+			config:       configWithoutYolo,
+			wantYoloMode: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := setupConfigDir(t, tt.config)
+			cfg, err := config.Load(dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.YoloMode != tt.wantYoloMode {
+				t.Errorf("yolo_mode = %v, want %v", cfg.YoloMode, tt.wantYoloMode)
+			}
+		})
+	}
+}
+
 func TestGetFirstAvailableModel(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1705,6 +1705,7 @@ type settingsData struct {
 	OpenCodePort      int
 	WorkerCount       int
 	Config            config.LLMConfig
+	YoloMode          bool
 	ForceStrongStages string
 	Success           bool
 	Errors            []string
@@ -1735,6 +1736,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, _ *http.Request) {
 		OpenCodePort:      s.webPort,
 		WorkerCount:       workerCount,
 		Config:            cfg.LLM,
+		YoloMode:          cfg.YoloMode,
 		ForceStrongStages: forceStrongStages,
 		AvailableModels:   s.modelsCache,
 	}
@@ -1848,6 +1850,9 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		cfg.LLM.RoutingRules.ForceStrongForStages = []string{} //nolint:staticcheck // deprecated but kept for backward compatibility
 	}
 
+	// Parse yolo_mode checkbox (checkbox returns "on" when checked, empty when unchecked)
+	cfg.YoloMode = r.FormValue("yolo_mode") == "on"
+
 	// If there are validation errors, re-render the form with errors
 	if len(errors) > 0 {
 		s.renderSettingsWithErrors(w, r, errors)
@@ -1874,6 +1879,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		OpenCodePort:      s.webPort,
 		WorkerCount:       workerCount,
 		Config:            cfg.LLM,
+		YoloMode:          cfg.YoloMode,
 		ForceStrongStages: forceStrongStages,
 		Success:           true,
 		Errors:            warnings, // Show warnings as info messages
@@ -1905,6 +1911,7 @@ func (s *Server) renderSettingsWithErrors(w http.ResponseWriter, r *http.Request
 		OpenCodePort:      s.webPort,
 		WorkerCount:       workerCount,
 		Config:            cfg.LLM,
+		YoloMode:          cfg.YoloMode,
 		ForceStrongStages: forceStrongStages,
 		Errors:            errors,
 		AvailableModels:   s.modelsCache,

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -94,6 +94,18 @@
       </div>
     </div>
     
+    <!-- Pipeline Settings -->
+    <div class="category-section">
+      <h2>Pipeline Settings</h2>
+      <div class="form-group checkbox-group">
+        <label class="checkbox-label">
+          <input type="checkbox" id="yolo_mode" name="yolo_mode" value="on" {{if .YoloMode}}checked{{end}}>
+          <span class="checkbox-text">Enable YOLO Mode</span>
+        </label>
+        <small>When enabled, tickets automatically transition from awaiting-approval to merge without requiring manual user approval</small>
+      </div>
+    </div>
+    
     <div class="form-actions">
       <button type="submit" class="btn btn-primary">Save Settings</button>
     </div>
@@ -165,6 +177,29 @@
   margin-top: 0.25rem;
   color: var(--muted);
   font-size: 0.8rem;
+}
+
+.form-group.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: auto;
+  margin: 0;
+}
+
+.checkbox-text {
+  color: var(--text);
 }
 
 .form-actions {

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -254,13 +254,19 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 		log.Printf("[Worker %d] [5/6] Awaiting user approval for #%d (PR: %s)", w.id, task.Issue.Number, prURL)
 		w.reportStageComplete("create-pr", EventSuccess, "PR created, awaiting approval: "+prURL)
 
-		// Block until user sends decision or context canceled
 		var decision UserDecision
-		select {
-		case decision = <-w.decisionCh:
-			log.Printf("[Worker %d] Received decision for #%d: %s", w.id, task.Issue.Number, decision.Action)
-		case <-ctx.Done():
-			return ctx.Err()
+		if w.cfg.YoloMode {
+			// YOLO mode: auto-approve without waiting for user
+			log.Printf("[Worker %d] YOLO mode enabled - auto-approving #%d", w.id, task.Issue.Number)
+			decision = UserDecision{Action: "approve"}
+		} else {
+			// Block until user sends decision or context canceled
+			select {
+			case decision = <-w.decisionCh:
+				log.Printf("[Worker %d] Received decision for #%d: %s", w.id, task.Issue.Number, decision.Action)
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 
 		if decision.Action == "approve" {

--- a/internal/mvp/worker_test.go
+++ b/internal/mvp/worker_test.go
@@ -3,6 +3,7 @@ package mvp
 import (
 	"testing"
 
+	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/opencode"
 )
 
@@ -225,6 +226,50 @@ func TestCheckAlreadyDone(t *testing.T) {
 			got := checkAlreadyDone(tt.response)
 			if got != tt.want {
 				t.Errorf("checkAlreadyDone() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWorker_YoloMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		yoloMode     bool
+		wantDecision string
+	}{
+		{
+			name:         "yolo mode enabled - auto approve",
+			yoloMode:     true,
+			wantDecision: "approve",
+		},
+		{
+			name:         "yolo mode disabled - wait for decision",
+			yoloMode:     false,
+			wantDecision: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a worker with the specified yolo mode
+			cfg := &config.Config{
+				YoloMode: tt.yoloMode,
+			}
+
+			worker := &Worker{
+				id:         1,
+				cfg:        cfg,
+				decisionCh: make(chan UserDecision, 1),
+			}
+
+			// Test that yolo mode correctly determines if we should auto-approve
+			var decision UserDecision
+			if worker.cfg.YoloMode {
+				decision = UserDecision{Action: "approve"}
+			}
+
+			if decision.Action != tt.wantDecision {
+				t.Errorf("yolo mode decision = %q, want %q", decision.Action, tt.wantDecision)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #290

## Description
Add a `yolo-mode` boolean configuration option to the ODA settings and config.yaml. When enabled (true), the pipeline should automatically proceed from ai-review to merge without requiring manual user approval. When disabled (false), the existing behavior requiring user approval before merge is preserved. This allows power users to streamline their workflow while maintaining safety for others.

## Tasks
1. Add `YoloMode` boolean field to the configuration struct in `internal/config/config.go` with default value `false`
2. Update `.oda/config.yaml` schema to include the new `yolo-mode` option with documentation comment
3. Modify the state machine transition logic in `internal/statemachine/transitions.go` to check `yolo-mode` setting when transitioning from `ai-review` stage
4. Update the settings UI in `internal/dashboard/settings.go` to display and allow toggling of the `yolo-mode` option
5. Add validation in `internal/config/validate.go` to ensure `yolo-mode` is a valid boolean value
6. Write unit tests in `internal/statemachine/transitions_test.go` to verify both yolo-mode enabled and disabled behaviors

## Files to Modify
- `internal/config/config.go` — Add `YoloMode` field to Config struct
- `.oda/config.yaml` — Add `yolo-mode` option with default false
- `internal/statemachine/transitions.go` — Check yolo-mode before requiring user approval
- `internal/dashboard/settings.go` — Add UI toggle for yolo-mode
- `internal/config/validate.go` — Add validation for yolo-mode value
- `internal/statemachine/transitions_test.go` — Add tests for yolo-mode behavior

## Acceptance Criteria
1. When `yolo-mode: false` (default), the pipeline pauses at ai-review stage and requires explicit user approval before proceeding to merge
2. When `yolo-mode: true`, the pipeline automatically transitions from ai-review to merge without user intervention
3. The setting is persisted in config.yaml and survives application restarts
4. The setting is visible and toggleable in the dashboard settings page
5. Invalid values for yolo-mode (non-boolean) are rejected with a clear error message during config validation