### PR TITLE
Simplify LLM config: remove legacy strong/weak structure and top-level planning/epic_analysis fields

### DIFF
--- a/.oda/config.yaml
+++ b/.oda/config.yaml
@@ -7,49 +7,26 @@ workers:
     count: 3
 opencode:
     url: http://localhost:4096
-    web_port: 8081  # Port for opencode web UI (auto-started by ODA)
+    web_port: 8081
 tools:
     lint_cmd: ""
     test_cmd: go test ./...
     e2e_cmd: ""
 pipeline:
     max_retries: 5
-planning:
-    llm: nexos-ai/Kimi K2.5
-epic_analysis:
-    llm: nexos-ai/Kimi K2.5
 sprint:
     tasks_per_sprint: 10
 yolo_mode: false
 
 # Multi-model LLM configuration with task-based routing
 llm:
-    development:
-        strong:
-            model: nexos-ai/Kimi K2.5
-        weak:
-            model: nexos-ai/Kimi K2.5
-    planning:
-        strong:
-            model: nexos-ai/Kimi K2.5
-        weak:
-            model: nexos-ai/Kimi K2.5
-    orchestration:
-        strong:
-            model: nexos-ai/Kimi K2.5
-        weak:
-            model: nexos-ai/Kimi K2.5
     setup:
-        strong:
-            model: nexos-ai/Kimi K2.5
-        weak:
-            model: nexos-ai/Kimi K2.5
-    default_complexity: medium
-    routing_rules:
-        complexity_thresholds:
-            code_size_threshold: 100
-            high_complexity_threshold: 500
-            file_count_threshold: 5
-        force_strong_for_stages:
-            - plan-review
-            - code-review
+        model: nexos-ai/Kimi K2.5
+    planning:
+        model: nexos-ai/Kimi K2.5
+    orchestration:
+        model: nexos-ai/Kimi K2.5
+    code:
+        model: nexos-ai/Kimi K2.5
+    code-heavy:
+        model: nexos-ai/Kimi K2.5

