### PR TITLE
Replace text labels with icons on dashboard cards for cleaner UI

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -48,6 +48,62 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 			}
 			return string(b)
 		},
+		"labelIcon": func(label string) string {
+			switch label {
+			case "type:feature":
+				return "✨"
+			case "type:bug":
+				return "🐛"
+			case "type:docs":
+				return "📚"
+			case "type:refactor":
+				return "🔧"
+			case "size:S":
+				return "🟢"
+			case "size:M":
+				return "🟡"
+			case "size:L":
+				return "🟠"
+			case "size:XL":
+				return "🔴"
+			case "priority:high":
+				return "🔥"
+			case "priority:medium":
+				return "⚡"
+			case "priority:low":
+				return "🌱"
+			default:
+				return ""
+			}
+		},
+		"labelTooltip": func(label string) string {
+			switch label {
+			case "type:feature":
+				return "Feature"
+			case "type:bug":
+				return "Bug"
+			case "type:docs":
+				return "Documentation"
+			case "type:refactor":
+				return "Refactor"
+			case "size:S":
+				return "Size: Small"
+			case "size:M":
+				return "Size: Medium"
+			case "size:L":
+				return "Size: Large"
+			case "size:XL":
+				return "Size: Extra Large"
+			case "priority:high":
+				return "Priority: High"
+			case "priority:medium":
+				return "Priority: Medium"
+			case "priority:low":
+				return "Priority: Low"
+			default:
+				return ""
+			}
+		},
 	}
 
 	pages := []string{"board.html", "task.html"}
@@ -4663,5 +4719,222 @@ func TestHandleYoloToggle_NoRootDir(t *testing.T) {
 	// Should return 500
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("expected status 500 when rootDir is empty, got %d", rec.Code)
+	}
+}
+
+// TestLabelIcon tests the labelIcon template function
+func TestLabelIcon(t *testing.T) {
+	tests := []struct {
+		name     string
+		label    string
+		expected string
+	}{
+		{"type:feature", "type:feature", "✨"},
+		{"type:bug", "type:bug", "🐛"},
+		{"type:docs", "type:docs", "📚"},
+		{"type:refactor", "type:refactor", "🔧"},
+		{"size:S", "size:S", "🟢"},
+		{"size:M", "size:M", "🟡"},
+		{"size:L", "size:L", "🟠"},
+		{"size:XL", "size:XL", "🔴"},
+		{"priority:high", "priority:high", "🔥"},
+		{"priority:medium", "priority:medium", "⚡"},
+		{"priority:low", "priority:low", "🌱"},
+		{"unknown label", "unknown:label", ""},
+		{"stage label", "stage:analysis", ""},
+		{"empty label", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a minimal template to test the function
+			funcMap := template.FuncMap{
+				"labelIcon": func(label string) string {
+					switch label {
+					case "type:feature":
+						return "✨"
+					case "type:bug":
+						return "🐛"
+					case "type:docs":
+						return "📚"
+					case "type:refactor":
+						return "🔧"
+					case "size:S":
+						return "🟢"
+					case "size:M":
+						return "🟡"
+					case "size:L":
+						return "🟠"
+					case "size:XL":
+						return "🔴"
+					case "priority:high":
+						return "🔥"
+					case "priority:medium":
+						return "⚡"
+					case "priority:low":
+						return "🌱"
+					default:
+						return ""
+					}
+				},
+			}
+
+			tmpl, err := template.New("test").Funcs(funcMap).Parse("{{labelIcon .}}")
+			if err != nil {
+				t.Fatalf("failed to parse template: %v", err)
+			}
+
+			var buf strings.Builder
+			if err := tmpl.Execute(&buf, tt.label); err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			if buf.String() != tt.expected {
+				t.Errorf("labelIcon(%q) = %q, want %q", tt.label, buf.String(), tt.expected)
+			}
+		})
+	}
+}
+
+// TestLabelTooltip tests the labelTooltip template function
+func TestLabelTooltip(t *testing.T) {
+	tests := []struct {
+		name     string
+		label    string
+		expected string
+	}{
+		{"type:feature", "type:feature", "Feature"},
+		{"type:bug", "type:bug", "Bug"},
+		{"type:docs", "type:docs", "Documentation"},
+		{"type:refactor", "type:refactor", "Refactor"},
+		{"size:S", "size:S", "Size: Small"},
+		{"size:M", "size:M", "Size: Medium"},
+		{"size:L", "size:L", "Size: Large"},
+		{"size:XL", "size:XL", "Size: Extra Large"},
+		{"priority:high", "priority:high", "Priority: High"},
+		{"priority:medium", "priority:medium", "Priority: Medium"},
+		{"priority:low", "priority:low", "Priority: Low"},
+		{"unknown label", "unknown:label", ""},
+		{"stage label", "stage:analysis", ""},
+		{"empty label", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a minimal template to test the function
+			funcMap := template.FuncMap{
+				"labelTooltip": func(label string) string {
+					switch label {
+					case "type:feature":
+						return "Feature"
+					case "type:bug":
+						return "Bug"
+					case "type:docs":
+						return "Documentation"
+					case "type:refactor":
+						return "Refactor"
+					case "size:S":
+						return "Size: Small"
+					case "size:M":
+						return "Size: Medium"
+					case "size:L":
+						return "Size: Large"
+					case "size:XL":
+						return "Size: Extra Large"
+					case "priority:high":
+						return "Priority: High"
+					case "priority:medium":
+						return "Priority: Medium"
+					case "priority:low":
+						return "Priority: Low"
+					default:
+						return ""
+					}
+				},
+			}
+
+			tmpl, err := template.New("test").Funcs(funcMap).Parse("{{labelTooltip .}}")
+			if err != nil {
+				t.Fatalf("failed to parse template: %v", err)
+			}
+
+			var buf strings.Builder
+			if err := tmpl.Execute(&buf, tt.label); err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			if buf.String() != tt.expected {
+				t.Errorf("labelTooltip(%q) = %q, want %q", tt.label, buf.String(), tt.expected)
+			}
+		})
+	}
+}
+
+// TestBoardTemplate_LabelIcons verifies that label icons are rendered correctly in the board template
+func TestBoardTemplate_LabelIcons(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create test data with mixed icon and text labels
+	data := boardData{
+		Active: "board",
+		Plan: []taskCard{
+			{
+				ID:     1,
+				Title:  "Test Feature",
+				Status: "Plan",
+				Labels: []string{"type:feature", "size:M", "priority:high", "stage:analysis"},
+			},
+		},
+	}
+
+	// Execute the board-columns template
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "board-columns", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify icon labels are rendered with icon class and tooltip
+	if !strings.Contains(output, `class="label-icon"`) {
+		t.Error("template should render icon labels with label-icon class")
+	}
+
+	// Verify text labels are still rendered for unknown labels
+	if !strings.Contains(output, `class="label"`) {
+		t.Error("template should render text labels with label class")
+	}
+
+	// Verify specific icons are present
+	if !strings.Contains(output, "✨") {
+		t.Error("template should contain feature icon (✨)")
+	}
+	if !strings.Contains(output, "🟡") {
+		t.Error("template should contain size M icon (🟡)")
+	}
+	if !strings.Contains(output, "🔥") {
+		t.Error("template should contain high priority icon (🔥)")
+	}
+
+	// Verify stage label is rendered as text (not icon)
+	if !strings.Contains(output, "stage:analysis") {
+		t.Error("template should render stage:analysis as text label")
+	}
+
+	// Verify tooltips are present
+	if !strings.Contains(output, `title="Feature"`) {
+		t.Error("template should contain tooltip for feature label")
+	}
+	if !strings.Contains(output, `title="Size: Medium"`) {
+		t.Error("template should contain tooltip for size M label")
+	}
+	if !strings.Contains(output, `title="Priority: High"`) {
+		t.Error("template should contain tooltip for priority high label")
 	}
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -150,6 +150,62 @@ func parseTemplates() (map[string]*template.Template, error) {
 			}
 			return string(b)
 		},
