### PR TITLE
Move processing panel to center of board layout

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5493,3 +5493,94 @@ func TestBoardTemplate_ProcessingPanel_PartialLabels(t *testing.T) {
 		t.Error("template should NOT contain size badge when Size is empty")
 	}
 }
+
+func TestBoardTemplate_ProcessingPanel_InsideGrid(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	data := boardData{
+		Active: "board",
+		CurrentTicket: &currentTicketInfo{
+			Number:   123,
+			Title:    "Test Ticket",
+			Status:   "coding",
+			Priority: "medium",
+			Type:     "feature",
+			Size:     "M",
+		},
+		Paused:     false,
+		Processing: true,
+	}
+
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "board-columns", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, `id="processing-panel"`) {
+		t.Error("board-columns template should contain processing-panel element")
+	}
+
+	if !strings.Contains(output, "#123") {
+		t.Error("board-columns template should display ticket number")
+	}
+}
+
+func TestBoardTemplate_ProcessingPanel_IdleInsideGrid(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	data := boardData{
+		Active:        "board",
+		CurrentTicket: nil,
+		Paused:        true,
+		Processing:    false,
+	}
+
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "board-columns", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, `class="processing-panel idle"`) {
+		t.Error("board-columns template should contain idle processing-panel")
+	}
+
+	if !strings.Contains(output, "No active ticket") {
+		t.Error("board-columns template should show idle text")
+	}
+}
+
+func TestBoardTemplate_ProcessingPanel_GridPositioning(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleBoard(rec, req)
+
+	body := rec.Body.String()
+
+	if !strings.Contains(body, "grid-column:2/8") {
+		t.Error("processing panel should have grid-column:2/8 CSS rule")
+	}
+
+	if !strings.Contains(body, "grid-template-rows:") {
+		t.Error("board grid should have grid-template-rows CSS rule")
+	}
+}

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -4,7 +4,8 @@
 .board-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;flex-wrap:wrap;gap:1rem}
 .board-actions{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center}
 @media (max-width:768px){.board-header{flex-direction:column;align-items:flex-start}.board-actions{width:100%;justify-content:flex-start}}
-.board{display:grid;grid-template-columns:repeat(8,1fr);gap:1rem;margin-bottom:2rem}
+.board{display:grid;grid-template-columns:repeat(8,1fr);grid-template-rows:auto 1fr;gap:1rem;margin-bottom:2rem}
+.board>.stacked-column,.board>.column{grid-row:2}
 .stacked-column{display:flex;flex-direction:column;gap:0.5rem;height:calc(100vh - 8rem);min-height:300px}
 .stacked-column .column{flex:1 1 50%;min-height:0;overflow-y:auto;scroll-behavior:smooth}
 .stacked-column .column-title{position:sticky;top:0;z-index:1;background:var(--surface);padding-bottom:.5rem}
