### PR TITLE
Add .oda/artifacts/ to .gitignore on ODA startup

### DIFF
--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -40,6 +40,10 @@ func (s *Setup) CheckAndGenerate() error {
 		return fmt.Errorf("GitHub Actions check: %w", err)
 	}
 
+	if err := s.checkGitignore(); err != nil {
+		return fmt.Errorf(".gitignore check: %w", err)
+	}
+
 	return nil
 }
 
@@ -136,6 +140,51 @@ func (s *Setup) checkGitHubActions() error {
 	}
 
 	fmt.Println("CI workflow created at .github/workflows/ci.yml")
+	return nil
+}
+
+func (s *Setup) checkGitignore() error {
+	path := filepath.Join(s.projectDir, ".gitignore")
+	entry := ".oda/artifacts/"
+
+	// Check if .gitignore exists and contains the entry
+	if fileExists(path) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading .gitignore: %w", err)
+		}
+
+		// Check if entry already exists (handle both with and without trailing slash)
+		contentStr := string(content)
+		if strings.Contains(contentStr, entry) || strings.Contains(contentStr, ".oda/artifacts") {
+			return nil
+		}
+
+		// Entry not found, append it
+		fmt.Println("Adding .oda/artifacts/ to .gitignore...")
+
+		// Ensure there's a newline before appending
+		if !strings.HasSuffix(contentStr, "\n") {
+			content = append(content, '\n')
+		}
+
+		content = append(content, []byte(entry+"\n")...)
+		if err := os.WriteFile(path, content, 0o644); err != nil {
+			return fmt.Errorf("writing .gitignore: %w", err)
+		}
+
+		fmt.Println(".gitignore updated.")
+		return nil
+	}
+
+	// .gitignore doesn't exist, create it
+	fmt.Println("Creating .gitignore with .oda/artifacts/ entry...")
+
+	if err := os.WriteFile(path, []byte(entry+"\n"), 0o644); err != nil {
+		return fmt.Errorf("creating .gitignore: %w", err)
+	}
+
+	fmt.Println(".gitignore created.")
 	return nil
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -303,3 +303,149 @@ func TestHasWorkflowFiles_Yaml(t *testing.T) {
 		t.Error("hasWorkflowFiles() = false for directory with .yaml file")
 	}
 }
+
+func TestCheckGitignore_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+
+	s := &Setup{
+		projectDir: dir,
+		oc:         opencode.NewClient("http://localhost:0"),
+		cfg:        &config.Config{},
+	}
+
+	if err := s.checkGitignore(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify file was created
+	path := filepath.Join(dir, ".gitignore")
+	if !fileExists(path) {
+		t.Fatal(".gitignore was not created")
+	}
+
+	// Verify content
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), ".oda/artifacts/") {
+		t.Errorf(".gitignore does not contain .oda/artifacts/: %q", string(content))
+	}
+}
+
+func TestCheckGitignore_AppendsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(path, []byte("*.log\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Setup{
+		projectDir: dir,
+		oc:         opencode.NewClient("http://localhost:0"),
+		cfg:        &config.Config{},
+	}
+
+	if err := s.checkGitignore(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify original content preserved and entry added
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+	if !strings.Contains(contentStr, "*.log") {
+		t.Errorf("original content was lost: %q", contentStr)
+	}
+	if !strings.Contains(contentStr, ".oda/artifacts/") {
+		t.Errorf(".oda/artifacts/ was not added: %q", contentStr)
+	}
+}
+
+func TestCheckGitignore_NoOpWhenEntryExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	originalContent := "*.log\n.oda/artifacts/\n"
+	if err := os.WriteFile(path, []byte(originalContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Setup{
+		projectDir: dir,
+		oc:         opencode.NewClient("http://localhost:0"),
+		cfg:        &config.Config{},
+	}
+
+	if err := s.checkGitignore(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify content unchanged
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != originalContent {
+		t.Errorf(".gitignore was modified when it shouldn't be: got %q, want %q", string(content), originalContent)
+	}
+}
+
+func TestCheckGitignore_NoOpWhenEntryExistsWithoutTrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	originalContent := "*.log\n.oda/artifacts\n"
+	if err := os.WriteFile(path, []byte(originalContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Setup{
+		projectDir: dir,
+		oc:         opencode.NewClient("http://localhost:0"),
+		cfg:        &config.Config{},
+	}
+
+	if err := s.checkGitignore(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify content unchanged
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != originalContent {
+		t.Errorf(".gitignore was modified when it shouldn't be: got %q, want %q", string(content), originalContent)
+	}
+}
+
+func TestCheckGitignore_HandlesNoTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	// File without trailing newline
+	if err := os.WriteFile(path, []byte("*.log"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Setup{
+		projectDir: dir,
+		oc:         opencode.NewClient("http://localhost:0"),
+		cfg:        &config.Config{},
+	}
+
+	if err := s.checkGitignore(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify entry was added with proper newline handling
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentStr := string(content)
+	// Should have newline between existing content and new entry
+	if !strings.Contains(contentStr, "*.log\n.oda/artifacts/") {
+		t.Errorf("improper newline handling: %q", contentStr)
+	}
+}


### PR DESCRIPTION
Closes #338

The .oda/artifacts/ directory contains temporary files created during ticket processing that should not be committed to git. ODA should automatically check on startup if this directory is in .gitignore and add it if missing.

## Current State

.gitignore contains:
```
.oda/metrics.db
.oda/metrics.db-shm
.oda/metrics.db-wal
.oda/oda.db
.oda/worktrees/
```

Missing: `.oda/artifacts/`

## Expected Behavior

On ODA startup:
1. Check if `.gitignore` exists
2. Check if `.oda/artifacts/` is listed
3. If not present, append it to `.gitignore`
4. Log the action

## Implementation

**File:** `main.go` or `internal/config/config.go`

Add to startup sequence a function that checks and updates `.gitignore`:

```go
func ensureGitignore(rootDir string) error {
    gitignorePath := filepath.Join(rootDir, ".gitignore")
    
    // Read existing content
    content, err := os.ReadFile(gitignorePath)
    if err != nil {
        if os.IsNotExist(err) {
            // Create new .gitignore
            return os.WriteFile(gitignorePath, []byte(".oda/artifacts/\n"), 0644)
        }
        return err
    }
    
    // Check if already present
    if strings.Contains(string(content), ".oda/artifacts/") {
        return nil // Already exists
    }
    
    // Append to .gitignore
    f, err := os.OpenFile(gitignorePath, os.O_APPEND|os.O_WRONLY, 0644)
    if err != nil {
        return err
    }
    defer f.Close()
    
    _, err = f.WriteString("\n# ODA artifacts directory\n.oda/artifacts/\n")
    return err
}
```

Call in `main()`:
```go
if err := ensureGitignore(dir); err != nil {
    log.Printf("Warning: failed to update .gitignore: %v", err)
}
```

## Acceptance Criteria:
- [ ] ODA checks `.gitignore` on startup
- [ ] `.oda/artifacts/` added if not present
- [ ] Existing entries preserved
- [ ] Comment added before entry
- [ ] Log message when updated
- [ ] No error if `.gitignore` does not exist (creates it)
- [ ] Idempotent - safe to run multiple times