### PR TITLE
Trigger dashboard sync after oda issue create to refresh board immediately

### DIFF
--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
@@ -20,7 +23,7 @@ type IssueCreateFlags struct {
 }
 
 // IssueCommand handles the 'issue' subcommand and its children
-func IssueCommand(args []string, client *github.Client) error {
+func IssueCommand(args []string, client *github.Client, dashboardPort int) error {
 	if len(args) < 1 {
 		return errors.New("issue command requires a subcommand: create")
 	}
@@ -30,14 +33,14 @@ func IssueCommand(args []string, client *github.Client) error {
 
 	switch subcommand {
 	case "create":
-		return IssueCreateCommand(subArgs, client)
+		return IssueCreateCommand(subArgs, client, dashboardPort)
 	default:
 		return fmt.Errorf("unknown issue subcommand: %s", subcommand)
 	}
 }
 
 // IssueCreateCommand handles the 'issue create' subcommand
-func IssueCreateCommand(args []string, client *github.Client) error {
+func IssueCreateCommand(args []string, client *github.Client, dashboardPort int) error {
 	flags := IssueCreateFlags{}
 
 	// Create a new flag set for this subcommand
@@ -95,6 +98,11 @@ func IssueCreateCommand(args []string, client *github.Client) error {
 	}
 	if len(labels) > 0 {
 		fmt.Printf("Labels: %s\n", strings.Join(labels, ", "))
+	}
+
+	// Trigger dashboard sync if port is configured
+	if dashboardPort > 0 {
+		triggerDashboardSync(dashboardPort)
 	}
 
 	return nil
@@ -158,4 +166,26 @@ func PrintIssueUsage() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  oda issue create --title \"Fix login bug\" --text \"Users cannot login\" --priority high --type bug --current-sprint")
+}
+
+// triggerDashboardSync sends an HTTP POST request to the dashboard sync endpoint
+func triggerDashboardSync(port int) {
+	url := fmt.Sprintf("http://localhost:%d/api/sync", port)
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+
+	resp, err := client.Post(url, "application/json", nil)
+	if err != nil {
+		log.Printf("Warning: dashboard sync failed (dashboard may not be running): %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("Dashboard synced")
+	} else {
+		log.Printf("Warning: dashboard sync returned status %d", resp.StatusCode)
+	}
 }

--- a/cmd/issue_test.go
+++ b/cmd/issue_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -164,7 +167,57 @@ func TestIssueCreateCommand_Help(t *testing.T) {
 		t.Run(tt.name, func(_ *testing.T) {
 			// Just verify it doesn't panic - help prints to stdout
 			// We can't easily capture stdout in this test structure
-			_ = tt.args
+			_ = IssueCreateCommand(tt.args, nil, 0)
 		})
 	}
+}
+
+func TestTriggerDashboardSync(t *testing.T) {
+	tests := []struct {
+		name             string
+		serverResponse   int
+		expectSyncCalled bool
+	}{
+		{
+			name:             "successful sync",
+			serverResponse:   http.StatusOK,
+			expectSyncCalled: true,
+		},
+		{
+			name:             "sync with non-200 status",
+			serverResponse:   http.StatusInternalServerError,
+			expectSyncCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/api/sync" && r.Method == "POST" {
+					syncCalled = true
+				}
+				w.WriteHeader(tt.serverResponse)
+			}))
+			defer server.Close()
+
+			// Extract port from server URL (format: http://127.0.0.1:PORT)
+			portStr := strings.TrimPrefix(server.URL, "http://127.0.0.1:")
+			portStr = strings.TrimPrefix(portStr, "http://[::]:")
+			port := 0
+			fmt.Sscanf(portStr, "%d", &port)
+
+			triggerDashboardSync(port)
+
+			if syncCalled != tt.expectSyncCalled {
+				t.Errorf("sync endpoint called = %v, want %v", syncCalled, tt.expectSyncCalled)
+			}
+		})
+	}
+}
+
+func TestTriggerDashboardSync_DashboardNotRunning(t *testing.T) {
+	// Use an unused port to simulate dashboard not running
+	triggerDashboardSync(59999)
+	// Should not panic or return error - function should return gracefully
 }

--- a/main.go
+++ b/main.go
@@ -136,7 +136,7 @@ func runIssue(args []string, dir string) error {
 	}
 
 	gh := github.NewClient(cfg.GitHub.Repo)
-	return cmd.IssueCommand(args, gh)
+	return cmd.IssueCommand(args, gh, cfg.Dashboard.Port)
 }
 
 func runServe(dir string, debugWebSocket bool) error {


### PR DESCRIPTION
Closes #310

Currently when a user creates an issue via `oda issue create` CLI command, the dashboard doesn't refresh automatically. The new ticket only appears after the next automatic sync (every 30 seconds) or manual sync button click. We should trigger an immediate sync via HTTP call to the dashboard API after successful issue creation.

## Current Behavior

1. User runs `oda issue create --title "..." --text "..."`
2. Issue is created on GitHub
3. Dashboard still shows old state (without new ticket)
4. User must wait ~30 seconds or click "Sync" button manually

## Expected Behavior

1. User runs `oda issue create`
2. Issue is created on GitHub
3. **CLI triggers sync via HTTP call to dashboard**
4. Dashboard refreshes immediately with new ticket visible

## Implementation Plan

### Changes needed:

1. `main.go:139` — Pass config to IssueCommand
2. `cmd/issue.go:23` — Update IssueCommand signature
3. `cmd/issue.go:33` — Pass config to IssueCreateCommand
4. `cmd/issue.go:40` — Update IssueCreateCommand signature and add sync trigger
5. `cmd/issue.go` — Add imports (log, net/http)

## Acceptance Criteria:
- [ ] After `oda issue create`, dashboard sync is triggered automatically
- [ ] New ticket appears on dashboard immediately (within seconds)
- [ ] Sync trigger reads dashboard port from `.oda/config.yaml`
- [ ] If dashboard is not running, warning is logged but creation succeeds
- [ ] Message "Dashboard synced" is printed after successful sync
- [ ] Unit tests updated for new function signatures
- [ ] Integration test verifying sync trigger after issue creation