@@ -43,7 +44,7 @@
 .card .card-pr a:hover{text-decoration:underline}
 .badge-merged { background: #6f42c1; color: white; font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; display: inline-flex; align-items: center; gap: .25rem; }
 .badge-closed { background: #6c757d; color: white; font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; display: inline-flex; align-items: center; gap: .25rem; }
-.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;margin-bottom:1rem;display:flex;align-items:center}
+.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;display:flex;align-items:center;grid-column:2/8;grid-row:1}
 .processing-panel-content{display:flex;align-items:center;gap:.75rem;width:100%;min-width:0}
 .processing-indicator{width:8px;height:8px;border-radius:50%;background:#3498db;flex-shrink:0;animation:pulse 2s infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
@@ -93,40 +94,6 @@
     </form>
   </div>
 </div>
-
-{{if .CurrentTicket}}
-<div class="processing-panel" id="processing-panel">
-  <div class="processing-panel-content">
-    <span class="processing-indicator"></span>
-    <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
-      <span class="processing-id">#{{.CurrentTicket.Number}}</span>
-      <span class="processing-title">{{.CurrentTicket.Title}}</span>
-    </a>
-    <div class="processing-labels">
-      {{if .CurrentTicket.Priority}}
-      <span class="processing-badge processing-priority-{{.CurrentTicket.Priority}}">
-        {{if eq .CurrentTicket.Priority "high"}}🔴{{else if eq .CurrentTicket.Priority "medium"}}🟡{{else}}🟢{{end}} {{.CurrentTicket.Priority}}
-      </span>
-      {{end}}
-      {{if .CurrentTicket.Type}}
-      <span class="processing-badge">
-        {{if eq .CurrentTicket.Type "bug"}}🐛 Bug{{else}}✨ Feature{{end}}
-      </span>
-      {{end}}
-      {{if .CurrentTicket.Size}}
-      <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
-      {{end}}
-    </div>
-  </div>
-</div>
-{{else}}
-<div class="processing-panel idle" id="processing-panel">
-  <div class="processing-panel-content">
-    <span class="processing-indicator"></span>
-    <span class="processing-idle-text">No active ticket</span>
-  </div>
-</div>
-{{end}}
 
 <div class="board" id="board-container" hx-get="/api/board-data" hx-swap="innerHTML" hx-trigger="refresh">
 {{template "board-columns" .}}
@@ -203,6 +170,39 @@ function triggerSync() {
 {{end}}
 
 {{define "board-columns"}}
+{{if .CurrentTicket}}
+<div class="processing-panel" id="processing-panel">
+  <div class="processing-panel-content">
+    <span class="processing-indicator"></span>
+    <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
+      <span class="processing-id">#{{.CurrentTicket.Number}}</span>
+      <span class="processing-title">{{.CurrentTicket.Title}}</span>
+    </a>
+    <div class="processing-labels">
+      {{if .CurrentTicket.Priority}}
+      <span class="processing-badge processing-priority-{{.CurrentTicket.Priority}}">
+        {{if eq .CurrentTicket.Priority "high"}}🔴{{else if eq .CurrentTicket.Priority "medium"}}🟡{{else}}🟢{{end}} {{.CurrentTicket.Priority}}
+      </span>
+      {{end}}
+      {{if .CurrentTicket.Type}}
+      <span class="processing-badge">
+        {{if eq .CurrentTicket.Type "bug"}}🐛 Bug{{else}}✨ Feature{{end}}
+      </span>
+      {{end}}
+      {{if .CurrentTicket.Size}}
+      <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{else}}
+<div class="processing-panel idle" id="processing-panel">
+  <div class="processing-panel-content">
+    <span class="processing-indicator"></span>
+    <span class="processing-idle-text">No active ticket</span>
+  </div>
+</div>
+{{end}}
   <div class="stacked-column">
     <div class="column">
       <div class="column-title">Backlog <span class="count">{{len .Backlog}}</span></div>


### PR DESCRIPTION
Closes #365

The processing panel is currently positioned at the top of the board, above all columns. It should be moved to the center area of the board layout, between the left stack (Backlog/Blocked) and right stack (Done/Failed), aligned with the middle columns (Plan, Code, AI Review, Check Pipeline, Approve, Merge).

## Current Location
Panel is rendered BEFORE the board columns as a separate full-width element:


## Expected Location
Panel should be INSIDE the board grid layout, in the middle section:


## Visual Reference
Current (wrong):
- Panel spans full width above all columns
- Separated from column layout

Expected (correct):
- Panel positioned in the gap between left and right column stacks
- Vertically aligned with middle columns
- Same width as middle columns area

## Implementation Details

### Files to Modify
1. internal/dashboard/templates/board.html
   - Move processing-panel div inside board grid structure
   - Add CSS grid positioning for the panel
   - Ensure panel aligns with middle columns row

2. internal/dashboard/handlers.go (if needed)
   - No changes expected, data structure already correct

### CSS Changes Needed
- Add grid-area or grid-column positioning for processing panel
- Panel should span columns 2-6 (Plan through Merge)
- Maintain consistent height (~50px)
- Keep existing styling for active/idle states

## Acceptance Criteria
- [ ] Panel positioned between left stack (Backlog/Blocked) and right stack (Done/Failed)
- [ ] Panel vertically aligned with middle columns row
- [ ] Panel does not span full width above columns
- [ ] Panel maintains styling and visibility in both active and idle states
- [ ] Responsive layout preserved on different screen sizes