### PR TITLE
Add current ticket details panel to dashboard

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -36,6 +36,15 @@ type taskCard struct {
 	IsMerged bool
 }
 
+type currentTicketInfo struct {
+	Number   int
+	Title    string
+	Status   string
+	Priority string
+	Type     string
+	Size     string
+}
+
 type boardData struct {
 	Active         string
 	OpenCodePort   int
@@ -44,7 +53,7 @@ type boardData struct {
 	Paused         bool
 	Processing     bool
 	CanCloseSprint bool
-	CurrentIssue   string
+	CurrentTicket  *currentTicketInfo
 	YoloMode       bool
 	Blocked        []taskCard
 	Backlog        []taskCard
@@ -99,7 +108,24 @@ func (s *Server) buildBoardData(_ *http.Request) boardData {
 		data.Paused = s.orchestrator.IsPaused()
 		data.Processing = s.orchestrator.IsProcessing()
 		if task := s.orchestrator.CurrentTask(); task != nil {
-			data.CurrentIssue = fmt.Sprintf("#%d: %s (%s)", task.Issue.Number, task.Issue.Title, task.Status)
+			info := &currentTicketInfo{
+				Number: task.Issue.Number,
+				Title:  task.Issue.Title,
+				Status: string(task.Status),
+			}
+			for _, label := range task.Issue.Labels {
+				switch {
+				case strings.HasPrefix(label.Name, "priority:"):
+					info.Priority = strings.TrimPrefix(label.Name, "priority:")
+				case label.Name == "bug" || label.Name == "type:bug":
+					info.Type = "bug"
+				case label.Name == "feature" || label.Name == "type:feature" || label.Name == "enhancement":
+					info.Type = "feature"
+				case strings.HasPrefix(label.Name, "size:"):
+					info.Size = strings.TrimPrefix(label.Name, "size:")
+				}
+			}
+			data.CurrentTicket = info
 		}
 	}
 

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5096,3 +5096,388 @@ func TestHandleBoard_NoSubtitleParagraph(t *testing.T) {
 		t.Error("SprintName should NOT appear inside a p element")
 	}
 }
+
+// TestBoardTemplate_ProcessingPanel_Visible tests that the processing panel is visible when CurrentTicket is set
+func TestBoardTemplate_ProcessingPanel_Visible(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create test data with CurrentTicket populated
+	data := boardData{
+		Active: "board",
+		CurrentTicket: &currentTicketInfo{
+			Number:   789,
+			Title:    "Processing Ticket Title",
+			Status:   "coding",
+			Priority: "high",
+			Type:     "feature",
+			Size:     "L",
+		},
+		Paused:     false,
+		Processing: true,
+	}
+
+	// Execute the content template
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify processing panel is present
+	if !strings.Contains(output, `id="processing-panel"`) {
+		t.Error("template should contain processing-panel element")
+	}
+
+	// Verify panel is visible (not display:none)
+	if strings.Contains(output, `id="processing-panel" style="display:none"`) {
+		t.Error("processing panel should be visible when CurrentTicket is set")
+	}
+
+	// Verify ticket number is displayed
+	if !strings.Contains(output, "#789") {
+		t.Error("template should display ticket number #789")
+	}
+
+	// Verify ticket title is displayed
+	if !strings.Contains(output, "Processing Ticket Title") {
+		t.Error("template should display ticket title")
+	}
+
+	// Verify priority badge is present
+	if !strings.Contains(output, `processing-priority-high`) {
+		t.Error("template should contain high priority badge class")
+	}
+
+	// Verify type badge is present
+	if !strings.Contains(output, "✨ Feature") {
+		t.Error("template should contain feature type badge")
+	}
+
+	// Verify size badge is present
+	if !strings.Contains(output, "📏 L") {
+		t.Error("template should contain size L badge")
+	}
+
+	// Verify link to task detail page
+	if !strings.Contains(output, `href="/task/789"`) {
+		t.Error("template should contain link to task detail page")
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_Hidden tests that the processing panel is hidden when CurrentTicket is nil
+func TestBoardTemplate_ProcessingPanel_Hidden(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create test data with CurrentTicket nil
+	data := boardData{
+		Active:        "board",
+		CurrentTicket: nil,
+		Paused:        true,
+		Processing:    false,
+	}
+
+	// Execute the content template
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify processing panel is present but hidden
+	if !strings.Contains(output, `id="processing-panel"`) {
+		t.Error("template should contain processing-panel element")
+	}
+
+	// Verify panel has display:none style
+	if !strings.Contains(output, `id="processing-panel" style="display:none"`) {
+		t.Error("processing panel should be hidden (display:none) when CurrentTicket is nil")
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_LongTitle tests that long titles are handled gracefully
+func TestBoardTemplate_ProcessingPanel_LongTitle(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create test data with a very long title
+	longTitle := strings.Repeat("A", 200)
+	data := boardData{
+		Active: "board",
+		CurrentTicket: &currentTicketInfo{
+			Number:   999,
+			Title:    longTitle,
+			Status:   "coding",
+			Priority: "low",
+			Type:     "bug",
+			Size:     "XL",
+		},
+		Paused:     false,
+		Processing: true,
+	}
+
+	// Execute the content template
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify the long title is rendered (CSS handles truncation)
+	if !strings.Contains(output, longTitle) {
+		t.Error("template should render long title (CSS handles truncation)")
+	}
+
+	// Verify processing panel is still visible
+	if strings.Contains(output, `id="processing-panel" style="display:none"`) {
+		t.Error("processing panel should be visible even with long title")
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_PriorityVariations tests priority badge variations
+func TestBoardTemplate_ProcessingPanel_PriorityVariations(t *testing.T) {
+	tests := []struct {
+		name          string
+		priority      string
+		expectedEmoji string
+		expectedClass string
+	}{
+		{
+			name:          "high priority",
+			priority:      "high",
+			expectedEmoji: "🔴",
+			expectedClass: "processing-priority-high",
+		},
+		{
+			name:          "medium priority",
+			priority:      "medium",
+			expectedEmoji: "🟡",
+			expectedClass: "processing-priority-medium",
+		},
+		{
+			name:          "low priority",
+			priority:      "low",
+			expectedEmoji: "🟢",
+			expectedClass: "processing-priority-low",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := createTestServerWithTemplates(t)
+			defer srv.wizardStore.Stop()
+
+			data := boardData{
+				Active: "board",
+				CurrentTicket: &currentTicketInfo{
+					Number:   100,
+					Title:    "Test Ticket",
+					Status:   "coding",
+					Priority: tt.priority,
+					Type:     "feature",
+					Size:     "M",
+				},
+				Paused:     false,
+				Processing: true,
+			}
+
+			tmpl := srv.tmpls["board.html"]
+			if tmpl == nil {
+				t.Fatal("board.html template not found")
+			}
+
+			var buf strings.Builder
+			if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			output := buf.String()
+
+			// Verify priority emoji is present
+			if !strings.Contains(output, tt.expectedEmoji) {
+				t.Errorf("template should contain %s emoji for %s priority", tt.expectedEmoji, tt.priority)
+			}
+
+			// Verify priority class is present
+			if !strings.Contains(output, tt.expectedClass) {
+				t.Errorf("template should contain %s class for %s priority", tt.expectedClass, tt.priority)
+			}
+		})
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_TypeVariations tests type badge variations
+func TestBoardTemplate_ProcessingPanel_TypeVariations(t *testing.T) {
+	tests := []struct {
+		name          string
+		issueType     string
+		expectedBadge string
+	}{
+		{
+			name:          "bug type",
+			issueType:     "bug",
+			expectedBadge: "🐛 Bug",
+		},
+		{
+			name:          "feature type",
+			issueType:     "feature",
+			expectedBadge: "✨ Feature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := createTestServerWithTemplates(t)
+			defer srv.wizardStore.Stop()
+
+			data := boardData{
+				Active: "board",
+				CurrentTicket: &currentTicketInfo{
+					Number:   200,
+					Title:    "Test Ticket",
+					Status:   "coding",
+					Priority: "medium",
+					Type:     tt.issueType,
+					Size:     "S",
+				},
+				Paused:     false,
+				Processing: true,
+			}
+
+			tmpl := srv.tmpls["board.html"]
+			if tmpl == nil {
+				t.Fatal("board.html template not found")
+			}
+
+			var buf strings.Builder
+			if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			output := buf.String()
+
+			// Verify type badge is present
+			if !strings.Contains(output, tt.expectedBadge) {
+				t.Errorf("template should contain %q badge for %s type", tt.expectedBadge, tt.issueType)
+			}
+		})
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_SizeVariations tests size badge variations
+func TestBoardTemplate_ProcessingPanel_SizeVariations(t *testing.T) {
+	tests := []struct {
+		name          string
+		size          string
+		expectedBadge string
+	}{
+		{"size S", "S", "📏 S"},
+		{"size M", "M", "📏 M"},
+		{"size L", "L", "📏 L"},
+		{"size XL", "XL", "📏 XL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := createTestServerWithTemplates(t)
+			defer srv.wizardStore.Stop()
+
+			data := boardData{
+				Active: "board",
+				CurrentTicket: &currentTicketInfo{
+					Number:   300,
+					Title:    "Test Ticket",
+					Status:   "coding",
+					Priority: "low",
+					Type:     "feature",
+					Size:     tt.size,
+				},
+				Paused:     false,
+				Processing: true,
+			}
+
+			tmpl := srv.tmpls["board.html"]
+			if tmpl == nil {
+				t.Fatal("board.html template not found")
+			}
+
+			var buf strings.Builder
+			if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+				t.Fatalf("failed to execute template: %v", err)
+			}
+
+			output := buf.String()
+
+			// Verify size badge is present
+			if !strings.Contains(output, tt.expectedBadge) {
+				t.Errorf("template should contain %q badge", tt.expectedBadge)
+			}
+		})
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_PartialLabels tests panel with partial label data
+func TestBoardTemplate_ProcessingPanel_PartialLabels(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	// Create test data with only priority (no type or size)
+	data := boardData{
+		Active: "board",
+		CurrentTicket: &currentTicketInfo{
+			Number:   400,
+			Title:    "Partial Labels Ticket",
+			Status:   "coding",
+			Priority: "high",
+			Type:     "", // No type
+			Size:     "", // No size
+		},
+		Paused:     false,
+		Processing: true,
+	}
+
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify priority badge is present
+	if !strings.Contains(output, `processing-priority-high`) {
+		t.Error("template should contain high priority badge")
+	}
+
+	// Verify type and size badges are NOT present (empty values)
+	if strings.Contains(output, "🐛 Bug") || strings.Contains(output, "✨ Feature") {
+		t.Error("template should NOT contain type badge when Type is empty")
+	}
+
+	if strings.Contains(output, "📏") {
+		t.Error("template should NOT contain size badge when Size is empty")
+	}
+}

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -43,6 +43,18 @@
 .card .card-pr a:hover{text-decoration:underline}
 .badge-merged { background: #6f42c1; color: white; font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; display: inline-flex; align-items: center; gap: .25rem; }
 .badge-closed { background: #6c757d; color: white; font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; display: inline-flex; align-items: center; gap: .25rem; }
+.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;margin-bottom:1rem;display:flex;align-items:center}
+.processing-panel-content{display:flex;align-items:center;gap:.75rem;width:100%;min-width:0}
+.processing-indicator{width:8px;height:8px;border-radius:50%;background:#3498db;flex-shrink:0;animation:pulse 2s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
+.processing-ticket{display:flex;align-items:center;gap:.4rem;text-decoration:none;color:var(--text);min-width:0;flex:1}
+.processing-id{color:var(--accent);font-weight:600;font-size:.85rem;flex-shrink:0}
+.processing-title{font-size:.85rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.processing-labels{display:flex;gap:.4rem;flex-shrink:0}
+.processing-badge{font-size:.7rem;padding:.15rem .5rem;border-radius:4px;background:var(--surface);border:1px solid var(--border);white-space:nowrap;text-transform:capitalize}
+.processing-priority-high{border-color:rgba(182,2,5,0.3);background:rgba(182,2,5,0.1)}
+.processing-priority-medium{border-color:rgba(251,202,4,0.3);background:rgba(251,202,4,0.1)}
+.processing-priority-low{border-color:rgba(14,138,22,0.3);background:rgba(14,138,22,0.1)}
 .empty-state{color:var(--muted);font-size:.85rem;text-align:center;padding:2rem 1rem;font-style:italic}
 </style>
 
@@ -78,6 +90,35 @@
     </form>
   </div>
 </div>
+
+{{if .CurrentTicket}}
+<div class="processing-panel" id="processing-panel">
+  <div class="processing-panel-content">
+    <span class="processing-indicator"></span>
+    <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
+      <span class="processing-id">#{{.CurrentTicket.Number}}</span>
+      <span class="processing-title">{{.CurrentTicket.Title}}</span>
+    </a>
+    <div class="processing-labels">
+      {{if .CurrentTicket.Priority}}
+      <span class="processing-badge processing-priority-{{.CurrentTicket.Priority}}">
+        {{if eq .CurrentTicket.Priority "high"}}🔴{{else if eq .CurrentTicket.Priority "medium"}}🟡{{else}}🟢{{end}} {{.CurrentTicket.Priority}}
+      </span>
+      {{end}}
+      {{if .CurrentTicket.Type}}
+      <span class="processing-badge">
+        {{if eq .CurrentTicket.Type "bug"}}🐛 Bug{{else}}✨ Feature{{end}}
+      </span>
+      {{end}}
+      {{if .CurrentTicket.Size}}
+      <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{else}}
+<div class="processing-panel" id="processing-panel" style="display:none"></div>
+{{end}}
 
 <div class="board" id="board-container" hx-get="/api/board-data" hx-swap="innerHTML" hx-trigger="refresh">
 {{template "board-columns" .}}

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -337,6 +337,27 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
         }
     }
     
+    function updateProcessingPanel() {
+        var panel = document.getElementById('processing-panel');
+        if (!panel) return;
+        
+        if (workerStatus.active && !workerStatus.paused && workerStatus.issueId) {
+            panel.style.display = 'flex';
+            panel.innerHTML = '<div class="processing-panel-content">' +
+                '<span class="processing-indicator"></span>' +
+                '<a href="/task/' + workerStatus.issueId + '" class="processing-ticket">' +
+                '<span class="processing-id">#' + workerStatus.issueId + '</span>' +
+                '<span class="processing-title">' + (workerStatus.issueTitle || '') + '</span>' +
+                '</a>' +
+                '<div class="processing-labels">' +
+                (workerStatus.step ? '<span class="processing-badge">' + workerStatus.step + '</span>' : '') +
+                '</div></div>';
+        } else {
+            panel.style.display = 'none';
+            panel.innerHTML = '';
+        }
+    }
+    
     function handleWorkerUpdate(data) {
         workerStatus.active = data.active || false;
         workerStatus.paused = data.paused || false;
@@ -354,6 +375,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
         }
         
         updateWorkerStatusUI();
+        updateProcessingPanel();
     }
     
     function fetchWorkerStatus() {
@@ -368,6 +390,8 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
         fetchWorkerStatus();
         // Update elapsed time display every second
         setInterval(updateWorkerStatusUI, 1000);
+        // Also update processing panel on load
+        setTimeout(updateProcessingPanel, 100);
     });
     
     // Expose for global access


### PR DESCRIPTION
Closes #358

Add a details panel to the dashboard showing information about the currently processing ticket. The panel should be placed in the empty space between the sprint header and the board columns.

## Current State
Dashboard shows "Sprint 2026-03-25 07:54" header with buttons on the right, followed by empty space, then the board columns. There is no indication of which ticket is currently being processed.

## Proposed Changes
Add a compact info panel in the empty space between the sprint header row and the board columns, displaying:
- Ticket number and title (e.g., "#356 Add Check Pipeline column...")
- Priority label with color (🔴 High / 🟡 Medium / 🟢 Low)
- Type label (🐛 Bug / ✨ Feature)
- Size label (📏 S / M / L / XL)

## Location
Panel should be placed in the empty horizontal space between:
- Sprint name + action buttons (top)
- Board columns: Backlog, Plan, Code, AI Review, Approve, Merge (bottom)

## Visual Layout


## Implementation Details

### Files to Modify
1. "internal/dashboard/handlers.go" - Extend boardData with current ticket metadata (title, labels)
2. "internal/dashboard/templates/board.html" - Add processing panel section between header and board
3. "internal/mvp/orchestrator.go" - Ensure CurrentTask() returns full issue data with labels

### Styling
- Background: subtle blue tint (matching Code column theme)
- Height: ~40-50px
- Full width of board container
- Labels as compact badges with icons
- Truncate long titles with ellipsis

## Acceptance Criteria
- [ ] Panel visible only when a ticket is being processed
- [ ] Shows ticket number, title, priority, type, and size
- [ ] Updates in real-time as processing state changes
- [ ] Responsive design - handles long titles gracefully
- [ ] Hidden/empty state when no ticket is processing
- [ ] Color-coded priority indicator