+		"labelIcon": func(label string) string {
+			switch label {
+			case "type:feature":
+				return "✨"
+			case "type:bug":
+				return "🐛"
+			case "type:docs":
+				return "📚"
+			case "type:refactor":
+				return "🔧"
+			case "size:S":
+				return "🟢"
+			case "size:M":
+				return "🟡"
+			case "size:L":
+				return "🟠"
+			case "size:XL":
+				return "🔴"
+			case "priority:high":
+				return "🔥"
+			case "priority:medium":
+				return "⚡"
+			case "priority:low":
+				return "🌱"
+			default:
+				return ""
+			}
+		},
+		"labelTooltip": func(label string) string {
+			switch label {
+			case "type:feature":
+				return "Feature"
+			case "type:bug":
+				return "Bug"
+			case "type:docs":
+				return "Documentation"
+			case "type:refactor":
+				return "Refactor"
+			case "size:S":
+				return "Size: Small"
+			case "size:M":
+				return "Size: Medium"
+			case "size:L":
+				return "Size: Large"
+			case "size:XL":
+				return "Size: Extra Large"
+			case "priority:high":
+				return "Priority: High"
+			case "priority:medium":
+				return "Priority: Medium"
+			case "priority:low":
+				return "Priority: Low"
+			default:
+				return ""
+			}
+		},
 	}
 
 	pages := []string{"board.html", "task.html"}

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -17,6 +17,7 @@
 .card .card-assignee{color:var(--accent);font-size:.75rem}
 .card .card-labels{display:flex;gap:.25rem;flex-wrap:wrap}
 .card .label{font-size:.65rem;padding:.1rem .4rem;border-radius:4px;background:var(--surface);border:1px solid var(--border)}
