### PR TITLE
Add manual ticket processing button to dashboard

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -526,6 +526,41 @@ func (s *Server) handleUnblock(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/", http.StatusSeeOther)
 }
 
+func (s *Server) handleManualProcess(w http.ResponseWriter, r *http.Request) {
+	if s.orchestrator == nil {
+		http.Error(w, "orchestrator not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	id := r.PathValue("id")
+	issueNum := 0
+	if _, err := fmt.Sscanf(id, "%d", &issueNum); err != nil {
+		http.Error(w, "invalid issue ID", http.StatusBadRequest)
+		return
+	}
+	if issueNum == 0 {
+		http.Error(w, "invalid issue ID", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.orchestrator.QueueManualProcess(issueNum); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	log.Printf("[Dashboard] Manual process queued for #%d", issueNum)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"success": true,
+		"message": fmt.Sprintf("Ticket #%d queued for processing", issueNum),
+	})
+}
+
 func (s *Server) handleDecline(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	issueNum := 0

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/crazy-goat/one-dev-army/internal/config"
 	"github.com/crazy-goat/one-dev-army/internal/github"
+	"github.com/crazy-goat/one-dev-army/internal/mvp"
 	"github.com/crazy-goat/one-dev-army/internal/opencode"
 )
 
@@ -5494,5 +5495,54 @@ func TestBoardTemplate_ProcessingPanel_PartialLabels(t *testing.T) {
 
 	if strings.Contains(output, "📏") {
 		t.Error("template should NOT contain size badge when Size is empty")
+	}
+}
+
+func TestHandleManualProcess(t *testing.T) {
+	orch := &mvp.Orchestrator{}
+	s := &Server{orchestrator: orch}
+
+	req := httptest.NewRequest("POST", "/api/tickets/42/process", nil)
+	req.SetPathValue("id", "42")
+	w := httptest.NewRecorder()
+
+	s.handleManualProcess(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["success"] != true {
+		t.Errorf("success = %v, want true", resp["success"])
+	}
+}
+
+func TestHandleManualProcessNoOrchestrator(t *testing.T) {
+	s := &Server{}
+
+	req := httptest.NewRequest("POST", "/api/tickets/42/process", nil)
+	req.SetPathValue("id", "42")
+	w := httptest.NewRecorder()
+
+	s.handleManualProcess(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestHandleManualProcessInvalidID(t *testing.T) {
+	orch := &mvp.Orchestrator{}
+	s := &Server{orchestrator: orch}
+
+	req := httptest.NewRequest("POST", "/api/tickets/abc/process", nil)
+	req.SetPathValue("id", "abc")
+	w := httptest.NewRecorder()
+
+	s.handleManualProcess(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -221,6 +221,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /decline/{id}", s.handleDecline)
 	s.mux.HandleFunc("POST /block/{id}", s.handleBlock)
 	s.mux.HandleFunc("POST /unblock/{id}", s.handleUnblock)
+	s.mux.HandleFunc("POST /api/tickets/{id}/process", s.handleManualProcess)
 
 	// WebSocket endpoint
 	s.mux.HandleFunc("GET /ws", s.handleWebSocket)

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -121,6 +121,19 @@
   </div>
 </div>
 
+<!-- Process confirmation modal -->
+<div id="process-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.5);z-index:1000;align-items:center;justify-content:center">
+  <div style="background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:1.5rem;width:400px;max-width:90vw">
+    <h3 style="margin-bottom:.5rem">Process Ticket</h3>
+    <p style="color:var(--muted);font-size:.85rem;margin-bottom:1rem">Start processing <strong>#<span id="process-issue-id"></span></strong>?</p>
+    <p id="process-issue-title" style="font-size:.85rem;margin-bottom:1rem"></p>
+    <div style="display:flex;gap:.5rem;justify-content:flex-end">
+      <button type="button" class="btn" onclick="closeProcessModal()">Cancel</button>
+      <button type="button" class="btn btn-primary" id="process-confirm-btn" onclick="confirmProcess()">Process Now</button>
+    </div>
+  </div>
+</div>
+
 <script>
 function openDeclineModal(id, title) {
   document.getElementById('decline-issue-id').textContent = id;
@@ -166,6 +179,43 @@ function triggerSync() {
             text.textContent = 'Sync';
         });
 }
+
+var processIssueId = 0;
+function openProcessModal(id, title) {
+  processIssueId = id;
+  document.getElementById('process-issue-id').textContent = id;
+  document.getElementById('process-issue-title').textContent = title;
+  document.getElementById('process-modal').style.display = 'flex';
+}
+function closeProcessModal() {
+  document.getElementById('process-modal').style.display = 'none';
+  processIssueId = 0;
+}
+function confirmProcess() {
+  if (!processIssueId) return;
+  var btn = document.getElementById('process-confirm-btn');
+  btn.disabled = true;
+  btn.textContent = 'Queuing...';
+  fetch('/api/tickets/' + processIssueId + '/process', {method: 'POST'})
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (!data.success) {
+        alert('Failed: ' + (data.error || 'Unknown error'));
+      }
+      closeProcessModal();
+    })
+    .catch(function(err) {
+      alert('Error: ' + err.message);
+      closeProcessModal();
+    })
+    .finally(function() {
+      btn.disabled = false;
+      btn.textContent = 'Process Now';
+    });
+}
+document.getElementById('process-modal').addEventListener('click', function(e) {
+  if (e.target === this) closeProcessModal();
+});
 </script>
 
 <!-- Modal container for wizard -->
@@ -185,6 +235,7 @@ function triggerSync() {
         {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
         {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
         <div class="card-actions">
+          <button type="button" class="btn btn-primary" onclick="openProcessModal({{.ID}}, '{{.Title}}')">Process</button>
           <form method="post" action="/block/{{.ID}}"><button type="submit" class="btn" title="Block this ticket">Block</button></form>
         </div>
       </div>

--- a/internal/github/reasons.go
+++ b/internal/github/reasons.go
@@ -16,6 +16,7 @@ const (
 	ReasonManualDecline     StageChangeReason = "manual_decline"
 	ReasonManualMerge       StageChangeReason = "manual_merge"
 	ReasonManualMergeFailed StageChangeReason = "manual_merge_failed"
+	ReasonManualProcess     StageChangeReason = "manual_process"
 
 	// Worker/Orchestrator pipeline changes
 	ReasonWorkerPickedUp            StageChangeReason = "worker_picked_up"
@@ -67,6 +68,8 @@ func (r StageChangeReason) String() string {
 		return "User approved and merged PR via dashboard"
 	case ReasonManualMergeFailed:
 		return "Merge failed (likely conflict), PR closed"
+	case ReasonManualProcess:
+		return "User manually selected ticket for processing via dashboard"
 	case ReasonWorkerPickedUp:
 		return "Orchestrator picked up ticket for processing"
 	case ReasonWorkerAlreadyDone:

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -40,6 +40,7 @@ type Orchestrator struct {
 	paused      bool
 	processing  bool
 	currentTask *Task
+	manualNext  int
 	mu          sync.Mutex
 }
 
@@ -98,6 +99,29 @@ func (o *Orchestrator) CurrentTask() *Task {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	return o.currentTask
+}
+
+func (o *Orchestrator) QueueManualProcess(issueNumber int) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.currentTask != nil && o.currentTask.Issue.Number == issueNumber {
+		return fmt.Errorf("ticket #%d is already being processed", issueNumber)
+	}
+
+	o.manualNext = issueNumber
+	if o.paused {
+		o.paused = false
+		log.Printf("[Orchestrator] ▶ Auto-started sprint for manual process of #%d", issueNumber)
+	}
+	log.Printf("[Orchestrator] Manual process queued: #%d", issueNumber)
+	return nil
+}
+
+func (o *Orchestrator) ManualNext() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.manualNext
 }
 
 // GetWorker returns the orchestrator's worker for config propagation.
@@ -203,13 +227,33 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			nextIssue = resumeIssue
 			isResume = true
 			log.Printf("[Orchestrator] Resuming in-progress #%d: %s", nextIssue.Number, nextIssue.Title)
-		} else if len(candidates) > 0 {
-			picked, err := o.pickNextTicket(ctx, candidates, nil)
-			if err != nil {
-				log.Printf("[Orchestrator] Error picking next ticket: %v — falling back to first candidate", err)
-				picked = &candidates[0]
+		} else {
+			o.mu.Lock()
+			manualNum := o.manualNext
+			o.manualNext = 0
+			o.mu.Unlock()
+
+			if manualNum > 0 {
+				for i := range candidates {
+					if candidates[i].Number == manualNum {
+						nextIssue = &candidates[i]
+						log.Printf("[Orchestrator] ▶ Manual process: picking #%d: %s", nextIssue.Number, nextIssue.Title)
+						break
+					}
+				}
+				if nextIssue == nil {
+					log.Printf("[Orchestrator] Manual process #%d not found in backlog candidates, falling back to auto-pick", manualNum)
+				}
 			}
-			nextIssue = picked
+
+			if nextIssue == nil && len(candidates) > 0 {
+				picked, err := o.pickNextTicket(ctx, candidates, nil)
+				if err != nil {
+					log.Printf("[Orchestrator] Error picking next ticket: %v — falling back to first candidate", err)
+					picked = &candidates[0]
+				}
+				nextIssue = picked
+			}
 		}
 
 		if nextIssue == nil {

--- a/internal/mvp/orchestrator_test.go
+++ b/internal/mvp/orchestrator_test.go
@@ -483,6 +483,42 @@ func TestOrchestrator_ImplementsConfigAwareWorker(_ *testing.T) {
 	var _ config.ConfigAwareWorker = (*Orchestrator)(nil)
 }
 
+func TestQueueManualProcess(t *testing.T) {
+	o := &Orchestrator{paused: true}
+
+	err := o.QueueManualProcess(42)
+	if err != nil {
+		t.Fatalf("QueueManualProcess() error = %v", err)
+	}
+	if o.ManualNext() != 42 {
+		t.Errorf("ManualNext() = %d, want 42", o.ManualNext())
+	}
+	if o.IsPaused() {
+		t.Error("orchestrator should be auto-started after manual process")
+	}
+}
+
+func TestQueueManualProcessReplace(t *testing.T) {
+	o := &Orchestrator{paused: false}
+
+	o.QueueManualProcess(42)
+	o.QueueManualProcess(99)
+
+	if o.ManualNext() != 99 {
+		t.Errorf("ManualNext() = %d, want 99 (should replace previous)", o.ManualNext())
+	}
+}
+
+func TestQueueManualProcessAlreadyProcessing(t *testing.T) {
+	o := &Orchestrator{}
+	o.currentTask = &Task{Issue: github.Issue{Number: 42}}
+
+	err := o.QueueManualProcess(42)
+	if err == nil {
+		t.Error("expected error when queuing ticket that is already being processed")
+	}
+}
+
 // mockStageBroadcaster is a test mock for StageBroadcaster
 type mockStageBroadcaster struct {
 	issueUpdates                  []github.Issue


### PR DESCRIPTION
Closes #373

## Problem
Currently, the orchestrator automatically picks the next ticket from the backlog using LLM or fallback logic. There's no way for the user to manually select which ticket should be processed next. Users want to prioritize specific tickets (like #372) and have them appear in the Processing Panel immediately.

## Expected Behavior
Add a "Process" button/action in the dashboard that allows users to manually select a ticket from the Backlog column and move it to the Processing Panel (start processing it immediately).

### Features:
1. **Process Button** in Backlog column for each ticket
2. **Confirmation dialog** - "Start processing ticket #N?"
3. **Priority override** - selected ticket becomes the next one processed by the worker
4. **Visual feedback** - ticket moves from Backlog to Processing Panel

### Behavior:
- If worker is idle → start processing selected ticket immediately
- If worker is busy → queue the ticket as next (pause current, or wait)
- Only one ticket can be manually selected at a time
- Manual selection overrides LLM pick logic

## Acceptance Criteria
- [ ] Add "Process" button to each ticket card in Backlog column
- [ ] Add confirmation modal/dialog before starting
- [ ] Implement API endpoint `/api/tickets/{id}/process` to trigger manual processing
- [ ] Update orchestrator to respect manual selection over automatic picking
- [ ] Show visual indicator that ticket was manually selected
- [ ] Handle case when worker is already processing another ticket
- [ ] Add tests for the new functionality

## Technical Notes
- May need to add new state: `stage:queued` or use existing logic
- Consider adding `priority:manual` label or similar marker
- WebSocket update needed to refresh Processing Panel immediately
- Should work with existing worker pool architecture

## Related
- Ticket #372 needs this feature to be processed next