### PR TITLE
Make stacked columns share height 50/50 with internal scrolling

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -2285,6 +2285,31 @@ func TestBoardLayout_StackedColumns(t *testing.T) {
 	if !strings.Contains(body, ".stacked-column .column{") {
 		t.Error("board page missing stacked-column .column CSS rule")
 	}
+
+	// Verify stacked column height constraint
+	if !strings.Contains(body, "calc(100vh") {
+		t.Error("stacked-column missing viewport height constraint")
+	}
+
+	// Verify internal scrolling
+	if !strings.Contains(body, "overflow-y:auto") {
+		t.Error("stacked-column columns missing overflow-y:auto for internal scrolling")
+	}
+
+	// Verify sticky column titles
+	if !strings.Contains(body, "position:sticky") {
+		t.Error("stacked-column titles missing position:sticky")
+	}
+
+	// Verify smooth scrolling
+	if !strings.Contains(body, "scroll-behavior:smooth") {
+		t.Error("stacked-column columns missing scroll-behavior:smooth")
+	}
+
+	// Verify flex basis for 50/50 split
+	if !strings.Contains(body, "50%") {
+		t.Error("stacked-column columns missing 50% flex basis for equal height split")
+	}
 }
 
 // TestBoardLayout_BacklogAboveBlocked verifies Backlog column appears before Blocked in the left stack

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -5,8 +5,9 @@
 .board-actions{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center}
 @media (max-width:768px){.board-header{flex-direction:column;align-items:flex-start}.board-actions{width:100%;justify-content:flex-start}}
 .board{display:grid;grid-template-columns:repeat(7,1fr);gap:1rem;margin-bottom:2rem}
-.stacked-column{display:flex;flex-direction:column;gap:0.5rem;min-height:300px}
-.stacked-column .column{min-height:140px;flex:1}
+.stacked-column{display:flex;flex-direction:column;gap:0.5rem;height:calc(100vh - 8rem);min-height:300px}
+.stacked-column .column{flex:1 1 50%;min-height:0;overflow-y:auto;scroll-behavior:smooth}
+.stacked-column .column-title{position:sticky;top:0;z-index:1;background:var(--surface);padding-bottom:.5rem}
 .column{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:.75rem;min-height:300px}
 .column-title{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin-bottom:.75rem;display:flex;justify-content:space-between;align-items:center}
 .column-title .count{background:var(--border);padding:.1rem .5rem;border-radius:10px;font-size:.75rem}


### PR DESCRIPTION
Closes #353

Stacked columns (Backlog/Blocked and Done/Failed) should share available height equally (50% each) and have internal scrolling when content overflows. This ensures both columns are always visible without scrolling the entire page.

## Current Behavior

- Stacked columns take full height of content
- Done column is 1017px, Failed starts below viewport
- User must scroll entire page to see Failed column
- Backlog/Blocked have same issue

## Expected Behavior

- Stacked column container fits available viewport height
- Each inner column takes exactly 50% height
- If tickets overflow - scroll appears inside that column only
- Both columns always visible side-by-side vertically

## Implementation

File: internal/dashboard/templates/board.html

Add CSS for stacked-column with flex layout and internal scrolling.

## Benefits

- Both columns always visible
- Independent scrolling per column
- No page scrolling needed to see Failed/Blocked
- Responsive to viewport height

## Acceptance Criteria:
- [ ] Stacked columns container has fixed height (viewport - header)
- [ ] Each inner column takes exactly 50% height
- [ ] Internal scroll appears when tickets overflow
- [ ] Column titles remain visible (do not scroll)
- [ ] Works for both left stack (Backlog/Blocked) and right stack (Done/Failed)
- [ ] Smooth scrolling within columns
- [ ] Visual gap between stacked columns preserved