### PR TITLE
Make processing panel always visible on dashboard

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5171,12 +5171,11 @@ func TestBoardTemplate_ProcessingPanel_Visible(t *testing.T) {
 	}
 }
 
-// TestBoardTemplate_ProcessingPanel_Hidden tests that the processing panel is hidden when CurrentTicket is nil
-func TestBoardTemplate_ProcessingPanel_Hidden(t *testing.T) {
+// TestBoardTemplate_ProcessingPanel_Idle tests that the processing panel shows idle state when CurrentTicket is nil
+func TestBoardTemplate_ProcessingPanel_Idle(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
 
-	// Create test data with CurrentTicket nil
 	data := boardData{
 		Active:        "board",
 		CurrentTicket: nil,
@@ -5184,7 +5183,6 @@ func TestBoardTemplate_ProcessingPanel_Hidden(t *testing.T) {
 		Processing:    false,
 	}
 
-	// Execute the content template
 	tmpl := srv.tmpls["board.html"]
 	if tmpl == nil {
 		t.Fatal("board.html template not found")
@@ -5197,14 +5195,28 @@ func TestBoardTemplate_ProcessingPanel_Hidden(t *testing.T) {
 
 	output := buf.String()
 
-	// Verify processing panel is present but hidden
 	if !strings.Contains(output, `id="processing-panel"`) {
 		t.Error("template should contain processing-panel element")
 	}
 
-	// Verify panel has display:none style
-	if !strings.Contains(output, `id="processing-panel" style="display:none"`) {
-		t.Error("processing panel should be hidden (display:none) when CurrentTicket is nil")
+	if strings.Contains(output, `id="processing-panel" style="display:none"`) || strings.Contains(output, `id="processing-panel" style='display:none'`) {
+		t.Error("processing panel should be visible when idle, not display:none")
+	}
+
+	if !strings.Contains(output, `class="processing-panel idle"`) {
+		t.Error("processing panel should have 'idle' class when CurrentTicket is nil")
+	}
+
+	if !strings.Contains(output, "No active ticket") {
+		t.Error("processing panel should show 'No active ticket' when idle")
+	}
+
+	if !strings.Contains(output, `class="processing-panel-content"`) {
+		t.Error("idle panel should have processing-panel-content for consistent height")
+	}
+
+	if !strings.Contains(output, `class="processing-indicator"`) {
+		t.Error("idle panel should have processing-indicator element")
 	}
 }
 

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -55,6 +55,9 @@
 .processing-priority-high{border-color:rgba(182,2,5,0.3);background:rgba(182,2,5,0.1)}
 .processing-priority-medium{border-color:rgba(251,202,4,0.3);background:rgba(251,202,4,0.1)}
 .processing-priority-low{border-color:rgba(14,138,22,0.3);background:rgba(14,138,22,0.1)}
+.processing-panel.idle{background:rgba(108,117,125,0.06);border-color:rgba(108,117,125,0.15)}
+.processing-panel.idle .processing-indicator{background:#6c757d;animation:none}
+.processing-panel.idle .processing-idle-text{color:var(--muted);font-size:.85rem;font-style:italic}
 .empty-state{color:var(--muted);font-size:.85rem;text-align:center;padding:2rem 1rem;font-style:italic}
 </style>
 
@@ -117,7 +120,12 @@
   </div>
 </div>
 {{else}}
-<div class="processing-panel" id="processing-panel" style="display:none"></div>
+<div class="processing-panel idle" id="processing-panel">
+  <div class="processing-panel-content">
+    <span class="processing-indicator"></span>
+    <span class="processing-idle-text">No active ticket</span>
+  </div>
+</div>
 {{end}}
 
 <div class="board" id="board-container" hx-get="/api/board-data" hx-swap="innerHTML" hx-trigger="refresh">

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -342,6 +342,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
         if (!panel) return;
         
         if (workerStatus.active && !workerStatus.paused && workerStatus.issueId) {
+            panel.className = 'processing-panel';
             panel.style.display = 'flex';
             panel.innerHTML = '<div class="processing-panel-content">' +
                 '<span class="processing-indicator"></span>' +
@@ -353,8 +354,12 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
                 (workerStatus.step ? '<span class="processing-badge">' + workerStatus.step + '</span>' : '') +
                 '</div></div>';
         } else {
-            panel.style.display = 'none';
-            panel.innerHTML = '';
+            panel.className = 'processing-panel idle';
+            panel.style.display = 'flex';
+            panel.innerHTML = '<div class="processing-panel-content">' +
+                '<span class="processing-indicator"></span>' +
+                '<span class="processing-idle-text">No active ticket</span>' +
+                '</div>';
         }
     }
     


### PR DESCRIPTION
Closes #361

The processing panel showing current ticket details should be visible at all times, not just when a ticket is being processed. When no ticket is active, it should display "No active ticket" or similar idle state.

## Current Behavior
- Panel is completely hidden (display:none) when no ticket is being processed
- User cannot see if the system is idle or waiting

## Expected Behavior
- Panel always visible on dashboard
- When processing: shows ticket #, title, priority, type, size with pulsing indicator
- When idle: shows "No active ticket" or "Waiting..." with grayed-out styling
- Consistent height and position regardless of state

## Location
Panel is currently at the top of the board, between sprint header and columns.

## Visual States

### Active State (current):


### Idle State (new):


## Implementation Details

### Files to Modify
1. "internal/dashboard/templates/board.html" - Update processing panel logic
2. "internal/dashboard/handlers.go" - Ensure CurrentTicket is always passed (even if nil)

### Changes Needed
- Remove {{if .CurrentTicket}} conditional that hides the panel
- Add conditional content: show ticket details if exists, else show idle message
- Add CSS class for idle state styling (gray text, no pulse animation)
- Keep consistent panel height (~50px) in both states

## Acceptance Criteria
- [ ] Panel visible at all times on dashboard
- [ ] Shows ticket details when processing
- [ ] Shows "No active ticket" or similar when idle
- [ ] Consistent styling and height in both states
- [ ] Pulsing indicator only when active
- [ ] Gray/idle styling when no ticket