### PR TITLE
LLM model changes in settings are not propagated to worker and orchestrator

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1873,6 +1873,13 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[Dashboard] LLM configuration saved successfully")
 
+	// Trigger immediate propagation to workers and orchestrator
+	// This ensures changes are applied immediately without waiting for file-poll
+	if s.configPropagator != nil {
+		s.configPropagator.Propagate(cfg)
+		log.Printf("[Dashboard] Configuration propagated immediately to all workers")
+	}
+
 	// Re-render with success message
 	workerCount := 0
 	if s.pool != nil {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/db"
 	"github.com/crazy-goat/one-dev-army/internal/git"
 	"github.com/crazy-goat/one-dev-army/internal/github"
@@ -41,9 +42,10 @@ type Server struct {
 	rootDir          string
 	modelsCache      []opencode.ProviderModel
 	brMgr            *git.BranchManager
+	configPropagator *config.ConfigPropagator
 }
 
-func NewServer(port int, webPort int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService, rootDir string, brMgr *git.BranchManager) (*Server, error) {
+func NewServer(port int, webPort int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService, rootDir string, brMgr *git.BranchManager, configPropagator *config.ConfigPropagator) (*Server, error) {
 	tmpls, err := parseTemplates()
 	if err != nil {
 		return nil, err
@@ -64,13 +66,14 @@ func NewServer(port int, webPort int, store *db.Store, pool func() []worker.Work
 			Addr:    fmt.Sprintf(":%d", port),
 			Handler: mux,
 		},
-		wizardStore: NewWizardSessionStore(),
-		oc:          oc,
-		wizardLLM:   wizardLLM,
-		hub:         hub,
-		syncService: syncService,
-		rootDir:     rootDir,
-		brMgr:       brMgr,
+		wizardStore:      NewWizardSessionStore(),
+		oc:               oc,
+		wizardLLM:        wizardLLM,
+		hub:              hub,
+		syncService:      syncService,
+		rootDir:          rootDir,
+		brMgr:            brMgr,
+		configPropagator: configPropagator,
 	}
 
 	if s.wizardLLM == "" {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -572,7 +572,7 @@ func TestDashboardRendering(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	srv, err := dashboard.NewServer(0, 5001, store, poolFn, nil, nil, nil, "", nil, nil, tmpDir, nil)
+	srv, err := dashboard.NewServer(0, 5001, store, poolFn, nil, nil, nil, "", nil, nil, tmpDir, nil, nil)
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}
@@ -623,7 +623,7 @@ func TestDashboard_WizardFlow_Integration(t *testing.T) {
 	}
 
 	tmpDir := t.TempDir()
-	srv, err := dashboard.NewServer(0, 5001, store, poolFn, nil, nil, nil, "", nil, nil, tmpDir, nil)
+	srv, err := dashboard.NewServer(0, 5001, store, poolFn, nil, nil, nil, "", nil, nil, tmpDir, nil, nil)
 	if err != nil {
 		t.Fatalf("creating dashboard server: %v", err)
 	}

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/crazy-goat/one-dev-army/internal/config"
@@ -26,7 +27,7 @@ type StageBroadcaster interface {
 }
 
 type Orchestrator struct {
-	cfg         *config.Config
+	cfg         atomic.Pointer[config.Config]
 	worker      *Worker
 	gh          *github.Client
 	oc          *opencode.Client
@@ -43,7 +44,6 @@ type Orchestrator struct {
 
 func NewOrchestrator(cfg *config.Config, gh *github.Client, oc *opencode.Client, brMgr *git.BranchManager, store *db.Store, hub StageBroadcaster, router *llm.Router) *Orchestrator {
 	o := &Orchestrator{
-		cfg:    cfg,
 		gh:     gh,
 		oc:     oc,
 		brMgr:  brMgr,
@@ -52,6 +52,7 @@ func NewOrchestrator(cfg *config.Config, gh *github.Client, oc *opencode.Client,
 		router: router,
 		paused: true,
 	}
+	o.cfg.Store(cfg)
 	o.worker = NewWorker(1, cfg, oc.Clone(), gh, brMgr, store, o, router)
 	return o
 }
@@ -102,6 +103,27 @@ func (o *Orchestrator) CurrentTask() *Task {
 func (o *Orchestrator) GetWorker() *Worker {
 	return o.worker
 }
+
+// UpdateConfig updates the orchestrator's configuration atomically and propagates to the worker and router.
+// This method is called by the ConfigPropagator when config changes.
+func (o *Orchestrator) UpdateConfig(cfg *config.Config) {
+	o.cfg.Store(cfg)
+
+	// Propagate to router (LLM config only)
+	if o.router != nil {
+		o.router.UpdateConfig(&cfg.LLM)
+	}
+
+	// Propagate to worker
+	if o.worker != nil {
+		o.worker.UpdateConfig(cfg)
+	}
+
+	log.Printf("[Orchestrator] Configuration updated (YoloMode=%v)", cfg.YoloMode)
+}
+
+// Compile-time interface check: ensure Orchestrator implements ConfigAwareWorker.
+var _ config.ConfigAwareWorker = (*Orchestrator)(nil)
 
 func (o *Orchestrator) Run(ctx context.Context) error {
 	o.mu.Lock()
@@ -297,7 +319,7 @@ func (o *Orchestrator) pickNextTicket(_ context.Context, candidates []github.Iss
 	}()
 
 	// Use router to select model for orchestration category
-	llmModel := o.cfg.LLM.Orchestration.Model
+	llmModel := o.cfg.Load().LLM.Orchestration.Model
 	if o.router != nil {
 		llmModel = o.router.SelectModel(config.CategoryOrchestration, config.ComplexityMedium, nil)
 	}

--- a/internal/mvp/orchestrator_test.go
+++ b/internal/mvp/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
 
@@ -439,5 +440,80 @@ func TestStageBacklogAsCandidate(t *testing.T) {
 	// Should NOT be a resume issue
 	if resumeIssue != nil {
 		t.Errorf("resumeIssue should be nil, got #%d", resumeIssue.Number)
+	}
+}
+
+// TestOrchestrator_UpdateConfig verifies that UpdateConfig updates the orchestrator's config atomically.
+func TestOrchestrator_UpdateConfig(t *testing.T) {
+	initialCfg := &config.Config{
+		YoloMode: false,
+		LLM:      config.DefaultLLMConfig(),
+	}
+
+	// Create orchestrator manually to avoid nil client issues
+	o := &Orchestrator{paused: true}
+	o.cfg.Store(initialCfg)
+
+	// Verify initial config
+	if o.cfg.Load().YoloMode != false {
+		t.Error("initial YoloMode should be false")
+	}
+
+	// Update config
+	newCfg := &config.Config{
+		YoloMode: true,
+		LLM:      config.DefaultLLMConfig(),
+	}
+	newCfg.LLM.Code.Model = "new-code-model"
+
+	o.UpdateConfig(newCfg)
+
+	// Verify updated config
+	if o.cfg.Load().YoloMode != true {
+		t.Error("YoloMode should be true after UpdateConfig")
+	}
+	if o.cfg.Load().LLM.Code.Model != "new-code-model" {
+		t.Errorf("Code.Model = %q, want %q", o.cfg.Load().LLM.Code.Model, "new-code-model")
+	}
+}
+
+// TestOrchestrator_ImplementsConfigAwareWorker verifies that Orchestrator implements ConfigAwareWorker interface.
+func TestOrchestrator_ImplementsConfigAwareWorker(t *testing.T) {
+	// This is a compile-time check
+	var _ config.ConfigAwareWorker = (*Orchestrator)(nil)
+}
+
+// TestOrchestrator_UpdateConfig_PropagatesToWorker verifies that UpdateConfig propagates to the worker.
+func TestOrchestrator_UpdateConfig_PropagatesToWorker(t *testing.T) {
+	initialCfg := &config.Config{
+		YoloMode: false,
+		LLM:      config.DefaultLLMConfig(),
+	}
+
+	// Create a worker manually
+	worker := &Worker{id: 1}
+	worker.cfg.Store(initialCfg)
+
+	// Create orchestrator with the worker
+	o := &Orchestrator{paused: true}
+	o.cfg.Store(initialCfg)
+	o.worker = worker
+
+	// Verify worker has initial config
+	if o.worker.cfg.Load().YoloMode != false {
+		t.Error("worker initial YoloMode should be false")
+	}
+
+	// Update config via orchestrator
+	newCfg := &config.Config{
+		YoloMode: true,
+		LLM:      config.DefaultLLMConfig(),
+	}
+
+	o.UpdateConfig(newCfg)
+
+	// Verify worker received the update
+	if o.worker.cfg.Load().YoloMode != true {
+		t.Error("worker YoloMode should be true after orchestrator UpdateConfig")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -362,7 +362,8 @@ func runServe(dir string, debugWebSocket bool) error {
 
 	// Create ConfigPropagator to propagate config changes to workers
 	configPropagator := config.NewConfigPropagator(0) // No polling, uses ReloadManager
-	configPropagator.RegisterWorker(orchestrator.GetWorker())
+	// Register the orchestrator (which propagates to its worker and router internally)
+	configPropagator.RegisterWorker(orchestrator)
 	// Register propagator with ReloadManager to only propagate when config actually changes
 	reloadManager.OnReload(func(cfg *config.Config) {
 		configPropagator.Propagate(cfg)
@@ -399,7 +400,7 @@ func runServe(dir string, debugWebSocket bool) error {
 		}
 	}()
 
-	srv, err := dashboard.NewServer(cfg.Dashboard.Port, cfg.OpenCode.WebPort, store, pool.Workers, gh, orchestrator, oc, cfg.LLM.Planning.Model, hub, syncService, dir, brMgr)
+	srv, err := dashboard.NewServer(cfg.Dashboard.Port, cfg.OpenCode.WebPort, store, pool.Workers, gh, orchestrator, oc, cfg.LLM.Planning.Model, hub, syncService, dir, brMgr, configPropagator)
 	if err != nil {
 		return fmt.Errorf("creating dashboard server: %w", err)
 	}


### PR DESCRIPTION
Closes #307

When a user changes LLM models in the dashboard settings, the changes are saved to `.oda/config.yaml` but are NOT propagated to the running worker and orchestrator. They continue using the old model configuration until ODA is restarted.

## Current Behavior

1. User changes LLM models in dashboard settings (e.g., from "nemotron-3-super-free" to "nexos-ai/Kimi K2.5")
2. Dashboard saves new config via `config.SaveConfig()`
3. **Router, Worker, and Orchestrator do NOT receive the update**
4. Components continue using old model configuration
5. Changes only take effect after ODA restart

## Root Cause Analysis

1. **Router** (`internal/llm/router.go:103-115`) has `UpdateConfig()` method but it's **never called**
2. **Worker** (`internal/mvp/worker.go:27,34`) holds pointers to `cfg` and `router` but has **no `UpdateConfig()` method**
3. **Orchestrator** (`internal/mvp/orchestrator.go:29,36`) holds pointers to `cfg` and `router` but has **no `UpdateConfig()` method**
4. **No propagation mechanism** - ConfigPropagator exists but is not used for LLM config
5. **Dashboard** creates new config object on save, but components still reference old objects

## Expected Behavior

1. User changes LLM models in dashboard
2. Config is saved to `.oda/config.yaml`
3. **Router receives update** via `UpdateConfig(&cfg.LLM)`
4. **Worker and Orchestrator receive update** via new `UpdateConfig()` methods
5. All components use new model configuration immediately

## Implementation Plan

### Option 1: Extend existing ConfigPropagator (Recommended)

1. `internal/mvp/worker.go` — Add `UpdateConfig()` method
2. `internal/mvp/orchestrator.go` — Add `UpdateConfig()` method
3. `internal/dashboard/handlers.go:1837` — After saving config, propagate to orchestrator

## Acceptance Criteria:
- [ ] Router receives LLM config update immediately after settings save
- [ ] Worker receives config update with new LLM models
- [ ] Orchestrator receives config update and propagates to worker
- [ ] All components use new model configuration without restart
- [ ] Log messages confirm config updates received
- [ ] Unit tests for `UpdateConfig()` methods
- [ ] Integration test verifying model propagation flow