### PR TITLE
YOLO mode footer toggle should not save to config file

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -80,6 +80,11 @@ func (s *Server) buildBoardData(_ *http.Request) boardData {
 		}
 	}
 
+	// Check runtime override (takes precedence over config file)
+	if s.yoloOverride != nil {
+		yoloMode = *s.yoloOverride
+	}
+
 	data := boardData{
 		Active:       "board",
 		OpenCodePort: s.webPort,
@@ -2001,20 +2006,26 @@ func (s *Server) handleYoloToggle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Toggle YOLO mode
-	cfg.YoloMode = !cfg.YoloMode
-
-	// Save config
-	if err := config.SaveConfig(s.rootDir, cfg); err != nil {
-		log.Printf("[Dashboard] Error saving config after YOLO toggle: %v", err)
-		http.Error(w, "failed to save configuration", http.StatusInternalServerError)
-		return
+	// Determine current state from runtime override or config
+	currentYolo := cfg.YoloMode
+	if s.yoloOverride != nil {
+		currentYolo = *s.yoloOverride
 	}
 
-	log.Printf("[Dashboard] YOLO mode toggled to: %v", cfg.YoloMode)
+	// Toggle YOLO mode
+	newYolo := !currentYolo
+	s.yoloOverride = &newYolo
+
+	// Propagate in-memory to workers (no file save)
+	cfg.YoloMode = newYolo
+	if s.configPropagator != nil {
+		s.configPropagator.Propagate(cfg)
+	}
+
+	log.Printf("[Dashboard] YOLO mode toggled to: %v (runtime only)", newYolo)
 
 	// Return the updated toggle HTML fragment
-	if cfg.YoloMode {
+	if newYolo {
 		_, _ = fmt.Fprint(w, `<div class="yolo-mode-container yolo-enabled" id="yolo-mode-container" hx-post="/api/yolo/toggle" hx-swap="outerHTML" title="Click to disable YOLO mode">
   <span class="yolo-mode-icon">⚡</span>
   <span>YOLO MODE</span>

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -4643,13 +4643,20 @@ func TestHandleYoloToggle_EnablesWhenDisabled(t *testing.T) {
 		t.Error("response should contain lightning bolt icon when enabling")
 	}
 
-	// Verify config file now has yolo_mode: true
+	// Verify config file is UNCHANGED (still yolo_mode: false)
 	cfg, err := config.Load(tempDir)
 	if err != nil {
 		t.Fatalf("failed to load config after toggle: %v", err)
 	}
-	if !cfg.YoloMode {
-		t.Error("expected config to have yolo_mode: true after toggle")
+	if cfg.YoloMode {
+		t.Error("expected config file to remain unchanged with yolo_mode: false (runtime-only toggle)")
+	}
+
+	// Verify runtime override is set to true
+	if srv.yoloOverride == nil {
+		t.Error("expected yoloOverride to be set after toggle")
+	} else if !*srv.yoloOverride {
+		t.Errorf("expected yoloOverride to be true, got %v", *srv.yoloOverride)
 	}
 }
 
@@ -4694,13 +4701,20 @@ func TestHandleYoloToggle_DisablesWhenEnabled(t *testing.T) {
 		t.Error("response should contain lock icon when disabling")
 	}
 
-	// Verify config file now has yolo_mode: false
+	// Verify config file is UNCHANGED (still yolo_mode: true)
 	cfg, err := config.Load(tempDir)
 	if err != nil {
 		t.Fatalf("failed to load config after toggle: %v", err)
 	}
-	if cfg.YoloMode {
-		t.Error("expected config to have yolo_mode: false after toggle")
+	if !cfg.YoloMode {
+		t.Error("expected config file to remain unchanged with yolo_mode: true (runtime-only toggle)")
+	}
+
+	// Verify runtime override is set to false
+	if srv.yoloOverride == nil {
+		t.Error("expected yoloOverride to be set after toggle")
+	} else if *srv.yoloOverride {
+		t.Errorf("expected yoloOverride to be false, got %v", *srv.yoloOverride)
 	}
 }
 
@@ -4719,6 +4733,50 @@ func TestHandleYoloToggle_NoRootDir(t *testing.T) {
 	// Should return 500
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("expected status 500 when rootDir is empty, got %d", rec.Code)
+	}
+}
+
+// TestHandleYoloToggle_RuntimeOverrideInBoardData tests that the runtime YOLO override
+// is reflected in board data without modifying the config file
+func TestHandleYoloToggle_RuntimeOverrideInBoardData(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create config with yolo_mode: false
+	configContent := `yolo_mode: false
+`
+	if err := os.MkdirAll(filepath.Join(tempDir, ".oda"), 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, ".oda", "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tempDir
+	defer srv.wizardStore.Stop()
+
+	// Toggle YOLO via handler
+	req := httptest.NewRequest(http.MethodPost, "/api/yolo/toggle", nil)
+	rec := httptest.NewRecorder()
+	srv.handleYoloToggle(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Call buildBoardData and verify YoloMode reflects the runtime override
+	data := srv.buildBoardData(nil)
+	if !data.YoloMode {
+		t.Error("expected buildBoardData to return YoloMode=true after toggle (runtime override)")
+	}
+
+	// Verify config file on disk is unchanged
+	cfg, err := config.Load(tempDir)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+	if cfg.YoloMode {
+		t.Error("expected config file to remain unchanged with yolo_mode: false")
 	}
 }
 

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -43,6 +43,7 @@ type Server struct {
 	modelsCache      []opencode.ProviderModel
 	brMgr            *git.BranchManager
 	configPropagator *config.ConfigPropagator
+	yoloOverride     *bool // Runtime YOLO mode override (nil = use config file)
 }
 
 func NewServer(port int, webPort int, store *db.Store, pool func() []worker.WorkerInfo, gh *github.Client, orchestrator *mvp.Orchestrator, oc *opencode.Client, wizardLLM string, hub *Hub, syncService *SyncService, rootDir string, brMgr *git.BranchManager, configPropagator *config.ConfigPropagator) (*Server, error) {


### PR DESCRIPTION
Closes #333

The YOLO mode toggle in the dashboard footer currently saves changes to .oda/config.yaml. This should only be a temporary runtime toggle that does not modify the configuration file.

## Current Behavior

Footer toggle calls config.SaveConfig() - saves to file permanently.

## Expected Behavior

Footer toggle only changes runtime value, config file stays unchanged.

## Implementation

Remove config.SaveConfig() call from footer toggle handler. YOLO mode should be read from config on startup only.

## Acceptance Criteria:
- [ ] Footer YOLO toggle does not modify config file
- [ ] YOLO mode changes immediately in UI
- [ ] After ODA restart, YOLO mode returns to config value
- [ ] Settings page still saves to config file