--- a/.opencode/skills/creating-oda-ticket/SKILL.md
+++ b/.opencode/skills/creating-oda-ticket/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: creating-oda-ticket
+description: >
+  Use when the user asks to create a ticket, issue, or task for ODA or One Dev Army —
+  e.g. "add a ticket to oda", "create an issue for one dev army", "new oda ticket",
+  "dodaj ticket do oda", "stwórz issue w one dev army".
+  Guides the conversation to gather required information (title, body) and optional
+  metadata (priority, size, type, sprint), then runs the `oda issue create` CLI command.
+---
+
+# Creating an ODA Ticket
+
+## Overview
+
+ODA (One Dev Army) has a CLI command `oda issue create` that creates GitHub Issues with optional labels and sprint assignment. This skill ensures you gather all necessary information from the user and run the command correctly.
+
+## When to Use
+
+- User asks to create/add a ticket, issue, or task for ODA / One Dev Army
+- User describes a bug or feature they want tracked in the ODA pipeline
+- User says something like "add this to the backlog" in an ODA project context
+
+## Command Reference
+
+```bash
+oda issue create \
+  --title "Issue title" \
+  --text "Issue body text" \
+  [--priority high|medium|low] \
+  [--size S|M|L|XL] \
+  [--type bug|feature] \
+  [--current-sprint]
+```
+
+### Required Flags
+
+| Flag | Description |
+|------|-------------|
+| `--title` | Short, descriptive issue title |
+| `--text` | Full issue body — requirements, acceptance criteria, context |
+
+### Optional Flags
+
+| Flag | Values | Effect |
+|------|--------|--------|
+| `--priority` | `high`, `medium`, `low` | Adds `priority:<value>` label |
+| `--size` | `S`, `M`, `L`, `XL` | Adds `size:<value>` label |
+| `--type` | `bug`, `feature` | Adds `bug` or `feature` label |
+| `--current-sprint` | (boolean) | Assigns to the oldest open milestone |
+
+### Labels Created
+
+- `--priority high` → label `priority:high`
+- `--size M` → label `size:M`
+- `--type bug` → label `bug`
+- `--type feature` → label `feature`
+
+## Workflow
+
+### Step 1 — Gather Information
+
+Before running the command, ensure you have at minimum:
+
+1. **Title** — a concise summary (required)
+2. **Body text** — detailed description with context, requirements, and acceptance criteria (required)
+
+If the user provides a vague request (e.g. "add a ticket for fixing the login"), ask clarifying questions to produce a well-written issue body. A good issue body includes:
+- **What** needs to be done
+- **Why** it matters (context, user impact)
+- **Acceptance criteria** — concrete conditions for "done"
+
+Also ask about or infer from context:
+- **Priority** — how urgent is this? (high/medium/low)
+- **Size** — estimated effort (S/M/L/XL)
+- **Type** — is this a bug fix or a new feature?
+- **Sprint** — should it go into the current sprint?
+
+If the user provides enough detail to infer these values confidently, use them without asking. If unclear, ask.
+
+### Step 2 — Confirm Before Creating
+
+Present the user with a summary of what will be created:
+
+```
+Title: <title>
+Body: <body text>
+Priority: <value or "not set">
+Size: <value or "not set">
+Type: <value or "not set">
+Sprint: <current sprint or "not assigned">
+```
+
+Wait for user confirmation before proceeding. If the user explicitly says "just do it" or provides all details upfront with clear intent, skip confirmation.
+
+### Step 3 — Run the Command
+
+Execute the command from the ODA project directory (where `.oda/config.yaml` exists):
+
+```bash
+oda issue create \
+  --title "Title here" \
+  --text "Body text here" \
+  --priority medium \
+  --size M \
+  --type feature \
+  --current-sprint
+```
+
+Only include optional flags that have values. Do not pass empty strings.
+
+### Step 4 — Report the Result
+
+The command outputs:
+```
+Created issue #<number>
+Assigned to sprint: <milestone>    (if --current-sprint was used)
+Labels: label1, label2, label3     (if any labels were applied)
+```
+
+Report the issue number and any labels/sprint assignment to the user.
+
+If the command fails, check:
+- Is `.oda/config.yaml` present in the working directory?
+- Is `gh` CLI authenticated? (`gh auth status`)
+- Does the repository exist and is accessible?
+- If `--current-sprint` was used, does the repo have open milestones?
+
+## Important Notes
+
+- The command requires `.oda/config.yaml` to exist in the working directory (it reads `github.repo` from it)
+- It shells out to `gh` CLI — the user must be authenticated with GitHub
+- Issues created via CLI do **not** automatically get a `stage:backlog` label — they enter the backlog by having no `stage:*` label
+- The `--text` flag value should be properly quoted — escape any quotes inside the body text
+- For multi-line body text, use `\n` for line breaks or pass the text in a single quoted string
+
+## Example
+
+User: "Add a high-priority bug ticket to ODA for the dashboard WebSocket disconnecting after 5 minutes of inactivity"
+
+```bash
+oda issue create \
+  --title "Dashboard WebSocket disconnects after 5 minutes of inactivity" \
+  --text "The dashboard WebSocket connection drops after approximately 5 minutes of user inactivity. This causes the real-time ticket status updates to stop, and the user sees stale data until they manually refresh the page.
+
+## Steps to Reproduce
+1. Open the ODA dashboard
+2. Wait 5 minutes without interacting with the page
+3. Observe that ticket status changes are no longer reflected in real-time
+
+## Expected Behavior
+WebSocket connection should remain alive indefinitely, using ping/pong keepalive frames.
+
+## Acceptance Criteria
+- [ ] WebSocket connection stays alive during idle periods
+- [ ] Implement ping/pong keepalive mechanism
+- [ ] Add automatic reconnection with exponential backoff if connection drops
+- [ ] Add tests for keepalive and reconnection logic" \
+  --priority high \
+  --size M \
+  --type bug \
+  --current-sprint
+```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,17 +9,15 @@ import (
 )
 
 type Config struct {
-	GitHub       GitHub       `yaml:"github"`
-	Dashboard    Dashboard    `yaml:"dashboard"`
-	Workers      Workers      `yaml:"workers"`
-	OpenCode     OpenCode     `yaml:"opencode"`
-	Tools        Tools        `yaml:"tools"`
-	Pipeline     Pipeline     `yaml:"pipeline"`
-	Planning     Planning     `yaml:"planning"`
-	EpicAnalysis EpicAnalysis `yaml:"epic_analysis"`
-	Sprint       Sprint       `yaml:"sprint"`
-	LLM          LLMConfig    `yaml:"llm"`
-	YoloMode     bool         `yaml:"yolo_mode"`
+	GitHub    GitHub    `yaml:"github"`
+	Dashboard Dashboard `yaml:"dashboard"`
+	Workers   Workers   `yaml:"workers"`
+	OpenCode  OpenCode  `yaml:"opencode"`
+	Tools     Tools     `yaml:"tools"`
+	Pipeline  Pipeline  `yaml:"pipeline"`
+	Sprint    Sprint    `yaml:"sprint"`
+	LLM       LLMConfig `yaml:"llm"`
+	YoloMode  bool      `yaml:"yolo_mode"`
 }
 
 type GitHub struct {
@@ -50,14 +48,6 @@ type Pipeline struct {
 	MaxRetries int `yaml:"max_retries"`
 }
 
-type Planning struct {
-	LLM string `yaml:"llm"`
-}
-
-type EpicAnalysis struct {
-	LLM string `yaml:"llm"`
-}
-
 type Sprint struct {
 	TasksPerSprint int `yaml:"tasks_per_sprint"`
 }
@@ -75,6 +65,9 @@ func Load(rootDir string, availableModels ...string) (*Config, error) {
 		return nil, fmt.Errorf("parsing config %s: %w", path, err)
 	}
 
+	// Migrate from legacy top-level planning/epic_analysis fields if present
+	cfg.migrateFromLegacyFields(data)
+
 	// Apply default LLM config if not fully specified
 	cfg.applyLLMDefaults()
 
@@ -84,6 +77,33 @@ func Load(rootDir string, availableModels ...string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// migrateFromLegacyFields migrates old top-level planning.llm and epic_analysis.llm to new structure
+func (cfg *Config) migrateFromLegacyFields(data []byte) {
+	// Check if old fields exist in raw YAML
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return
+	}
+
+	// Migrate planning.llm -> llm.planning.model
+	if planning, ok := raw["planning"].(map[string]any); ok {
+		if llm, ok := planning["llm"].(string); ok && llm != "" {
+			if cfg.LLM.Planning.Model == "" {
+				cfg.LLM.Planning.Model = llm
+			}
+		}
+	}
+
+	// Migrate epic_analysis.llm -> llm.planning.model (epic analysis uses planning model)
+	if epicAnalysis, ok := raw["epic_analysis"].(map[string]any); ok {
+		if llm, ok := epicAnalysis["llm"].(string); ok && llm != "" {
+			if cfg.LLM.Planning.Model == "" {
+				cfg.LLM.Planning.Model = llm
+			}
+		}
+	}
 }
 
 // applyLLMDefaults fills in missing LLM configuration with defaults
@@ -113,15 +133,5 @@ func (cfg *Config) applyLLMDefaults() {
 	// If CodeHeavy model is empty, use defaults
 	if cfg.LLM.CodeHeavy.Model == "" {
 		cfg.LLM.CodeHeavy.Model = defaults.CodeHeavy.Model
-	}
-
-	// Apply default complexity if not set
-	if cfg.LLM.DefaultComplexity == "" {
-		cfg.LLM.DefaultComplexity = defaults.DefaultComplexity
-	}
-
-	// Apply default routing rules if not set
-	if cfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold == 0 {
-		cfg.LLM.RoutingRules.ComplexityThresholds = defaults.RoutingRules.ComplexityThresholds
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -22,12 +22,19 @@ tools:
   e2e_cmd: "make e2e"
 pipeline:
   max_retries: 5
-planning:
-  llm: claude-opus-4
-epic_analysis:
-  llm: claude-sonnet-4
 sprint:
   tasks_per_sprint: 10
+llm:
+  setup:
+    model: "nexos-ai/Kimi K2.5"
+  planning:
+    model: "nexos-ai/Kimi K2.5"
+  orchestration:
+    model: "nexos-ai/Kimi K2.5"
+  code:
+    model: "nexos-ai/Kimi K2.5"
+  code-heavy:
+    model: "nexos-ai/Kimi K2.5"
 `
 
 func setupConfigDir(t *testing.T, content string) string {
@@ -81,22 +88,6 @@ func TestLoad_ToolsFields(t *testing.T) {
 	}
 	if cfg.Tools.E2ECmd != "make e2e" {
 		t.Errorf("tools.e2e_cmd = %q, want %q", cfg.Tools.E2ECmd, "make e2e")
-	}
-}
-
-func TestLoad_PlanningAndEpicAnalysis(t *testing.T) {
-	dir := setupConfigDir(t, validConfig)
-
-	cfg, err := config.Load(dir)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if cfg.Planning.LLM != "claude-opus-4" {
-		t.Errorf("planning.llm = %q, want %q", cfg.Planning.LLM, "claude-opus-4")
-	}
-	if cfg.EpicAnalysis.LLM != "claude-sonnet-4" {
-		t.Errorf("epic_analysis.llm = %q, want %q", cfg.EpicAnalysis.LLM, "claude-sonnet-4")
 	}
 }
 

--- a/internal/config/llm.go
+++ b/internal/config/llm.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"slices"
 	"strings"
 )
 
@@ -17,22 +16,14 @@ const (
 )
 
 // ComplexityLevel represents the complexity hint for model selection
+//
+// Deprecated: No longer used with per-mode model selection
 type ComplexityLevel string
 
 const (
 	ComplexityLow    ComplexityLevel = "low"
 	ComplexityMedium ComplexityLevel = "medium"
 	ComplexityHigh   ComplexityLevel = "high"
-)
-
-// ModelVariant represents the strength variant for a model
-//
-// Deprecated: No longer used with per-mode model selection
-type ModelVariant string
-
-const (
-	VariantStrong ModelVariant = "strong" // High quality, expensive
-	VariantWeak   ModelVariant = "weak"   // Fast, cheap
 )
 
 // ModelConfig represents a single LLM model configuration
@@ -82,39 +73,6 @@ type LLMConfig struct {
 	Orchestration CategoryModels `yaml:"orchestration"`
 	Code          CategoryModels `yaml:"code"`       // renamed from Development
 	CodeHeavy     CategoryModels `yaml:"code-heavy"` // new
-
-	// DefaultComplexity is used when no complexity hint is provided
-	DefaultComplexity ComplexityLevel `yaml:"default_complexity,omitempty"`
-
-	// RoutingRules define when to use strong vs weak models
-	//
-	// Deprecated: Complexity-based routing is being phased out in favor of explicit mode selection
-	RoutingRules RoutingConfig `yaml:"routing_rules,omitempty"`
-}
-
-// RoutingConfig defines rules for model selection
-//
-// Deprecated: Being phased out in favor of explicit per-mode model selection
-type RoutingConfig struct {
-	// ComplexityThresholds define when to upgrade to strong model
-	ComplexityThresholds ComplexityThresholds `yaml:"complexity_thresholds,omitempty"`
-
-	// ForceStrongForStages lists pipeline stages that always use strong models
-	ForceStrongForStages []string `yaml:"force_strong_for_stages,omitempty"`
-}
-
-// ComplexityThresholds defines thresholds for complexity detection
-//
-// Deprecated: Being phased out in favor of explicit per-mode model selection
-type ComplexityThresholds struct {
-	// CodeSizeThreshold is the number of lines that triggers medium complexity
-	CodeSizeThreshold int `yaml:"code_size_threshold,omitempty"`
-
-	// HighComplexityThreshold is the number of lines that triggers high complexity
-	HighComplexityThreshold int `yaml:"high_complexity_threshold,omitempty"`
-
-	// FileCountThreshold is the number of files that triggers higher complexity
-	FileCountThreshold int `yaml:"file_count_threshold,omitempty"`
 }
 
 // DefaultLLMConfig returns a default configuration with sensible defaults
@@ -134,15 +92,6 @@ func DefaultLLMConfig() LLMConfig {
 		},
 		CodeHeavy: CategoryModels{
 			Model: "nexos-ai/Kimi K2.5",
-		},
-		DefaultComplexity: ComplexityMedium,
-		RoutingRules: RoutingConfig{
-			ComplexityThresholds: ComplexityThresholds{
-				CodeSizeThreshold:       100,
-				HighComplexityThreshold: 500,
-				FileCountThreshold:      5,
-			},
-			ForceStrongForStages: []string{"plan-review", "code-review", "merge"},
 		},
 	}
 }
@@ -166,75 +115,9 @@ func (cfg *LLMConfig) GetModelForCategory(category TaskCategory, _ ComplexityLev
 	}
 }
 
-// ShouldUseStrongModel determines if a task should use the strong model based on complexity
-//
-// Deprecated: No longer relevant with per-mode model selection, kept for backward compatibility
-func (cfg *LLMConfig) ShouldUseStrongModel(complexity ComplexityLevel, stage string) bool {
-	// Check if stage is in force-strong list
-	if slices.Contains(cfg.RoutingRules.ForceStrongForStages, stage) {
-		return true
-	}
-
-	// Otherwise use complexity-based routing
-	return complexity == ComplexityHigh
-}
-
 // ToModelRef converts a ModelConfig to a model reference string
 func (mc *ModelConfig) ToModelRef() string {
 	return mc.Model
-}
-
-// LegacyCategoryModels holds strong and weak model variants for a category
-// Used for migration from old config format
-type LegacyCategoryModels struct {
-	Strong ModelConfig `yaml:"strong"`
-	Weak   ModelConfig `yaml:"weak"`
-}
-
-// LegacyLLMConfig represents the old config format with strong/weak variants
-type LegacyLLMConfig struct {
-	Development       LegacyCategoryModels `yaml:"development"`
-	Planning          LegacyCategoryModels `yaml:"planning"`
-	Orchestration     LegacyCategoryModels `yaml:"orchestration"`
-	Setup             LegacyCategoryModels `yaml:"setup"`
-	DefaultComplexity ComplexityLevel      `yaml:"default_complexity,omitempty"`
-	RoutingRules      RoutingConfig        `yaml:"routing_rules,omitempty"`
-}
-
-// MigrateFromLegacy converts old strong/weak format to new single-model format
-// Returns true if migration was performed
-func (cfg *LLMConfig) MigrateFromLegacy(legacy *LegacyLLMConfig) bool {
-	migrated := false
-
-	// Migrate Development -> Code (use strong model)
-	if legacy.Development.Strong.Model != "" {
-		cfg.Code.Model = legacy.Development.Strong.Model
-		migrated = true
-	}
-
-	// Migrate Planning
-	if legacy.Planning.Strong.Model != "" {
-		cfg.Planning.Model = legacy.Planning.Strong.Model
-		migrated = true
-	}
-
-	// Migrate Orchestration
-	if legacy.Orchestration.Strong.Model != "" {
-		cfg.Orchestration.Model = legacy.Orchestration.Strong.Model
-		migrated = true
-	}
-
-	// Migrate Setup
-	if legacy.Setup.Strong.Model != "" {
-		cfg.Setup.Model = legacy.Setup.Strong.Model
-		migrated = true
-	}
-
-	// Copy other settings
-	cfg.DefaultComplexity = legacy.DefaultComplexity
-	cfg.RoutingRules = legacy.RoutingRules
-
-	return migrated
 }
 
 // ModelValidationResult tracks which models were replaced during validation

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1723,15 +1723,14 @@ func (s *Server) handleRateLimitRefresh(w http.ResponseWriter, r *http.Request) 
 
 // settingsData holds the data for the settings template
 type settingsData struct {
-	Active            string
-	OpenCodePort      int
-	WorkerCount       int
-	Config            config.LLMConfig
-	YoloMode          bool
-	ForceStrongStages string
-	Success           bool
-	Errors            []string
-	AvailableModels   []opencode.ProviderModel
+	Active          string
+	OpenCodePort    int
+	WorkerCount     int
+	Config          config.LLMConfig
+	YoloMode        bool
+	Success         bool
+	Errors          []string
+	AvailableModels []opencode.ProviderModel
 }
 
 // handleSettings renders the LLM configuration settings page
@@ -1746,21 +1745,17 @@ func (s *Server) handleSettings(w http.ResponseWriter, _ *http.Request) {
 		cfg = &config.Config{LLM: defaultCfg}
 	}
 
-	// Build comma-separated list of forced strong stages
-	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ") //nolint:staticcheck // deprecated but kept for backward compatibility
-
 	workerCount := 0
 	if s.pool != nil {
 		workerCount = len(s.pool())
 	}
 	data := settingsData{
-		Active:            "settings",
-		OpenCodePort:      s.webPort,
-		WorkerCount:       workerCount,
-		Config:            cfg.LLM,
-		YoloMode:          cfg.YoloMode,
-		ForceStrongStages: forceStrongStages,
-		AvailableModels:   s.modelsCache,
+		Active:          "settings",
+		OpenCodePort:    s.webPort,
+		WorkerCount:     workerCount,
+		Config:          cfg.LLM,
+		YoloMode:        cfg.YoloMode,
+		AvailableModels: s.modelsCache,
 	}
 
 	s.render(w, "llm-config.html", data)
@@ -1834,44 +1829,6 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Parse routing thresholds
-	codeSizeThreshold, err := strconv.Atoi(r.FormValue("routing_code_size_threshold"))
-	if err != nil || codeSizeThreshold < 1 {
-		errors = append(errors, "Code Size Threshold must be a positive integer")
-	} else {
-		cfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold = codeSizeThreshold //nolint:staticcheck // deprecated but kept for backward compatibility
-	}
-
-	highComplexityThreshold, err := strconv.Atoi(r.FormValue("routing_high_complexity_threshold"))
-	if err != nil || highComplexityThreshold < 1 {
-		errors = append(errors, "High Complexity Threshold must be a positive integer")
-	} else {
-		cfg.LLM.RoutingRules.ComplexityThresholds.HighComplexityThreshold = highComplexityThreshold //nolint:staticcheck // deprecated but kept for backward compatibility
-	}
-
-	fileCountThreshold, err := strconv.Atoi(r.FormValue("routing_file_count_threshold"))
-	if err != nil || fileCountThreshold < 1 {
-		errors = append(errors, "File Count Threshold must be a positive integer")
-	} else {
-		cfg.LLM.RoutingRules.ComplexityThresholds.FileCountThreshold = fileCountThreshold //nolint:staticcheck // deprecated but kept for backward compatibility
-	}
-
-	// Parse forced strong stages
-	forceStrongStagesStr := r.FormValue("routing_force_strong_stages")
-	if forceStrongStagesStr != "" {
-		// Split by comma and trim whitespace
-		stages := strings.Split(forceStrongStagesStr, ",")
-		cfg.LLM.RoutingRules.ForceStrongForStages = make([]string, 0, len(stages)) //nolint:staticcheck // deprecated but kept for backward compatibility
-		for _, stage := range stages {
-			stage = strings.TrimSpace(stage)
-			if stage != "" {
-				cfg.LLM.RoutingRules.ForceStrongForStages = append(cfg.LLM.RoutingRules.ForceStrongForStages, stage) //nolint:staticcheck // deprecated but kept for backward compatibility
-			}
-		}
-	} else {
-		cfg.LLM.RoutingRules.ForceStrongForStages = []string{} //nolint:staticcheck // deprecated but kept for backward compatibility
-	}
-
 	// Parse yolo_mode checkbox (checkbox returns "on" when checked, empty when unchecked)
 	cfg.YoloMode = r.FormValue("yolo_mode") == "on"
 
@@ -1891,21 +1848,19 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[Dashboard] LLM configuration saved successfully")
 
 	// Re-render with success message and any warnings
-	forceStrongStages := strings.Join(cfg.LLM.RoutingRules.ForceStrongForStages, ", ") //nolint:staticcheck // deprecated but kept for backward compatibility
 	workerCount := 0
 	if s.pool != nil {
 		workerCount = len(s.pool())
 	}
 	data := settingsData{
-		Active:            "settings",
-		OpenCodePort:      s.webPort,
-		WorkerCount:       workerCount,
-		Config:            cfg.LLM,
-		YoloMode:          cfg.YoloMode,
-		ForceStrongStages: forceStrongStages,
-		Success:           true,
-		Errors:            warnings, // Show warnings as info messages
-		AvailableModels:   s.modelsCache,
+		Active:          "settings",
+		OpenCodePort:    s.webPort,
+		WorkerCount:     workerCount,
+		Config:          cfg.LLM,
+		YoloMode:        cfg.YoloMode,
+		Success:         true,
+		Errors:          warnings, // Show warnings as info messages
+		AvailableModels: s.modelsCache,
 	}
 
 	s.render(w, "llm-config.html", data)
@@ -1920,35 +1875,26 @@ func (s *Server) renderSettingsWithErrors(w http.ResponseWriter, r *http.Request
 		cfg = &config.Config{LLM: config.DefaultLLMConfig()}
 	}
 
-	// Override with form values to preserve user input
-	// This is a simplified approach - in production, you'd want to preserve all form values
-	forceStrongStages := r.FormValue("routing_force_strong_stages")
-
 	workerCount := 0
 	if s.pool != nil {
 		workerCount = len(s.pool())
 	}
 	data := settingsData{
-		Active:            "settings",
-		OpenCodePort:      s.webPort,
-		WorkerCount:       workerCount,
-		Config:            cfg.LLM,
-		YoloMode:          cfg.YoloMode,
-		ForceStrongStages: forceStrongStages,
-		Errors:            errors,
-		AvailableModels:   s.modelsCache,
+		Active:          "settings",
+		OpenCodePort:    s.webPort,
+		WorkerCount:     workerCount,
+		Config:          cfg.LLM,
+		YoloMode:        cfg.YoloMode,
+		Errors:          errors,
+		AvailableModels: s.modelsCache,
 	}
 
 	s.render(w, "llm-config.html", data)
 }
 
-// validateModelFormat checks if the model string is in the correct "provider/model" format
+// validateModelFormat checks if the model string is valid (any non-empty string is accepted)
 func validateModelFormat(model string) bool {
-	if model == "" {
-		return false
-	}
-	parts := strings.Split(model, "/")
-	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+	return model != ""
 }
 
 // validateModelSelection checks if a model selection is valid against the cached models

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -3789,10 +3789,6 @@ func TestHandleSaveSettings(t *testing.T) {
 	form.Set("orchestration_model", "orch-provider/orch-model")
 	form.Set("code_model", "code-provider/code-model")
 	form.Set("code_heavy_model", "code-heavy-provider/code-heavy-model")
-	form.Set("routing_code_size_threshold", "150")
-	form.Set("routing_high_complexity_threshold", "600")
-	form.Set("routing_file_count_threshold", "10")
-	form.Set("routing_force_strong_stages", "plan-review, code-review")
 
 	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -3820,9 +3816,6 @@ func TestHandleSaveSettings(t *testing.T) {
 	savedContent := string(savedData)
 	if !strings.Contains(savedContent, "code-provider/code-model") {
 		t.Error("saved config should contain new model")
-	}
-	if !strings.Contains(savedContent, "150") {
-		t.Error("saved config should contain new code size threshold")
 	}
 }
 
@@ -3884,64 +3877,6 @@ func TestHandleSaveSettingsValidation(t *testing.T) {
 	}
 }
 
-// TestHandleSaveSettingsValidationNegativeThresholds tests validation for negative thresholds
-func TestHandleSaveSettingsValidationNegativeThresholds(t *testing.T) {
-	// Create a temporary directory for config
-	tmpDir := t.TempDir()
-
-	// Create .oda directory
-	odaDir := filepath.Join(tmpDir, ".oda")
-	if err := os.MkdirAll(odaDir, 0755); err != nil {
-		t.Fatalf("failed to create .oda directory: %v", err)
-	}
-
-	// Create a minimal config file
-	configPath := filepath.Join(odaDir, "config.yaml")
-	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
-`
-	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
-		t.Fatalf("failed to write config file: %v", err)
-	}
-
-	// Create server with templates
-	srv := createTestServerWithTemplates(t)
-	srv.rootDir = tmpDir
-	defer srv.wizardStore.Stop()
-
-	// Test POST /settings with negative threshold
-	form := url.Values{}
-	form.Set("setup_model", "setup-provider/setup-model")
-	form.Set("planning_model", "planning-provider/planning-model")
-	form.Set("orchestration_model", "orch-provider/orch-model")
-	form.Set("code_model", "code-provider/code-model")
-	form.Set("code_heavy_model", "code-heavy-provider/code-heavy-model")
-	form.Set("routing_code_size_threshold", "-1") // Negative - should fail validation
-	form.Set("routing_high_complexity_threshold", "600")
-	form.Set("routing_file_count_threshold", "10")
-
-	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	rec := httptest.NewRecorder()
-
-	srv.handleSaveSettings(rec, req)
-
-	// Should return 200 OK but with error message
-	if rec.Code != http.StatusOK {
-		t.Errorf("expected status 200, got %d", rec.Code)
-	}
-
-	// Verify error message
-	body := rec.Body.String()
-	if !strings.Contains(body, "positive integer") {
-		t.Error("response should contain validation error for negative threshold")
-	}
-}
-
 // TestSettingsPersistence verifies that saved config can be reloaded correctly
 func TestSettingsPersistence(t *testing.T) {
 	// Create a temporary directory for config
@@ -3999,12 +3934,6 @@ func TestSettingsPersistence(t *testing.T) {
 	// Verify the values were persisted
 	if reloadedCfg.LLM.Code.Model != "persisted-provider/persisted-model" {
 		t.Errorf("expected model to be 'persisted-provider/persisted-model', got %q", reloadedCfg.LLM.Code.Model)
-	}
-	if reloadedCfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold != 200 { //nolint:staticcheck // deprecated but kept for backward compatibility
-		t.Errorf("expected code size threshold to be 200, got %d", reloadedCfg.LLM.RoutingRules.ComplexityThresholds.CodeSizeThreshold) //nolint:staticcheck // deprecated but kept for backward compatibility
-	}
-	if len(reloadedCfg.LLM.RoutingRules.ForceStrongForStages) != 1 || reloadedCfg.LLM.RoutingRules.ForceStrongForStages[0] != "test-stage" { //nolint:staticcheck // deprecated but kept for backward compatibility
-		t.Errorf("expected force strong stages to be ['test-stage'], got %v", reloadedCfg.LLM.RoutingRules.ForceStrongForStages) //nolint:staticcheck // deprecated but kept for backward compatibility
 	}
 }
 
@@ -4321,18 +4250,18 @@ func TestHandleSettingsTemplateData(t *testing.T) {
 		t.Fatalf("failed to create .oda directory: %v", err)
 	}
 
-	// Create a config file with force strong stages
+	// Create a config file with model settings
 	configContent := `llm:
-  development:
-    strong:
-      model: test-provider/test-model
-    weak:
-      model: test-provider/test-model-weak
-  routing_rules:
-    force_strong_for_stages:
-      - stage1
-      - stage2
-      - stage3
+  setup:
+    model: test-provider/test-model
+  planning:
+    model: test-provider/test-model
+  orchestration:
+    model: test-provider/test-model
+  code:
+    model: test-provider/test-model
+  code-heavy:
+    model: test-provider/test-model
 `
 	configPath := filepath.Join(odaDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -4355,10 +4284,10 @@ func TestHandleSettingsTemplateData(t *testing.T) {
 		t.Errorf("expected status 200, got %d", rec.Code)
 	}
 
-	// Verify force strong stages are displayed as comma-separated
+	// Verify model settings are displayed
 	body := rec.Body.String()
-	if !strings.Contains(body, "stage1, stage2, stage3") && !strings.Contains(body, "stage1,stage2,stage3") {
-		t.Error("response should contain comma-separated force strong stages")
+	if !strings.Contains(body, "test-provider/test-model") {
+		t.Error("response should contain model settings")
 	}
 }
 

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -29,7 +29,6 @@
           <input type="text" id="setup_model" name="setup_model" value="{{.Config.Setup.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
           <div class="model-dropdown-list" id="dropdown-setup_model"></div>
         </div>
-        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
       
       <div class="form-group">
@@ -38,7 +37,6 @@
           <input type="text" id="planning_model" name="planning_model" value="{{.Config.Planning.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
           <div class="model-dropdown-list" id="dropdown-planning_model"></div>
         </div>
-        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
       
       <div class="form-group">
@@ -47,7 +45,6 @@
           <input type="text" id="orchestration_model" name="orchestration_model" value="{{.Config.Orchestration.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
           <div class="model-dropdown-list" id="dropdown-orchestration_model"></div>
         </div>
-        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
       
       <div class="form-group">
@@ -56,7 +53,6 @@
           <input type="text" id="code_model" name="code_model" value="{{.Config.Code.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
           <div class="model-dropdown-list" id="dropdown-code_model"></div>
         </div>
-        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
       </div>
       
       <div class="form-group">
@@ -65,32 +61,6 @@
           <input type="text" id="code_heavy_model" name="code_heavy_model" value="{{.Config.CodeHeavy.Model}}" required autocomplete="off" class="model-dropdown-input" placeholder="e.g., nexos-ai/Kimi K2.5">
           <div class="model-dropdown-list" id="dropdown-code_heavy_model"></div>
         </div>
-        <small>Format: provider/model (e.g., nexos-ai/Kimi K2.5)</small>
-      </div>
-    </div>
-    
-    <!-- Routing Rules -->
-    <div class="category-section">
-      <h2>Routing Rules</h2>
-      <div class="form-group">
-        <label for="routing_code_size_threshold">Code Size Threshold (lines)</label>
-        <input type="number" id="routing_code_size_threshold" name="routing_code_size_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.CodeSizeThreshold}}" min="1" required>
-        <small>Number of lines that triggers medium complexity</small>
-      </div>
-      <div class="form-group">
-        <label for="routing_high_complexity_threshold">High Complexity Threshold (lines)</label>
-        <input type="number" id="routing_high_complexity_threshold" name="routing_high_complexity_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.HighComplexityThreshold}}" min="1" required>
-        <small>Number of lines that triggers high complexity</small>
-      </div>
-      <div class="form-group">
-        <label for="routing_file_count_threshold">File Count Threshold</label>
-        <input type="number" id="routing_file_count_threshold" name="routing_file_count_threshold" value="{{.Config.RoutingRules.ComplexityThresholds.FileCountThreshold}}" min="1" required>
-        <small>Number of files that triggers higher complexity</small>
-      </div>
-      <div class="form-group">
-        <label for="routing_force_strong_stages">Force Strong For Stages (comma-separated)</label>
-        <input type="text" id="routing_force_strong_stages" name="routing_force_strong_stages" value="{{.ForceStrongStages}}" placeholder="plan-review, code-review, merge">
-        <small>Pipeline stages that always use strong models</small>
       </div>
     </div>
     

--- a/internal/initialize/init.go
+++ b/internal/initialize/init.go
@@ -85,14 +85,12 @@ func (i *Init) Run() error {
 }
 
 type configFile struct {
-	GitHub       ghSection       `yaml:"github"`
-	Dashboard    dashSection     `yaml:"dashboard"`
-	Workers      workersSection  `yaml:"workers"`
-	OpenCode     ocSection       `yaml:"opencode"`
-	Pipeline     pipelineSection `yaml:"pipeline"`
-	Planning     llmSection      `yaml:"planning"`
-	EpicAnalysis llmSection      `yaml:"epic_analysis"`
-	Sprint       sprintSection   `yaml:"sprint"`
+	GitHub    ghSection       `yaml:"github"`
+	Dashboard dashSection     `yaml:"dashboard"`
+	Workers   workersSection  `yaml:"workers"`
+	OpenCode  ocSection       `yaml:"opencode"`
+	Pipeline  pipelineSection `yaml:"pipeline"`
+	Sprint    sprintSection   `yaml:"sprint"`
 }
 
 type ghSection struct {
@@ -116,10 +114,6 @@ type pipelineSection struct {
 	MaxRetries int `yaml:"max_retries"`
 }
 
-type llmSection struct {
-	LLM string `yaml:"llm"`
-}
-
 type sprintSection struct {
 	TasksPerSprint int `yaml:"tasks_per_sprint"`
 }
@@ -133,9 +127,7 @@ func defaultConfig(repo string) configFile {
 		Pipeline: pipelineSection{
 			MaxRetries: 5,
 		},
-		Planning:     llmSection{LLM: "claude-opus-4"},
-		EpicAnalysis: llmSection{LLM: "claude-sonnet-4"},
-		Sprint:       sprintSection{TasksPerSprint: 10},
+		Sprint: sprintSection{TasksPerSprint: 10},
 	}
 }
 

--- a/internal/llm/complexity.go
+++ b/internal/llm/complexity.go
@@ -46,14 +46,41 @@ func countComplexityIndicators(text string) int {
 }
 
 // ComplexityAnalyzer provides detailed complexity analysis for tasks
+//
+// Deprecated: Complexity-based routing is being phased out
 type ComplexityAnalyzer struct {
-	thresholds config.ComplexityThresholds //nolint:staticcheck // deprecated but kept for backward compatibility
+	thresholds ComplexityThresholds
+}
+
+// ComplexityThresholds defines thresholds for complexity detection
+//
+// Deprecated: Being phased out in favor of explicit per-mode model selection
+type ComplexityThresholds struct {
+	// CodeSizeThreshold is the number of lines that triggers medium complexity
+	CodeSizeThreshold int
+
+	// HighComplexityThreshold is the number of lines that triggers high complexity
+	HighComplexityThreshold int
+
+	// FileCountThreshold is the number of files that triggers higher complexity
+	FileCountThreshold int
+}
+
+// defaultThresholds returns the default complexity thresholds
+func defaultThresholds() ComplexityThresholds {
+	return ComplexityThresholds{
+		CodeSizeThreshold:       100,
+		HighComplexityThreshold: 500,
+		FileCountThreshold:      5,
+	}
 }
 
 // NewComplexityAnalyzer creates a new complexity analyzer
-func NewComplexityAnalyzer(thresholds config.ComplexityThresholds) *ComplexityAnalyzer { //nolint:staticcheck // deprecated but kept for backward compatibility
+//
+// Deprecated: Complexity-based routing is being phased out
+func NewComplexityAnalyzer(thresholds ComplexityThresholds) *ComplexityAnalyzer {
 	if thresholds.CodeSizeThreshold == 0 {
-		thresholds = config.DefaultLLMConfig().RoutingRules.ComplexityThresholds //nolint:staticcheck // deprecated but kept for backward compatibility
+		thresholds = defaultThresholds()
 	}
 
 	return &ComplexityAnalyzer{
@@ -259,7 +286,7 @@ func EstimateFromKeywords(text string, keywords TaskKeywords) config.ComplexityL
 //
 // Deprecated: Complexity-based routing is being phased out
 func DetectComplexity(context string) config.ComplexityLevel {
-	thresholds := config.DefaultLLMConfig().RoutingRules.ComplexityThresholds
+	thresholds := defaultThresholds()
 	analyzer := NewComplexityAnalyzer(thresholds)
 	report := analyzer.AnalyzeTask(context, []string{}, nil)
 	return report.Complexity

--- a/internal/llm/router_test.go
+++ b/internal/llm/router_test.go
@@ -141,7 +141,7 @@ func TestRouter_OnReload(t *testing.T) {
 }
 
 func TestComplexityAnalyzer(t *testing.T) {
-	thresholds := config.ComplexityThresholds{ //nolint:staticcheck // deprecated but kept for backward compatibility
+	thresholds := llm.ComplexityThresholds{
 		CodeSizeThreshold:       100,
 		HighComplexityThreshold: 500,
 		FileCountThreshold:      5,

--- a/internal/mvp/integration_test.go
+++ b/internal/mvp/integration_test.go
@@ -224,9 +224,11 @@ func TestWorkerProcessEndToEnd(t *testing.T) {
 	gh := &github.Client{Repo: "owner/repo"}
 
 	cfg := &config.Config{
-		Planning:     config.Planning{LLM: "claude-sonnet-4"},
-		EpicAnalysis: config.EpicAnalysis{LLM: "claude-sonnet-4"},
-		Tools:        config.Tools{TestCmd: "echo test-ok"},
+		LLM: config.LLMConfig{
+			Planning: config.CategoryModels{Model: "claude-sonnet-4"},
+			Code:     config.CategoryModels{Model: "claude-sonnet-4"},
+		},
+		Tools: config.Tools{TestCmd: "echo test-ok"},
 	}
 
 	router := llm.NewRouter(&cfg.LLM)
@@ -287,9 +289,11 @@ func TestWorkerProcessStatusTransitions(t *testing.T) {
 	gh := &github.Client{Repo: "owner/repo"}
 
 	cfg := &config.Config{
-		Planning:     config.Planning{LLM: "claude-sonnet-4"},
-		EpicAnalysis: config.EpicAnalysis{LLM: "claude-sonnet-4"},
-		Tools:        config.Tools{TestCmd: "echo ok"},
+		LLM: config.LLMConfig{
+			Planning: config.CategoryModels{Model: "claude-sonnet-4"},
+			Code:     config.CategoryModels{Model: "claude-sonnet-4"},
+		},
+		Tools: config.Tools{TestCmd: "echo ok"},
 	}
 
 	router := llm.NewRouter(&cfg.LLM)
@@ -323,9 +327,11 @@ func TestWorkerProcessTestFailure(t *testing.T) {
 	gh := &github.Client{Repo: "owner/repo"}
 
 	cfg := &config.Config{
-		Planning:     config.Planning{LLM: "claude-sonnet-4"},
-		EpicAnalysis: config.EpicAnalysis{LLM: "claude-sonnet-4"},
-		Tools:        config.Tools{TestCmd: "exit 1"},
+		LLM: config.LLMConfig{
+			Planning: config.CategoryModels{Model: "claude-sonnet-4"},
+			Code:     config.CategoryModels{Model: "claude-sonnet-4"},
+		},
+		Tools: config.Tools{TestCmd: "exit 1"},
 	}
 
 	router := llm.NewRouter(&cfg.LLM)

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -292,7 +292,7 @@ func (o *Orchestrator) pickNextTicket(_ context.Context, candidates []github.Iss
 	}()
 
 	// Use router to select model for orchestration category
-	llmModel := o.cfg.Planning.LLM
+	llmModel := o.cfg.LLM.Orchestration.Model
 	if o.router != nil {
 		llmModel = o.router.SelectModel(config.CategoryOrchestration, config.ComplexityMedium, nil)
 	}

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -368,7 +368,7 @@ func (w *Worker) technicalPlanning(ctx context.Context, task *Task) (analysis, i
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPTechnicalPlanning), task.Issue.Number, task.Issue.Title, task.Issue.Body)
 
 	// Use router to select model for planning category
-	llmModel := w.cfg.Planning.LLM
+	llmModel := w.cfg.LLM.Planning.Model
 	if w.router != nil {
 		llmModel = w.router.SelectModel(config.CategoryPlanning, config.ComplexityMedium, nil)
 	}
@@ -473,7 +473,7 @@ func (w *Worker) implement(ctx context.Context, task *Task, planStr string) erro
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPImplementation), task.Issue.Number, task.Issue.Title, planStr, task.Worktree, testCmd)
 
 	// Use router to select model for code category with complexity detection
-	llmModel := w.cfg.EpicAnalysis.LLM
+	llmModel := w.cfg.LLM.Code.Model
 	if w.router != nil {
 		complexity := llm.DetectComplexity(planStr) //nolint:staticcheck // deprecated but still used
 		llmModel = w.router.SelectModel(config.CategoryCode, complexity, nil)
@@ -508,7 +508,7 @@ func (w *Worker) fixFromReview(ctx context.Context, task *Task, review string) e
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPFixFromReview), task.Issue.Number, task.Issue.Title, task.Worktree, testCmd, review)
 
 	// Use router to select model for code category
-	llmModel := w.cfg.EpicAnalysis.LLM
+	llmModel := w.cfg.LLM.Code.Model
 	if w.router != nil {
 		llmModel = w.router.SelectModel(config.CategoryCode, config.ComplexityMedium, nil)
 	}
@@ -571,7 +571,7 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string) (appr
 	task.AddChatMessage("user", prompt)
 
 	// Use router to select model for code category with high complexity (code review is important)
-	llmModel := w.cfg.Planning.LLM
+	llmModel := w.cfg.LLM.Code.Model
 	if w.router != nil {
 		hints := map[string]any{"stage": "code-review"}
 		llmModel = w.router.SelectModel(config.CategoryCode, config.ComplexityHigh, hints)

--- a/internal/scheduler/epic.go
+++ b/internal/scheduler/epic.go
@@ -41,7 +41,7 @@ func (ea *EpicAnalyzer) Analyze(description string) ([]TaskSpec, error) {
 	prompt := buildEpicPrompt(description)
 
 	// Use router to select model for planning category with complexity detection
-	llmModel := ea.cfg.EpicAnalysis.LLM
+	llmModel := ea.cfg.LLM.Planning.Model
 	if ea.router != nil {
 		complexity := llm.DetectComplexity(description) //nolint:staticcheck // deprecated but still used
 		routerModel := ea.router.SelectModel(config.CategoryPlanning, complexity, nil)

--- a/internal/scheduler/epic_test.go
+++ b/internal/scheduler/epic_test.go
@@ -142,7 +142,9 @@ func TestEpicAnalyzer_ParseResponse(t *testing.T) {
 	defer srv.Close()
 
 	cfg := &config.Config{
-		EpicAnalysis: config.EpicAnalysis{LLM: "test-model"},
+		LLM: config.LLMConfig{
+			Planning: config.CategoryModels{Model: "test-model"},
+		},
 	}
 	oc := opencode.NewClient(srv.URL)
 	router := llm.NewRouter(&cfg.LLM)

--- a/internal/scheduler/planner.go
+++ b/internal/scheduler/planner.go
@@ -53,7 +53,7 @@ func (p *Planner) PlanSprint() (*Sprint, error) {
 	prompt := prompts.MustGet(prompts.WorkerAutomatedPipeline) + buildSprintPrompt(issues, p.cfg.Sprint.TasksPerSprint)
 
 	// Use router to select model for planning category
-	llmModel := p.cfg.Planning.LLM
+	llmModel := p.cfg.LLM.Planning.Model
 	if p.router != nil {
 		llmModel = p.router.SelectModel(config.CategoryPlanning, config.ComplexityMedium, nil)
 	}
@@ -131,7 +131,7 @@ func (p *Planner) AnalyzeInsights(sprintID int) error {
 	prompt := buildInsightPrompt(allInsights)
 
 	// Use router to select model for planning category
-	llmModel := p.cfg.Planning.LLM
+	llmModel := p.cfg.LLM.Planning.Model
 	if p.router != nil {
 		llmModel = p.router.SelectModel(config.CategoryPlanning, config.ComplexityLow, nil)
 	}

--- a/internal/scheduler/planner_test.go
+++ b/internal/scheduler/planner_test.go
@@ -202,8 +202,10 @@ func TestPlanSprint_Integration(t *testing.T) {
 	defer srv.Close()
 
 	cfg := &config.Config{
-		Planning: config.Planning{LLM: "test-planner"},
-		Sprint:   config.Sprint{TasksPerSprint: 5},
+		LLM: config.LLMConfig{
+			Planning: config.CategoryModels{Model: "test-planner"},
+		},
+		Sprint: config.Sprint{TasksPerSprint: 5},
 	}
 	oc := opencode.NewClient(srv.URL)
 
@@ -223,7 +225,7 @@ func TestPlanSprint_Integration(t *testing.T) {
 		{Number: 5, Title: "Task B", Labels: []label{{Name: "size:M"}}},
 	}, cfg.Sprint.TasksPerSprint)
 
-	msg, err := planner.oc.SendMessage(session.ID, prompt, opencode.ParseModelRef(cfg.Planning.LLM), nil)
+	msg, err := planner.oc.SendMessage(session.ID, prompt, opencode.ParseModelRef(cfg.LLM.Planning.Model), nil)
 	if err != nil {
 		t.Fatalf("sending message: %v", err)
 	}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -146,7 +146,7 @@ func (s *Setup) generateWithLLM(title, prompt string) (string, error) {
 	}
 
 	// Use router to select model for setup category
-	llmModel := s.cfg.Planning.LLM
+	llmModel := s.cfg.LLM.Setup.Model
 	if s.router != nil {
 		llmModel = s.router.SelectModel(config.CategorySetup, config.ComplexityMedium, nil)
 	}

--- a/main.go
+++ b/main.go
@@ -372,7 +372,7 @@ func runServe(dir string, debugWebSocket bool) error {
 		}
 	}()
 
-	srv, err := dashboard.NewServer(cfg.Dashboard.Port, cfg.OpenCode.WebPort, store, pool.Workers, gh, orchestrator, oc, cfg.Planning.LLM, hub, syncService, dir)
+	srv, err := dashboard.NewServer(cfg.Dashboard.Port, cfg.OpenCode.WebPort, store, pool.Workers, gh, orchestrator, oc, cfg.LLM.Planning.Model, hub, syncService, dir)
 	if err != nil {
 		return fmt.Errorf("creating dashboard server: %w", err)
 	}
@@ -449,10 +449,6 @@ func collectConfigModels(cfg *config.Config) []opencode.ModelRef {
 		seen[llm] = true
 		models = append(models, opencode.ParseModelRef(llm))
 	}
-
-	// Add legacy config models for backward compatibility
-	add(cfg.Planning.LLM)
-	add(cfg.EpicAnalysis.LLM)
 
 	// Add models from new LLM config (5 independent modes)
 	add(cfg.LLM.Setup.Model)


### PR DESCRIPTION
Closes #296

## Context

The LLM configuration has accumulated technical debt from multiple iterations:

1. **Top-level `planning.llm` and `epic_analysis.llm` fields** — these are redundant with `llm.planning.model` and should be removed
2. **Legacy `strong/weak` nesting** — the YAML uses `development.strong.model` / `development.weak.model` but the Go structs already expect flat `category.model`. The `MigrateFromLegacy()` function exists but is never called from `Load()`
3. **`validateModelFormat()`** in the dashboard settings handler requires `provider/model` format (must contain `/`), but many real model IDs from the opencode API don't follow this pattern (e.g. `nemotron-3-super-free`, `kimi-k2.5`, `deepseek-chat`). This causes the settings page to reject valid models on save.
4. **Deprecated routing fields** — `default_complexity`, `ShouldUseStrongModel()`, `ModelVariant`, `VariantStrong/VariantWeak`, `LegacyCategoryModels`, `LegacyLLMConfig` are dead code.

## Requirements

### New config structure

The `llm:` section should have exactly 5 flat categories:

```yaml
llm:
    setup:
        model: nexos-ai/Kimi K2.5
    planning:
        model: nexos-ai/Kimi K2.5
    orchestration:
        model: nexos-ai/Kimi K2.5
    code:
        model: nexos-ai/Kimi K2.5
    code-heavy:
        model: nexos-ai/Kimi K2.5
```

No `strong/weak` nesting, no `default_complexity`, no `routing_rules`.

### Fields to remove from Config struct

- `Planning` (top-level, the one with `LLM string`)
- `EpicAnalysis` (top-level)

All code referencing `cfg.Planning.LLM` must use `cfg.LLM.Planning.Model` instead.
All code referencing `cfg.EpicAnalysis.LLM` must use `cfg.LLM.Planning.Model` instead.

### Legacy migration in Load()

When `Load()` detects the old YAML format, it must auto-migrate in memory:

- `development.weak.model` → `code.model`
- `development.strong.model` → `code-heavy.model`
- `planning.strong.model` → `planning.model` (fallback to `weak` if `strong` empty)
- `orchestration.strong.model` → `orchestration.model` (fallback to `weak`)
- `setup.strong.model` → `setup.model` (fallback to `weak`)
- Top-level `planning.llm` → `llm.planning.model` (if `llm.planning.model` is empty after migration)
- Top-level `epic_analysis.llm` → ignored (mapped to planning)

### Fix validateModelFormat()

Change validation to accept any non-empty string. Model IDs from the opencode API do not always contain `/`.

### Dead code removal

Remove from `internal/config/llm.go`:
- `ModelVariant` type and `VariantStrong`/`VariantWeak` constants
- `LegacyCategoryModels` struct
- `LegacyLLMConfig` struct
- `MigrateFromLegacy()` method (replaced by new migration logic in `Load()`)
- `ShouldUseStrongModel()` method
- `DefaultComplexity` field from `LLMConfig`
- `RoutingRules` / `RoutingConfig` / `ComplexityThresholds` — if still referenced in dashboard settings UI, remove from UI too

### Dashboard settings page

- Remove Routing Rules section (complexity thresholds, force strong for stages) from `templates/llm-config.html`
- Remove corresponding handler code in `handleSaveSettings`
- Keep only the 5 model selectors and pipeline settings (YOLO mode)

### Update .oda/config.yaml

Rewrite to new format, removing `planning:`, `epic_analysis:`, and legacy `llm:` structure.

### Update internal/initialize/init.go

The generated default config for `oda init` must use the new structure (no `planning:`, no `epic_analysis:`, flat `llm:` categories).

## Files to modify

- `internal/config/config.go` — remove `Planning`, `EpicAnalysis` structs and fields; add legacy detection in `Load()`
- `internal/config/llm.go` — remove dead code, remove `RoutingRules`/`ComplexityThresholds`/`DefaultComplexity`
- `internal/config/config_test.go` — update tests
- `internal/dashboard/handlers.go` — fix `validateModelFormat()`, remove routing rules handling
- `internal/dashboard/handlers_test.go` — update tests
- `internal/dashboard/templates/llm-config.html` — remove routing rules section
- `internal/initialize/init.go` — update default config template
- `internal/mvp/worker.go` — replace `cfg.Planning.LLM` / `cfg.EpicAnalysis.LLM`
- `internal/mvp/orchestrator.go` — replace `cfg.Planning.LLM`
- `internal/mvp/integration_test.go` — update test configs
- `internal/scheduler/planner.go` — replace `cfg.Planning.LLM`
- `internal/scheduler/planner_test.go` — update test
- `internal/scheduler/epic.go` — replace `cfg.EpicAnalysis.LLM`
- `internal/scheduler/epic_test.go` — update test
- `internal/setup/setup.go` — replace `cfg.Planning.LLM`
- `main.go` — replace `cfg.Planning.LLM`, `cfg.EpicAnalysis.LLM`
- `.oda/config.yaml` — rewrite to new format

## Acceptance Criteria

- [ ] Config YAML has flat 5-category `llm:` structure, no `strong/weak`
- [ ] No top-level `planning:` or `epic_analysis:` fields in config
- [ ] `Load()` auto-migrates old format in memory (dev.weak→code, dev.strong→code-heavy)
- [ ] Settings page saves without errors when model IDs don't contain `/`
- [ ] All dead code removed (`ModelVariant`, `LegacyCategoryModels`, `ShouldUseStrongModel`, etc.)
- [ ] Dashboard settings page shows only 5 model selectors + YOLO mode
- [ ] `golangci-lint run ./...` passes
- [ ] `go test -race ./...` passes