### PR TITLE
Add feature label to labelIcon function (without type: prefix)

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -50,7 +50,7 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 		},
 		"labelIcon": func(label string) string {
 			switch label {
-			case "type:feature", "enhancement":
+			case "type:feature", "feature", "enhancement":
 				return "✨"
 			case "type:bug", "bug":
 				return "🐛"
@@ -78,7 +78,7 @@ func parseTemplatesFromDisk(templateDir string) (map[string]*template.Template, 
 		},
 		"labelTooltip": func(label string) string {
 			switch label {
-			case "type:feature", "enhancement":
+			case "type:feature", "feature", "enhancement":
 				return "Type: Feature"
 			case "type:bug", "bug":
 				return "Type: Bug"
@@ -4855,6 +4855,7 @@ func TestLabelIcon(t *testing.T) {
 		expected string
 	}{
 		{"type:feature", "type:feature", "✨"},
+		{"feature", "feature", "✨"},
 		{"type:bug", "type:bug", "🐛"},
 		{"enhancement", "enhancement", "✨"},
 		{"bug", "bug", "🐛"},
@@ -4878,7 +4879,7 @@ func TestLabelIcon(t *testing.T) {
 			funcMap := template.FuncMap{
 				"labelIcon": func(label string) string {
 					switch label {
-					case "type:feature", "enhancement":
+					case "type:feature", "feature", "enhancement":
 						return "✨"
 					case "type:bug", "bug":
 						return "🐛"
@@ -4931,6 +4932,7 @@ func TestLabelTooltip(t *testing.T) {
 		expected string
 	}{
 		{"type:feature", "type:feature", "Type: Feature"},
+		{"feature", "feature", "Type: Feature"},
 		{"type:bug", "type:bug", "Type: Bug"},
 		{"enhancement", "enhancement", "Type: Feature"},
 		{"bug", "bug", "Type: Bug"},
@@ -4954,7 +4956,7 @@ func TestLabelTooltip(t *testing.T) {
 			funcMap := template.FuncMap{
 				"labelTooltip": func(label string) string {
 					switch label {
-					case "type:feature", "enhancement":
+					case "type:feature", "feature", "enhancement":
 						return "Type: Feature"
 					case "type:bug", "bug":
 						return "Type: Bug"

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -156,7 +156,7 @@ func parseTemplates() (map[string]*template.Template, error) {
 		},
 		"labelIcon": func(label string) string {
 			switch label {
-			case "type:feature", "enhancement":
+			case "type:feature", "feature", "enhancement":
 				return "✨"
 			case "type:bug", "bug":
 				return "🐛"
@@ -184,7 +184,7 @@ func parseTemplates() (map[string]*template.Template, error) {
 		},
 		"labelTooltip": func(label string) string {
 			switch label {
-			case "type:feature", "enhancement":
+			case "type:feature", "feature", "enhancement":
 				return "Type: Feature"
 			case "type:bug", "bug":
 				return "Type: Bug"


### PR DESCRIPTION
Closes #350

The labelIcon function only matches type:feature but tickets are labeled with just feature (without the prefix). This causes feature tickets to not show the ✨ icon.

## Current Behavior

Label feature → no icon shown
Label type:feature → ✨ icon shown

## Expected Behavior

Label feature → ✨ icon shown
Label type:feature → ✨ icon shown

## Fix

File: internal/dashboard/server.go:159

Change from:
case type:feature, enhancement:

To:
case type:feature, feature, enhancement:

## Acceptance Criteria:
- [ ] feature label shows ✨ icon
- [ ] type:feature label still shows ✨ icon
- [ ] enhancement label still shows ✨ icon