### PR TITLE
Auto-checkout default branch after PR merge and issue closure

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -541,6 +541,10 @@ func (s *Server) handleDirectMerge(w http.ResponseWriter, r *http.Request, issue
 	}
 
 	_ = s.orchestrator.ChangeStage(issueNum, github.StageDone, github.ReasonManualMerge)
+
+	// Checkout default branch to prepare for next ticket (non-critical)
+	s.orchestrator.CheckoutDefault()
+
 	log.Printf("[Dashboard] ✓ Direct merged #%d (fallback)", issueNum)
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -156,6 +156,20 @@ func (m *BranchManager) detectDefaultBranch() string {
 	return "master"
 }
 
+// CheckoutDefault switches to the default branch (main or master).
+// This is called after a successful merge to prepare the repository
+// for the next ticket. Errors are logged but not returned as this
+// is a non-critical cleanup operation.
+func (m *BranchManager) CheckoutDefault() error {
+	defaultBranch := m.detectDefaultBranch()
+	cmd := exec.Command("git", "checkout", defaultBranch)
+	cmd.Dir = m.repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git checkout %s: %w\n%s", defaultBranch, err, out)
+	}
+	return nil
+}
+
 // detectRemoteDefaultBranch returns the default branch name on origin
 // (e.g. "main" or "master") by inspecting origin/HEAD. Returns "" if
 // the remote has no HEAD or the remote doesn't exist.

--- a/internal/git/worktree_test.go
+++ b/internal/git/worktree_test.go
@@ -328,3 +328,81 @@ func TestRemoveBranchNonExistent(t *testing.T) {
 		t.Errorf("current branch = %q, want master or main", got)
 	}
 }
+
+// TestCheckoutDefault verifies that CheckoutDefault switches to the default branch.
+func TestCheckoutDefault(t *testing.T) {
+	repoDir := setupRepo(t)
+	mgr := git.NewBranchManager(repoDir)
+
+	// Create and switch to a feature branch
+	if err := mgr.CreateBranch("feature-test"); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+
+	if got := currentBranch(t, repoDir); got != "feature-test" {
+		t.Errorf("current branch = %q, want %q", got, "feature-test")
+	}
+
+	// CheckoutDefault should switch back to master
+	if err := mgr.CheckoutDefault(); err != nil {
+		t.Fatalf("CheckoutDefault: %v", err)
+	}
+
+	got := currentBranch(t, repoDir)
+	if got != "master" && got != "main" {
+		t.Errorf("current branch = %q, want master or main", got)
+	}
+}
+
+// TestCheckoutDefaultWithMainBranch verifies CheckoutDefault works when default is main.
+func TestCheckoutDefaultWithMainBranch(t *testing.T) {
+	env := []string{
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	}
+
+	runGit := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), env...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Create a bare repo to act as "origin"
+	bareDir := t.TempDir()
+	runGit(bareDir, "init", "--bare")
+
+	// Clone it to get a working repo with origin configured
+	cloneDir := t.TempDir()
+	runGit(cloneDir, "clone", bareDir, ".")
+
+	// Create an initial commit and push to origin on main branch
+	runGit(cloneDir, "commit", "--allow-empty", "-m", "init")
+	runGit(cloneDir, "branch", "-m", "main")
+	runGit(cloneDir, "push", "origin", "main")
+
+	mgr := git.NewBranchManager(cloneDir)
+
+	// Create and switch to a feature branch
+	if err := mgr.CreateBranch("feature-test"); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+
+	if got := currentBranch(t, cloneDir); got != "feature-test" {
+		t.Errorf("current branch = %q, want %q", got, "feature-test")
+	}
+
+	// CheckoutDefault should switch back to main
+	if err := mgr.CheckoutDefault(); err != nil {
+		t.Fatalf("CheckoutDefault: %v", err)
+	}
+
+	if got := currentBranch(t, cloneDir); got != "main" {
+		t.Errorf("current branch = %q, want %q", got, "main")
+	}
+}

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -564,3 +564,14 @@ func (o *Orchestrator) activeMilestone() string {
 	}
 	return ""
 }
+
+// CheckoutDefault switches to the default branch (main or master) after merge.
+// This is a non-critical operation - errors are logged but not returned.
+func (o *Orchestrator) CheckoutDefault() {
+	if o.brMgr == nil {
+		return
+	}
+	if err := o.brMgr.CheckoutDefault(); err != nil {
+		log.Printf("[Orchestrator] Warning: failed to checkout default branch: %v", err)
+	}
+}

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -296,6 +296,11 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 
 			w.reportStageComplete("merge", EventSuccess, "PR merged successfully")
 
+			// Checkout default branch to prepare for next ticket
+			if err := w.brMgr.CheckoutDefault(); err != nil {
+				log.Printf("[Worker %d] Warning: failed to checkout default branch after merge: %v", w.id, err)
+			}
+
 			task.Status = StatusDone
 			task.Result = &TaskResult{
 				PRURL:   prURL,


### PR DESCRIPTION
Closes #300

Currently after merging a PR (`gh pr merge --delete-branch`), the repository remains in a detached state or on a deleted branch. The repository should automatically checkout the default branch (main/master) **after** the issue is successfully closed (reaches `stage:done`), preparing it for the next ticket.

## Current Behavior

1. Worker/dashboard calls `gh pr merge <branch> --merge --delete-branch`
2. Issue transitions to `stage:done` (closed)
3. Git remains on deleted branch reference
4. Next ticket creation may fail or require manual intervention

## Expected Behavior

1. PR is merged and branch deleted
2. Issue transitions to `stage:done` (closed)
3. **After successful closure**, execute `git checkout main` (or master)
4. Repository is clean and ready for next ticket

## Implementation Plan

### Changes needed:

1. `internal/git/worktree.go` — Add `CheckoutDefault()` method to BranchManager
2. `internal/mvp/worker.go:298-305` — After successful merge AND stage completion, checkout default
3. `internal/dashboard/handlers.go:543-546` — Same for dashboard merge handler

## Acceptance Criteria:
- [ ] Issue is closed (stage:done) BEFORE checking out default branch
- [ ] After PR merge + issue closure, repository is on default branch (main/master)
- [ ] Worker can immediately start next ticket without manual git operations
- [ ] Works with both "main" and "master" default branches (auto-detection)
- [ ] Error during checkout is logged but doesn't fail the ticket (non-critical)
- [ ] Unit tests for `CheckoutDefault()` method
- [ ] Integration test verifying repo state after merge