### PR TITLE
Stack Blocked/Backlog and Done/Failed columns vertically to save horizontal space

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -2232,7 +2232,7 @@ func TestBoardLayout_ValidHTMLStructure(t *testing.T) {
 		"board-header":  `class="board-header"`,
 		"board-actions": `class="board-actions"`,
 		"board grid":    `class="board"`,
-		"9 columns":     "grid-template-columns:repeat(9,1fr)",
+		"7 columns":     "grid-template-columns:repeat(7,1fr)",
 	}
 
 	for name, pattern := range structureChecks {
@@ -2247,6 +2247,43 @@ func TestBoardLayout_ValidHTMLStructure(t *testing.T) {
 	closeDivs := strings.Count(body, "</div>")
 	if openDivs != closeDivs {
 		t.Errorf("HTML structure issue: %d opening <div> tags but %d closing </div> tags", openDivs, closeDivs)
+	}
+}
+
+// TestBoardLayout_StackedColumns verifies board has stacked columns for Blocked/Backlog and Done/Failed
+func TestBoardLayout_StackedColumns(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleBoard(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+
+	body := rec.Body.String()
+
+	if !strings.Contains(body, `class="stacked-column"`) {
+		t.Error("board page missing stacked-column CSS class")
+	}
+
+	if !strings.Contains(body, "stacked-column") {
+		t.Error("board page missing stacked column containers")
+	}
+
+	if strings.Count(body, `class="stacked-column"`) != 2 {
+		t.Errorf("expected 2 stacked-column containers, got %d", strings.Count(body, `class="stacked-column"`))
+	}
+
+	if !strings.Contains(body, ".stacked-column{") {
+		t.Error("board page missing stacked-column CSS rule")
+	}
+
+	if !strings.Contains(body, ".stacked-column .column{") {
+		t.Error("board page missing stacked-column .column CSS rule")
 	}
 }
 

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -4,7 +4,9 @@
 .board-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;flex-wrap:wrap;gap:1rem}
 .board-actions{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center}
 @media (max-width:768px){.board-header{flex-direction:column;align-items:flex-start}.board-actions{width:100%;justify-content:flex-start}}
-.board{display:grid;grid-template-columns:repeat(9,1fr);gap:1rem;margin-bottom:2rem}
+.board{display:grid;grid-template-columns:repeat(7,1fr);gap:1rem;margin-bottom:2rem}
+.stacked-column{display:flex;flex-direction:column;gap:0.5rem;min-height:300px}
+.stacked-column .column{min-height:140px;flex:1}
 .column{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:.75rem;min-height:300px}
 .column-title{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin-bottom:.75rem;display:flex;justify-content:space-between;align-items:center}
 .column-title .count{background:var(--border);padding:.1rem .5rem;border-radius:10px;font-size:.75rem}
@@ -150,40 +152,42 @@ function triggerSync() {
 {{end}}
 
 {{define "board-columns"}}
-  <div class="column col-blocked">
-    <div class="column-title">Blocked <span class="count">{{len .Blocked}}</span></div>
-    {{range .Blocked}}
-    <div class="card">
-      <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
-      <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
-      <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
-      {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
-      <div class="card-actions">
-        <form method="post" action="/unblock/{{.ID}}"><button type="submit" class="btn btn-success">Unblock</button></form>
+  <div class="stacked-column">
+    <div class="column col-blocked">
+      <div class="column-title">Blocked <span class="count">{{len .Blocked}}</span></div>
+      {{range .Blocked}}
+      <div class="card">
+        <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
+        <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
+        <div class="card-title">{{.Title}}</div>
+        {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
+        {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
+        <div class="card-actions">
+          <form method="post" action="/unblock/{{.ID}}"><button type="submit" class="btn btn-success">Unblock</button></form>
+        </div>
       </div>
+      {{else}}
+      <div class="empty-state">No blocked tickets</div>
+      {{end}}
     </div>
-    {{else}}
-    <div class="empty-state">No blocked tickets</div>
-    {{end}}
-  </div>
 
-  <div class="column">
-    <div class="column-title">Backlog <span class="count">{{len .Backlog}}</span></div>
-    {{range .Backlog}}
-    <div class="card">
-      <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
-      <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
-      <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
-      {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
-      <div class="card-actions">
-        <form method="post" action="/block/{{.ID}}"><button type="submit" class="btn" title="Block this ticket">Block</button></form>
+    <div class="column">
+      <div class="column-title">Backlog <span class="count">{{len .Backlog}}</span></div>
+      {{range .Backlog}}
+      <div class="card">
+        <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
+        <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
+        <div class="card-title">{{.Title}}</div>
+        {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
+        {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
+        <div class="card-actions">
+          <form method="post" action="/block/{{.ID}}"><button type="submit" class="btn" title="Block this ticket">Block</button></form>
+        </div>
       </div>
+      {{else}}
+      <div class="empty-state">No tickets in backlog</div>
+      {{end}}
     </div>
-    {{else}}
-    <div class="empty-state">No tickets in backlog</div>
-    {{end}}
   </div>
 
   <div class="column col-plan">
@@ -268,43 +272,45 @@ function triggerSync() {
     {{end}}
   </div>
 
-  <div class="column">
-    <div class="column-title">Done <span class="count">{{len .Done}}</span></div>
-    {{range .Done}}
-    <div class="card">
-      <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
-      <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
-      <div class="card-title">{{.Title}}</div>
-      <div class="card-meta">
-        {{if .IsMerged}}
-        <span class="badge-merged">✓ Merged</span>
-        {{else}}
-        <span class="badge-closed">✕ Closed</span>
-        {{end}}
+  <div class="stacked-column">
+    <div class="column">
+      <div class="column-title">Done <span class="count">{{len .Done}}</span></div>
+      {{range .Done}}
+      <div class="card">
+        <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
+        <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
+        <div class="card-title">{{.Title}}</div>
+        <div class="card-meta">
+          {{if .IsMerged}}
+          <span class="badge-merged">✓ Merged</span>
+          {{else}}
+          <span class="badge-closed">✕ Closed</span>
+          {{end}}
+        </div>
+        {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
+        {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
       </div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
-      {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
+      {{else}}
+      <div class="empty-state">No completed tickets</div>
+      {{end}}
     </div>
-    {{else}}
-    <div class="empty-state">No completed tickets</div>
-    {{end}}
-  </div>
 
-  <div class="column col-failed">
-    <div class="column-title">Failed <span class="count">{{len .Failed}}</span></div>
-    {{range .Failed}}
-    <div class="card">
-      <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
-      <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
-      <div class="card-title">{{.Title}}</div>
-      {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
-      <div class="card-actions">
-        <form method="post" action="/retry/{{.ID}}"><button type="submit" class="btn btn-success">Retry</button></form>
-        <form method="post" action="/retry-fresh/{{.ID}}"><button type="submit" class="btn btn-primary">Retry Fresh</button></form>
+    <div class="column col-failed">
+      <div class="column-title">Failed <span class="count">{{len .Failed}}</span></div>
+      {{range .Failed}}
+      <div class="card">
+        <div class="card-icons">{{range .Labels}}{{if labelIcon .}}<span class="label-icon" title="{{labelTooltip .}}">{{labelIcon .}}</span>{{end}}{{end}}</div>
+        <div class="card-id"><a href="/task/{{.ID}}">#{{.ID}}</a></div>
+        <div class="card-title">{{.Title}}</div>
+        {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
+        <div class="card-actions">
+          <form method="post" action="/retry/{{.ID}}"><button type="submit" class="btn btn-success">Retry</button></form>
+          <form method="post" action="/retry-fresh/{{.ID}}"><button type="submit" class="btn btn-primary">Retry Fresh</button></form>
+        </div>
       </div>
+      {{else}}
+      <div class="empty-state">No failed tickets</div>
+      {{end}}
     </div>
-    {{else}}
-    <div class="empty-state">No failed tickets</div>
-    {{end}}
   </div>
 {{end}}


### PR DESCRIPTION
Closes #343

The dashboard currently shows all 9 columns in a single horizontal row, making it crowded on smaller screens. We should stack Blocked+Backlog vertically on the left, and Done+Failed vertically on the right to save horizontal space.

## Current Layout

All 9 columns in one row: Blocked | Backlog | Plan | Code | AI Review | Approve | Merge | Done | Failed

## Proposed Layout

Left stack (Blocked+Backlog) | Plan | Code | AI Review | Approve | Merge | Right stack (Done+Failed)

## Implementation

### 1. Add CSS for stacked columns

File: internal/dashboard/templates/board.html

Add CSS classes for vertical stacking with reduced height.

### 2. Update HTML structure

Wrap Blocked+Backlog in a container, wrap Done+Failed in a container, keep middle columns horizontal.

### 3. Adjust column widths

Update board CSS from 9 columns to 7 columns in the grid.

## Benefits

- More horizontal space for each column
- Better visibility on smaller screens
- Logical grouping of waiting and completed columns
- 7 columns instead of 9 in the main grid

## Acceptance Criteria:
- [ ] Blocked and Backlog stacked vertically on the left
- [ ] Done and Failed stacked vertically on the right
- [ ] Middle columns remain horizontal
- [ ] Stacked columns have reduced height
- [ ] CSS grid updated to 7 columns
- [ ] Responsive design maintained
- [ ] Visual distinction between stacked columns