### PR TITLE
Fix processing panel regressions - restore always-visible and center positioning

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5171,8 +5171,8 @@ func TestBoardTemplate_ProcessingPanel_Visible(t *testing.T) {
 	}
 }
 
-// TestBoardTemplate_ProcessingPanel_Hidden tests that the processing panel is hidden when CurrentTicket is nil
-func TestBoardTemplate_ProcessingPanel_Hidden(t *testing.T) {
+// TestBoardTemplate_ProcessingPanel_Idle tests that the processing panel shows idle state when CurrentTicket is nil
+func TestBoardTemplate_ProcessingPanel_Idle(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
 
@@ -5197,14 +5197,29 @@ func TestBoardTemplate_ProcessingPanel_Hidden(t *testing.T) {
 
 	output := buf.String()
 
-	// Verify processing panel is present but hidden
+	// Verify processing panel is present
 	if !strings.Contains(output, `id="processing-panel"`) {
 		t.Error("template should contain processing-panel element")
 	}
 
-	// Verify panel has display:none style
-	if !strings.Contains(output, `id="processing-panel" style="display:none"`) {
-		t.Error("processing panel should be hidden (display:none) when CurrentTicket is nil")
+	// Verify panel does NOT have display:none style (should always be visible)
+	if strings.Contains(output, `id="processing-panel" style="display:none"`) {
+		t.Error("processing panel should not be hidden (no display:none) when CurrentTicket is nil")
+	}
+
+	// Verify panel has idle class
+	if !strings.Contains(output, `processing-panel-idle`) {
+		t.Error("processing panel should have processing-panel-idle class when CurrentTicket is nil")
+	}
+
+	// Verify idle message is displayed
+	if !strings.Contains(output, "No active ticket") {
+		t.Error("template should display 'No active ticket' message when idle")
+	}
+
+	// Verify idle message contains "Worker ready"
+	if !strings.Contains(output, "Worker ready") {
+		t.Error("template should display 'Worker ready' message when idle")
 	}
 }
 

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -43,7 +43,10 @@
 .card .card-pr a:hover{text-decoration:underline}
 .badge-merged { background: #6f42c1; color: white; font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; display: inline-flex; align-items: center; gap: .25rem; }
 .badge-closed { background: #6c757d; color: white; font-size: .65rem; padding: .1rem .4rem; border-radius: 4px; display: inline-flex; align-items: center; gap: .25rem; }
-.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;margin-bottom:1rem;display:flex;align-items:center}
+.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;display:flex;align-items:center;grid-column:2/8;grid-row:1}
+.processing-panel-idle{background:rgba(108,117,125,0.08);border-color:rgba(108,117,125,0.2)}
+.processing-panel-idle .processing-indicator{background:#6c757d;animation:none}
+.processing-idle-text{color:var(--muted);font-size:.85rem}
 .processing-panel-content{display:flex;align-items:center;gap:.75rem;width:100%;min-width:0}
 .processing-indicator{width:8px;height:8px;border-radius:50%;background:#3498db;flex-shrink:0;animation:pulse 2s infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
@@ -90,35 +93,6 @@
     </form>
   </div>
 </div>
-
-{{if .CurrentTicket}}
-<div class="processing-panel" id="processing-panel">
-  <div class="processing-panel-content">
-    <span class="processing-indicator"></span>
-    <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
-      <span class="processing-id">#{{.CurrentTicket.Number}}</span>
-      <span class="processing-title">{{.CurrentTicket.Title}}</span>
-    </a>
-    <div class="processing-labels">
-      {{if .CurrentTicket.Priority}}
-      <span class="processing-badge processing-priority-{{.CurrentTicket.Priority}}">
-        {{if eq .CurrentTicket.Priority "high"}}🔴{{else if eq .CurrentTicket.Priority "medium"}}🟡{{else}}🟢{{end}} {{.CurrentTicket.Priority}}
-      </span>
-      {{end}}
-      {{if .CurrentTicket.Type}}
-      <span class="processing-badge">
-        {{if eq .CurrentTicket.Type "bug"}}🐛 Bug{{else}}✨ Feature{{end}}
-      </span>
-      {{end}}
-      {{if .CurrentTicket.Size}}
-      <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
-      {{end}}
-    </div>
-  </div>
-</div>
-{{else}}
-<div class="processing-panel" id="processing-panel" style="display:none"></div>
-{{end}}
 
 <div class="board" id="board-container" hx-get="/api/board-data" hx-swap="innerHTML" hx-trigger="refresh">
 {{template "board-columns" .}}
@@ -195,6 +169,34 @@ function triggerSync() {
 {{end}}
 
 {{define "board-columns"}}
+  <div class="processing-panel{{if not .CurrentTicket}} processing-panel-idle{{end}}" id="processing-panel">
+    <div class="processing-panel-content">
+      <span class="processing-indicator"></span>
+      {{if .CurrentTicket}}
+      <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
+        <span class="processing-id">#{{.CurrentTicket.Number}}</span>
+        <span class="processing-title">{{.CurrentTicket.Title}}</span>
+      </a>
+      <div class="processing-labels">
+        {{if .CurrentTicket.Priority}}
+        <span class="processing-badge processing-priority-{{.CurrentTicket.Priority}}">
+          {{if eq .CurrentTicket.Priority "high"}}🔴{{else if eq .CurrentTicket.Priority "medium"}}🟡{{else}}🟢{{end}} {{.CurrentTicket.Priority}}
+        </span>
+        {{end}}
+        {{if .CurrentTicket.Type}}
+        <span class="processing-badge">
+          {{if eq .CurrentTicket.Type "bug"}}🐛 Bug{{else}}✨ Feature{{end}}
+        </span>
+        {{end}}
+        {{if .CurrentTicket.Size}}
+        <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
+        {{end}}
+      </div>
+      {{else}}
+      <span class="processing-idle-text">No active ticket &mdash; Worker ready</span>
+      {{end}}
+    </div>
+  </div>
   <div class="stacked-column">
     <div class="column">
       <div class="column-title">Backlog <span class="count">{{len .Backlog}}</span></div>

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -342,7 +342,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
         if (!panel) return;
         
         if (workerStatus.active && !workerStatus.paused && workerStatus.issueId) {
-            panel.style.display = 'flex';
+            panel.className = 'processing-panel';
             panel.innerHTML = '<div class="processing-panel-content">' +
                 '<span class="processing-indicator"></span>' +
                 '<a href="/task/' + workerStatus.issueId + '" class="processing-ticket">' +
@@ -353,8 +353,11 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
                 (workerStatus.step ? '<span class="processing-badge">' + workerStatus.step + '</span>' : '') +
                 '</div></div>';
         } else {
-            panel.style.display = 'none';
-            panel.innerHTML = '';
+            panel.className = 'processing-panel processing-panel-idle';
+            panel.innerHTML = '<div class="processing-panel-content">' +
+                '<span class="processing-indicator"></span>' +
+                '<span class="processing-idle-text">No active ticket &mdash; Worker ready</span>' +
+                '</div>';
         }
     }
     


### PR DESCRIPTION
Closes #368

The processing panel has two critical regressions that need to be fixed. Previous implementations (#361 and #365) were overwritten and the panel currently:
1. Is hidden when no ticket is processing (should always be visible)
2. Is positioned above the board columns (should be in center of board)

## Current Broken State

### Problem 1: Panel Hidden When Idle
Current code shows panel only when CurrentTicket exists. Expected: Panel always visible, showing "No active ticket" when idle.

### Problem 2: Wrong Position
Panel is rendered BEFORE the board container. Expected: Panel inside board grid, spanning middle columns.

## Expected Behavior

### Visual Layout
Panel should be in center of board, between left stack (Backlog/Blocked) and right stack (Done/Failed), aligned with middle columns (Plan, Code, AI Review, Check Pipeline, Approve, Merge).

### When Processing
- Shows: ticket number, title, priority, type, size
- Blue pulsing indicator
- Clickable link to ticket

### When Idle
- Shows: "No active ticket - Worker ready"
- Gray static indicator (no pulse)
- Consistent panel height maintained

## Implementation Requirements

### Files to Modify
1. internal/dashboard/templates/board.html
   - Move processing-panel inside board grid (grid-column: 2/8, grid-row: 1)
   - Remove conditional hiding the panel
   - Add conditional content: active state vs idle state
   - Add CSS for idle state styling

2. internal/dashboard/handlers.go
   - Ensure CurrentTicket is always passed to template (nil when idle)

### CSS Changes
- Panel: grid-column: 2/8 (span Plan through Merge columns)
- Panel: grid-row: 1 (first row of board grid)
- Idle state: gray text, no pulse animation
- Active state: normal styling with pulse

## Acceptance Criteria
- [ ] Panel visible at all times (never display:none)
- [ ] Panel positioned in center of board layout
- [ ] Shows ticket details when processing
- [ ] Shows "No active ticket" message when idle
- [ ] Consistent height and styling in both states
- [ ] Pulsing indicator only when active
- [ ] Gray/idle styling when no ticket
- [ ] Responsive layout preserved