### PR TITLE
Add quick YOLO mode toggle in footer - click to enable/disable

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1976,3 +1976,58 @@ func (s *Server) handleWorkerStatus(w http.ResponseWriter, _ *http.Request) {
 		log.Printf("[Dashboard] Error encoding JSON: %v", err)
 	}
 }
+
+// handleYoloToggle toggles the YOLO mode setting and returns an HTMX fragment
+func (s *Server) handleYoloToggle(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	if s.rootDir == "" {
+		http.Error(w, "root directory not configured", http.StatusInternalServerError)
+		return
+	}
+
+	// Load current config
+	cfg, err := config.Load(s.rootDir)
+	if err != nil {
+		log.Printf("[Dashboard] Error loading config for YOLO toggle: %v", err)
+		http.Error(w, "failed to load configuration", http.StatusInternalServerError)
+		return
+	}
+
+	// Toggle YOLO mode
+	cfg.YoloMode = !cfg.YoloMode
+
+	// Save config
+	if err := config.SaveConfig(s.rootDir, cfg); err != nil {
+		log.Printf("[Dashboard] Error saving config after YOLO toggle: %v", err)
+		http.Error(w, "failed to save configuration", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[Dashboard] YOLO mode toggled to: %v", cfg.YoloMode)
+
+	// Return the updated toggle HTML fragment
+	if cfg.YoloMode {
+		_, _ = fmt.Fprint(w, `<div class="yolo-mode-container yolo-enabled" id="yolo-mode-container" hx-post="/api/yolo/toggle" hx-swap="outerHTML" title="Click to disable YOLO mode">
+  <span class="yolo-mode-icon">⚡</span>
+  <span>YOLO MODE</span>
+  <div class="yolo-mode-tooltip">
+    <div class="yolo-mode-tooltip-header">YOLO Mode Enabled</div>
+    <div class="yolo-mode-tooltip-content">
+      AI will auto-approve all changes without human review. Click to disable.
+    </div>
+  </div>
+</div>`)
+	} else {
+		_, _ = fmt.Fprint(w, `<div class="yolo-mode-container yolo-disabled" id="yolo-mode-container" hx-post="/api/yolo/toggle" hx-swap="outerHTML" title="Click to enable YOLO mode">
+  <span class="yolo-mode-icon">🔒</span>
+  <span>SAFE MODE</span>
+  <div class="yolo-mode-tooltip">
+    <div class="yolo-mode-tooltip-header">Safe Mode Enabled</div>
+    <div class="yolo-mode-tooltip-content">
+      All changes require manual approval. Click to enable YOLO mode (auto-approve).
+    </div>
+  </div>
+</div>`)
+	}
+}

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -4412,10 +4412,13 @@ func TestHandleTaskDetail_YoloMode(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
 
-	// Verify the response does NOT contain the YOLO mode indicator when disabled
+	// Verify the response shows SAFE MODE toggle when disabled (toggle is always visible)
 	body = rec.Body.String()
-	if strings.Contains(body, "YOLO MODE") {
-		t.Error("task detail page should NOT contain YOLO MODE indicator when yolo_mode is disabled")
+	if !strings.Contains(body, "SAFE MODE") {
+		t.Error("task detail page should show 'SAFE MODE' toggle when yolo_mode is disabled")
+	}
+	if !strings.Contains(body, `id="yolo-mode-container"`) {
+		t.Error("task detail page should always contain yolo-mode-container element")
 	}
 }
 
@@ -4479,13 +4482,15 @@ func TestHandleBoard_YoloModeIndicator(t *testing.T) {
 
 	body = rec.Body.String()
 
-	// Verify YOLO mode indicator is NOT present when disabled
-	// Check for the actual element id, not just the CSS class name which appears in styles
-	if strings.Contains(body, `id="yolo-mode-container"`) {
-		t.Error("board page should NOT contain yolo-mode-container element when yolo_mode is disabled")
+	// Verify YOLO mode toggle is always present (now in SAFE MODE state when disabled)
+	if !strings.Contains(body, `id="yolo-mode-container"`) {
+		t.Error("board page should always contain yolo-mode-container element")
 	}
-	if strings.Contains(body, ">YOLO MODE<") {
-		t.Error("board page should NOT contain YOLO MODE text when yolo_mode is disabled")
+	if !strings.Contains(body, "SAFE MODE") {
+		t.Error("board page should show 'SAFE MODE' when yolo_mode is disabled")
+	}
+	if !strings.Contains(body, "yolo-disabled") {
+		t.Error("board page should contain yolo-disabled class when yolo_mode is disabled")
 	}
 }
 
@@ -4535,5 +4540,128 @@ func TestSettingsForm_HTMXTargetBody(t *testing.T) {
 	// Verify the form does NOT use hx-target=".settings-container" (old incorrect value)
 	if strings.Contains(body, `hx-target=".settings-container"`) {
 		t.Error("settings form should NOT use hx-target=\".settings-container\" (causes layout duplication)")
+	}
+}
+
+// TestHandleYoloToggle_EnablesWhenDisabled tests that YOLO toggle enables YOLO mode when it's disabled
+func TestHandleYoloToggle_EnablesWhenDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create config with yolo_mode: false
+	configContent := `yolo_mode: false
+`
+	if err := os.WriteFile(filepath.Join(tempDir, ".oda", "config.yaml"), []byte(configContent), 0644); err != nil {
+		// Try creating the directory first
+		if err := os.MkdirAll(filepath.Join(tempDir, ".oda"), 0755); err != nil {
+			t.Fatalf("failed to create .oda directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tempDir, ".oda", "config.yaml"), []byte(configContent), 0644); err != nil {
+			t.Fatalf("failed to write config file: %v", err)
+		}
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tempDir
+	defer srv.wizardStore.Stop()
+
+	// POST to toggle endpoint
+	req := httptest.NewRequest(http.MethodPost, "/api/yolo/toggle", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleYoloToggle(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify response contains enabled state
+	body := rec.Body.String()
+	if !strings.Contains(body, "yolo-enabled") {
+		t.Error("response should contain yolo-enabled class when enabling YOLO mode")
+	}
+	if !strings.Contains(body, "YOLO MODE") {
+		t.Error("response should contain 'YOLO MODE' text when enabling")
+	}
+	if !strings.Contains(body, "⚡") {
+		t.Error("response should contain lightning bolt icon when enabling")
+	}
+
+	// Verify config file now has yolo_mode: true
+	cfg, err := config.Load(tempDir)
+	if err != nil {
+		t.Fatalf("failed to load config after toggle: %v", err)
+	}
+	if !cfg.YoloMode {
+		t.Error("expected config to have yolo_mode: true after toggle")
+	}
+}
+
+// TestHandleYoloToggle_DisablesWhenEnabled tests that YOLO toggle disables YOLO mode when it's enabled
+func TestHandleYoloToggle_DisablesWhenEnabled(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create config with yolo_mode: true
+	configContent := `yolo_mode: true
+`
+	if err := os.MkdirAll(filepath.Join(tempDir, ".oda"), 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, ".oda", "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tempDir
+	defer srv.wizardStore.Stop()
+
+	// POST to toggle endpoint
+	req := httptest.NewRequest(http.MethodPost, "/api/yolo/toggle", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleYoloToggle(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify response contains disabled state
+	body := rec.Body.String()
+	if !strings.Contains(body, "yolo-disabled") {
+		t.Error("response should contain yolo-disabled class when disabling YOLO mode")
+	}
+	if !strings.Contains(body, "SAFE MODE") {
+		t.Error("response should contain 'SAFE MODE' text when disabling")
+	}
+	if !strings.Contains(body, "🔒") {
+		t.Error("response should contain lock icon when disabling")
+	}
+
+	// Verify config file now has yolo_mode: false
+	cfg, err := config.Load(tempDir)
+	if err != nil {
+		t.Fatalf("failed to load config after toggle: %v", err)
+	}
+	if cfg.YoloMode {
+		t.Error("expected config to have yolo_mode: false after toggle")
+	}
+}
+
+// TestHandleYoloToggle_NoRootDir tests that YOLO toggle returns 500 when rootDir is empty
+func TestHandleYoloToggle_NoRootDir(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = "" // Empty rootDir
+	defer srv.wizardStore.Stop()
+
+	// POST to toggle endpoint
+	req := httptest.NewRequest(http.MethodPost, "/api/yolo/toggle", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleYoloToggle(rec, req)
+
+	// Should return 500
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("expected status 500 when rootDir is empty, got %d", rec.Code)
 	}
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -241,6 +241,9 @@ func (s *Server) routes() {
 	// Settings endpoints
 	s.mux.HandleFunc("GET /settings", s.handleSettings)
 	s.mux.HandleFunc("POST /settings", s.handleSaveSettings)
+
+	// YOLO mode toggle endpoint
+	s.mux.HandleFunc("POST /api/yolo/toggle", s.handleYoloToggle)
 }
 
 func (s *Server) Start() error {

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -84,12 +84,16 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
 .worker-status-tooltip::before{content:'';position:absolute;top:100%;right:calc(1rem - 1px);border:7px solid transparent;border-top-color:var(--border)}
 
 /* YOLO mode indicator */
-.yolo-mode-container{position:relative;display:inline-flex;align-items:center;gap:.5rem;padding:.25rem .5rem;border-radius:4px;background:var(--red);border:1px solid var(--red);color:#fff;font-weight:600;font-size:.75rem;margin-right:.75rem;animation:yolo-pulse 2s ease-in-out infinite}
+.yolo-mode-container{position:relative;display:inline-flex;align-items:center;gap:.5rem;padding:.25rem .5rem;border-radius:4px;background:var(--red);border:1px solid var(--red);color:#fff;font-weight:600;font-size:.75rem;margin-right:.75rem;animation:yolo-pulse 2s ease-in-out infinite;cursor:pointer;transition:opacity .2s}
+.yolo-mode-container:hover{opacity:.8}
+.yolo-mode-container.yolo-disabled{background:var(--surface);border-color:var(--border);color:var(--muted);animation:none}
+.yolo-mode-container.yolo-disabled:hover{background:var(--border)}
 @keyframes yolo-pulse{0%,100%{opacity:1;box-shadow:0 0 0 0 rgba(248,81,73,.4)}50%{opacity:.9;box-shadow:0 0 0 4px rgba(248,81,73,.2)}}
 .yolo-mode-container:hover .yolo-mode-tooltip{display:block}
 .yolo-mode-icon{font-size:.9rem}
 .yolo-mode-tooltip{display:none;position:absolute;bottom:100%;right:0;margin-bottom:.5rem;padding:.75rem;background:var(--surface);border:1px solid var(--border);border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,.3);min-width:220px;z-index:1000;color:var(--text);font-weight:400}
 .yolo-mode-tooltip-header{font-weight:600;font-size:.9rem;margin-bottom:.5rem;padding-bottom:.5rem;border-bottom:1px solid var(--border);color:var(--red)}
+.yolo-mode-container.yolo-disabled .yolo-mode-tooltip-header{color:var(--green)}
 .yolo-mode-tooltip-content{font-size:.8rem;line-height:1.4;color:var(--muted)}
 .yolo-mode-tooltip::after{content:'';position:absolute;top:100%;right:1rem;border:6px solid transparent;border-top-color:var(--surface)}
 .yolo-mode-tooltip::before{content:'';position:absolute;top:100%;right:calc(1rem - 1px);border:7px solid transparent;border-top-color:var(--border)}
@@ -129,13 +133,24 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
     </div>
   </div>
   {{if .YoloMode}}
-  <div class="yolo-mode-container" id="yolo-mode-container">
+  <div class="yolo-mode-container yolo-enabled" id="yolo-mode-container" hx-post="/api/yolo/toggle" hx-swap="outerHTML" title="Click to disable YOLO mode">
     <span class="yolo-mode-icon">⚡</span>
     <span>YOLO MODE</span>
     <div class="yolo-mode-tooltip">
       <div class="yolo-mode-tooltip-header">YOLO Mode Enabled</div>
       <div class="yolo-mode-tooltip-content">
-        AI will auto-approve all changes without human review. Use with caution!
+        AI will auto-approve all changes without human review. Click to disable.
+      </div>
+    </div>
+  </div>
+  {{else}}
+  <div class="yolo-mode-container yolo-disabled" id="yolo-mode-container" hx-post="/api/yolo/toggle" hx-swap="outerHTML" title="Click to enable YOLO mode">
+    <span class="yolo-mode-icon">🔒</span>
+    <span>SAFE MODE</span>
+    <div class="yolo-mode-tooltip">
+      <div class="yolo-mode-tooltip-header">Safe Mode Enabled</div>
+      <div class="yolo-mode-tooltip-content">
+        All changes require manual approval. Click to enable YOLO mode (auto-approve).
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #305

Currently YOLO mode can only be changed through the Settings page. Users need a faster way to toggle YOLO mode on/off during active work. The YOLO mode indicator in the footer should be clickable to quickly toggle the mode without navigating to settings.

## Current Behavior

1. YOLO mode indicator is displayed in footer (static, non-interactive)
2. To change YOLO mode, user must:
   - Navigate to Settings page
   - Check/uncheck "Enable YOLO Mode" checkbox
   - Click "Save Settings"
   - Return to board

## Expected Behavior

1. User clicks YOLO mode indicator in footer
2. Mode toggles immediately (on → off, off → on)
3. Config is saved automatically
4. UI updates to show new state
5. Worker receives update (after issue #303 is fixed)

## Implementation Plan

### Backend Changes:

1. `internal/dashboard/server.go` — Add new route:
   ```go
   s.mux.HandleFunc("POST /api/yolo/toggle", s.handleYoloToggle)
   ```

2. `internal/dashboard/handlers.go` — Add handler:
   ```go
   func (s *Server) handleYoloToggle(w http.ResponseWriter, r *http.Request) {
       // Load current config
       cfg, err := config.Load(s.rootDir)
       if err != nil {
           http.Error(w, "Failed to load config", http.StatusInternalServerError)
           return
       }
       
       // Toggle YOLO mode
       cfg.YoloMode = !cfg.YoloMode
       
       // Save config
       if err := config.SaveConfig(s.rootDir, cfg); err != nil {
           http.Error(w, "Failed to save config", http.StatusInternalServerError)
           return
       }
       
       // Return updated YOLO mode status for HTMX
       w.Header().Set("Content-Type", "text/html")
       if cfg.YoloMode {
           fmt.Fprint(w, "<div class=\"yolo-mode-container\" id=\"yolo-mode-container\" hx-post=\"/api/yolo/toggle\" hx-swap=\"outerHTML\">...</div>")
       } else {
           fmt.Fprint(w, "") // Empty when disabled
       }
   }
   ```

### Frontend Changes:

3. `internal/dashboard/templates/layout.html` — Make YOLO mode clickable with HTMX
4. Add CSS styles for disabled state in `static/style.css`

## Acceptance Criteria:
- [ ] YOLO mode indicator in footer is clickable
- [ ] Click toggles YOLO mode on/off immediately
- [ ] Config is saved automatically without page reload (HTMX)
- [ ] UI updates to show new state (icon/text change)
- [ ] Visual feedback during toggle (loading state)
- [ ] Works on all pages (board, settings, task detail)
- [ ] Tooltip shows current state and action ("Click to enable/disable")
- [ ] Unit tests for `handleYoloToggle` handler
- [ ] Integration test verifying toggle flow