### PR TITLE
Update LLM prompts to check for pipeline failure logs in artifacts

### DIFF
--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -495,7 +495,7 @@ func (w *Worker) implement(ctx context.Context, task *Task, planStr string) erro
 	if testCmd == "" {
 		testCmd = "go test ./..."
 	}
-	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPImplementation), task.Issue.Number, task.Issue.Title, planStr, task.Worktree, testCmd, task.Issue.Number, task.Issue.Number, task.Issue.Number)
+	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPImplementation), task.Issue.Number, task.Issue.Title, planStr, task.Worktree, testCmd, task.Issue.Number, task.Issue.Number, task.Issue.Number, task.Issue.Number, task.Issue.Number)
 
 	// Use router to select model for code category with complexity detection
 	llmModel := w.cfg.Load().LLM.Code.Model
@@ -565,7 +565,7 @@ type crResult struct {
 }
 
 func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string) (approved bool, review string, err error) {
-	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPCodeReview), task.Issue.Number, task.Issue.Title, prURL, w.gh.Repo)
+	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPCodeReview), task.Issue.Number, task.Issue.Title, prURL, w.gh.Repo, task.Issue.Number)
 
 	sessionTitle := fmt.Sprintf("code-review-%d", task.Issue.Number)
 	session, err := w.oc.CreateSession(sessionTitle)