+.card .label-icon{font-size:1rem;line-height:1;cursor:help}
 .card .card-worker{color:var(--accent);font-size:.75rem;margin-top:.3rem}
 .card-actions{display:flex;gap:.3rem;margin-top:.4rem}
 .card-actions .btn{padding:.2rem .5rem;font-size:.75rem}
@@ -150,7 +151,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
       <div class="card-actions">
         <form method="post" action="/unblock/{{.ID}}"><button type="submit" class="btn btn-success">Unblock</button></form>
@@ -167,7 +168,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
       <div class="card-actions">
         <form method="post" action="/block/{{.ID}}"><button type="submit" class="btn" title="Block this ticket">Block</button></form>
@@ -184,7 +185,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
       {{if .Worker}}<div class="card-worker">{{.Worker}}</div>{{end}}
     </div>
@@ -199,7 +200,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
       {{if .Worker}}<div class="card-worker">{{.Worker}}</div>{{end}}
     </div>
@@ -214,7 +215,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
     </div>
     {{else}}
@@ -229,7 +230,7 @@ function triggerSync() {
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
       {{if .PRURL}}<div class="card-pr"><a href="{{.PRURL}}" target="_blank">View PR →</a></div>{{end}}
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
       <div class="card-actions">
         <form method="post" action="/approve-merge/{{.ID}}"><button type="submit" class="btn btn-success">Approve & Merge</button></form>
@@ -247,7 +248,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
     </div>
     {{else}}
@@ -268,7 +269,7 @@ function triggerSync() {
         <span class="badge-closed">✕ Closed</span>
         {{end}}
       </div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
     </div>
     {{else}}
@@ -282,7 +283,7 @@ function triggerSync() {
     <div class="card">
       <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
       <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}<span class="label">{{.}}</span>{{end}}</div></div>{{end}}
+      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{else}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
       <div class="card-actions">
         <form method="post" action="/retry/{{.ID}}"><button type="submit" class="btn btn-success">Retry</button></form>
         <form method="post" action="/retry-fresh/{{.ID}}"><button type="submit" class="btn btn-primary">Retry Fresh</button></form>


### PR DESCRIPTION
Closes #317

Currently dashboard cards display text labels like "bug", "feature", "size:S", "priority:high" which take up space and clutter the card. We should replace these with small, compact icons that have tooltips showing the full label text on hover. Other labels (like stage labels) should still display as text.

## Current Behavior

Cards show text labels:


This takes horizontal space and makes cards look busy.

## Expected Behavior

Cards show mixed icons and text:

(hover shows tooltip: "Type: Bug", "Size: Small", "Priority: High", "Type: Feature")

## Proposed Icons

| Label | Icon | Tooltip |
|-------|------|---------|
| **Type** |||
| bug | 🐛 | "Type: Bug" |
| feature | ✨ | "Type: Feature" |
| **Size** |||
| size:S | 🐜 | "Size: Small" |
| size:M | 🐕 | "Size: Medium" |
| size:L | 🐘 | "Size: Large" |
| size:XL | 🦕 | "Size: Extra Large" |
| **Priority** |||
| priority:high | 🔴 | "Priority: High" |
| priority:medium | 🟡 | "Priority: Medium" |
| priority:low | 🟢 | "Priority: Low" |
| **Other** |||
| (any other label) | text | full label text |

## Implementation Plan

### 1. Create icon mapping helper

**File:** `internal/dashboard/templates/board.html`

Add template function or inline logic to map labels to icons:



### 2. Update card label rendering

**File:** `internal/dashboard/templates/board.html:153`

Change from:


To:


### 3. Add CSS for icons



## Benefits

- **Cleaner UI** - Less text clutter on cards for common labels
- **More compact** - Icons take less space than text
- **Still informative** - Tooltips show full label on hover for icons
- **Visual recognition** - Icons are easier to scan quickly
- **Fun & memorable** - Animal sizes are intuitive (ant → dog → elephant → dinosaur)
- **Backward compatible** - Other labels (stage, custom) still show as text

## Acceptance Criteria:
- [ ] Bug tickets show 🐛 icon with "Type: Bug" tooltip
- [ ] Feature tickets show ✨ icon with "Type: Feature" tooltip
- [ ] Size S shows 🐜 (ant) with "Size: Small" tooltip
- [ ] Size M shows 🐕 (dog) with "Size: Medium" tooltip
- [ ] Size L shows 🐘 (elephant) with "Size: Large" tooltip
- [ ] Size XL shows 🦕 (dinosaur) with "Size: Extra Large" tooltip
- [ ] Priority high shows 🔴 with "Priority: High" tooltip
- [ ] Priority medium shows 🟡 with "Priority: Medium" tooltip
- [ ] Priority low shows 🟢 with "Priority: Low" tooltip
- [ ] Other labels (stage:xxx, custom) still display as text
- [ ] Icons are compact and don't overflow card width
- [ ] Tooltips work on hover for icons
- [ ] Responsive - still looks good on mobile
- [ ] No JavaScript errors