--- a/internal/mvp/worker_test.go
+++ b/internal/mvp/worker_test.go
@@ -462,8 +462,8 @@ func TestTechnicalPlanningPromptFormat(t *testing.T) {
 func TestImplementationPromptFormat(t *testing.T) {
 	promptTemplate := prompts.MustGet(prompts.MVPImplementation)
 
-	// Verify the prompt template can be formatted with 8 arguments
-	formatted := fmt.Sprintf(promptTemplate, 456, "Test Implementation", "Test Plan", "/tmp/work", "go test ./...", 456, 456, 456)
+	// Verify the prompt template can be formatted with 10 arguments (added pipeline-fail.log placeholders)
+	formatted := fmt.Sprintf(promptTemplate, 456, "Test Implementation", "Test Plan", "/tmp/work", "go test ./...", 456, 456, 456, 456, 456)
 
 	// Verify the formatted prompt contains the planning artifact path
 	expectedPlanningPath := ".oda/artifacts/456/01-planning.md"
@@ -475,6 +475,12 @@ func TestImplementationPromptFormat(t *testing.T) {
 	expectedCodingPath := ".oda/artifacts/456/02-coding.md"
 	if !strings.Contains(formatted, expectedCodingPath) {
 		t.Errorf("formatted prompt does not contain expected coding artifact path %q", expectedCodingPath)
+	}
+
+	// Verify the formatted prompt contains the pipeline failure log path
+	expectedPipelineFailPath := ".oda/artifacts/456/pipeline-fail.log"
+	if !strings.Contains(formatted, expectedPipelineFailPath) {
+		t.Errorf("formatted prompt does not contain expected pipeline-fail.log path %q", expectedPipelineFailPath)
 	}
 
 	// Verify all format specifiers were replaced (no %! patterns indicating missing args)
@@ -491,5 +497,46 @@ func TestImplementationPromptFormat(t *testing.T) {
 	}
 	if !strings.Contains(formatted, "CRITICAL: Save coding notes to the artifact file") {
 		t.Error("formatted prompt does not contain artifact save instruction")
+	}
+	if !strings.Contains(formatted, "PIPELINE FAILURE") {
+		t.Error("formatted prompt does not contain pipeline failure check section")
+	}
+	if !strings.Contains(formatted, "CHECK FOR PIPELINE FAILURE LOGS") {
+		t.Error("formatted prompt does not contain 'CHECK FOR PIPELINE FAILURE LOGS' step")
+	}
+}
+
+func TestCodeReviewPromptFormat(t *testing.T) {
+	promptTemplate := prompts.MustGet(prompts.MVPCodeReview)
+
+	// Verify the prompt template can be formatted with 5 arguments (added pipeline-fail.log placeholder)
+	formatted := fmt.Sprintf(promptTemplate, 789, "Test Review", "https://github.com/org/repo/pull/42", "org/repo", 789)
+
+	// Verify the formatted prompt contains the pipeline failure log path
+	expectedPipelineFailPath := ".oda/artifacts/789/pipeline-fail.log"
+	if !strings.Contains(formatted, expectedPipelineFailPath) {
+		t.Errorf("formatted prompt does not contain expected pipeline-fail.log path %q", expectedPipelineFailPath)
+	}
+
+	// Verify all format specifiers were replaced (no %! patterns indicating missing args)
+	if strings.Contains(formatted, "%!") {
+		t.Errorf("formatted prompt contains unreplaced format specifiers: %s", formatted)
+	}
+
+	// Verify the prompt contains key sections
+	if !strings.Contains(formatted, "PIPELINE FAILURE") {
+		t.Error("formatted prompt does not contain pipeline failure check section")
+	}
+
+	if !strings.Contains(formatted, "Pipeline failures resolved") {
+		t.Error("formatted prompt does not contain 'Pipeline failures resolved' criterion")
+	}
+
+	if !strings.Contains(formatted, "REVIEW PROCESS") {
+		t.Error("formatted prompt does not contain 'REVIEW PROCESS' section")
+	}
+
+	if !strings.Contains(formatted, "REVIEW CRITERIA") {
+		t.Error("formatted prompt does not contain 'REVIEW CRITERIA' section")
 	}
 }

--- a/internal/prompts/mvp/code_review.md
+++ b/internal/prompts/mvp/code_review.md
@@ -2,6 +2,13 @@ You are reviewing code changes for GitHub issue #%d: %s
 
 The changes are in PR %s in repository %s.
 
+PIPELINE FAILURE CHECK:
+Check if .oda/artifacts/%d/pipeline-fail.log exists.
+If the file exists:
+- Read the pipeline failure logs
+- Verify that ALL errors from the logs have been addressed in the code changes
+- Add "Pipeline failures resolved" as a critical review criterion
+
 REVIEW PROCESS:
 1. Fetch the PR diff using: gh pr diff <pr-number>
 2. Read the diff carefully to understand all changes
@@ -21,6 +28,7 @@ REVIEW CRITERIA (assign severity: critical, major, minor, or none):
    - Context propagation (accept context.Context in public APIs)
    - Resource cleanup (defer Close(), handle cleanup on all paths)
    - Race conditions (shared state properly synchronized)
+8. Pipeline failures resolved — if pipeline-fail.log exists, verify all errors fixed
 
 APPROVAL THRESHOLD:
 - approved=true: Code is production-ready, all critical and major issues resolved

--- a/internal/prompts/mvp/implementation.md
+++ b/internal/prompts/mvp/implementation.md
@@ -13,7 +13,23 @@ Save your coding notes, decisions, and progress to: .oda/artifacts/%d/02-coding.
 
 CRITICAL: Save coding notes to the artifact file using file write tools BEFORE returning your response.
 
+PIPELINE FAILURE RECOVERY:
+Check if the file .oda/artifacts/%d/pipeline-fail.log exists.
+If the file exists:
+- CRITICAL: Read the pipeline failure logs from this file
+- CRITICAL: Fix ALL errors described in the logs BEFORE proceeding with any other work
+- The pipeline previously failed — your primary goal is to fix those failures
+If the file does not exist, proceed normally with the implementation plan.
+
 STEP-BY-STEP WORKFLOW:
+
+0. CHECK FOR PIPELINE FAILURE LOGS
+   - Check if .oda/artifacts/%d/pipeline-fail.log exists
+   - If the file exists:
+     - CRITICAL: Read the pipeline failure logs from this file
+     - CRITICAL: Fix ALL errors described in the logs BEFORE proceeding
+     - The pipeline previously failed — your primary goal is to fix those failures
+   - If the file does not exist, skip this step
 
 1. READ AGENTS.md FIRST
    - Read the AGENTS.md file in the working directory for project-specific rules


### PR DESCRIPTION
Closes #372

## Problem
When a pipeline check fails and the ticket returns to `stage:coding`, the LLM agent doesn't know about the previous failure or the logs from the failed pipeline. This makes it harder for the agent to fix the issues correctly.

## Expected Behavior
Update the LLM prompts (templates) to:

### 1. Implementation Prompt (`internal/prompts/mvp/implementation.md`)
Before starting implementation, check if `.oda/artifacts/{issueNumber}/pipeline-fail.log` exists.

If the file exists:
- **CRITICAL**: Read the pipeline failure logs
- **CRITICAL**: Fix ALL errors described in the logs before proceeding
- Add a dedicated section in the workflow for handling pipeline failures

### 2. Code Review Prompt (`internal/prompts/mvp/code_review.md`)
Before reviewing code, check if `.oda/artifacts/{issueNumber}/pipeline-fail.log` exists.

If the file exists:
- **Verify** that all errors from the pipeline logs have been fixed
- **Check** that the code now passes the checks that previously failed
- Add a specific review criterion: "Pipeline failures resolved"

## Acceptance Criteria
- [ ] Modify `internal/prompts/mvp/implementation.md` to check for pipeline-fail.log and add CRITICAL instructions
- [ ] Modify `internal/prompts/mvp/code_review.md` to verify pipeline errors are fixed
- [ ] Use `%d` placeholder for issue number to construct the artifact path
- [ ] Test that the prompts work correctly with the artifact file
- [ ] Ensure backward compatibility (works even if file doesn't exist)

## Technical Notes
- Artifact path pattern: `.oda/artifacts/%d/pipeline-fail.log`
- The file will be created by the Check Pipeline implementation (issue #371)
- Prompts should use file read tools to check if the file exists
- If file exists, include its contents in the prompt context