### PR TITLE
Improve empty state for central panel when no tickets exist

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -55,6 +55,7 @@ type boardData struct {
 	CanCloseSprint bool
 	CurrentTicket  *currentTicketInfo
 	YoloMode       bool
+	TotalTickets   int
 	Blocked        []taskCard
 	Backlog        []taskCard
 	Plan           []taskCard
@@ -157,6 +158,11 @@ func (s *Server) buildBoardData(_ *http.Request) boardData {
 		col := inferColumnFromIssue(issue)
 		s.addCardToColumn(&data, col, issue)
 	}
+
+	// Compute total ticket count across all columns
+	data.TotalTickets = len(data.Blocked) + len(data.Backlog) + len(data.Plan) +
+		len(data.Code) + len(data.AIReview) + len(data.CheckPipeline) +
+		len(data.Approve) + len(data.Merge) + len(data.Done) + len(data.Failed)
 
 	// Check if sprint can be closed: all tasks in Done/Failed columns and not processing
 	if !data.Processing &&

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -3488,6 +3488,87 @@ func TestBuildBoardData_CanCloseSprint_False_WhenActiveTasks(t *testing.T) {
 	}
 }
 
+// TestBuildBoardData_TotalTickets verifies that TotalTickets is computed correctly from all columns
+func TestBuildBoardData_TotalTickets(t *testing.T) {
+	tests := []struct {
+		name          string
+		blocked       []taskCard
+		backlog       []taskCard
+		plan          []taskCard
+		code          []taskCard
+		aiReview      []taskCard
+		checkPipeline []taskCard
+		approve       []taskCard
+		merge         []taskCard
+		done          []taskCard
+		failed        []taskCard
+		expectedTotal int
+	}{
+		{
+			name:          "empty sprint",
+			expectedTotal: 0,
+		},
+		{
+			name:          "single ticket in backlog",
+			backlog:       []taskCard{{ID: 1, Title: "Backlog task"}},
+			expectedTotal: 1,
+		},
+		{
+			name:          "tickets in multiple columns",
+			backlog:       []taskCard{{ID: 1, Title: "Backlog task"}},
+			plan:          []taskCard{{ID: 2, Title: "Plan task"}},
+			code:          []taskCard{{ID: 3, Title: "Code task"}},
+			expectedTotal: 3,
+		},
+		{
+			name:          "tickets in all columns",
+			blocked:       []taskCard{{ID: 1, Title: "Blocked"}},
+			backlog:       []taskCard{{ID: 2, Title: "Backlog"}},
+			plan:          []taskCard{{ID: 3, Title: "Plan"}},
+			code:          []taskCard{{ID: 4, Title: "Code"}},
+			aiReview:      []taskCard{{ID: 5, Title: "AI Review"}},
+			checkPipeline: []taskCard{{ID: 6, Title: "Check Pipeline"}},
+			approve:       []taskCard{{ID: 7, Title: "Approve"}},
+			merge:         []taskCard{{ID: 8, Title: "Merge"}},
+			done:          []taskCard{{ID: 9, Title: "Done"}},
+			failed:        []taskCard{{ID: 10, Title: "Failed"}},
+			expectedTotal: 10,
+		},
+		{
+			name:          "tickets only in done and failed",
+			done:          []taskCard{{ID: 1, Title: "Done 1"}, {ID: 2, Title: "Done 2"}},
+			failed:        []taskCard{{ID: 3, Title: "Failed"}},
+			expectedTotal: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := boardData{
+				Blocked:       tt.blocked,
+				Backlog:       tt.backlog,
+				Plan:          tt.plan,
+				Code:          tt.code,
+				AIReview:      tt.aiReview,
+				CheckPipeline: tt.checkPipeline,
+				Approve:       tt.approve,
+				Merge:         tt.merge,
+				Done:          tt.done,
+				Failed:        tt.failed,
+			}
+
+			// Apply the same logic as in buildBoardData
+			data.TotalTickets = len(data.Blocked) + len(data.Backlog) + len(data.Plan) +
+				len(data.Code) + len(data.AIReview) + len(data.CheckPipeline) +
+				len(data.Approve) + len(data.Merge) + len(data.Done) + len(data.Failed)
+
+			if data.TotalTickets != tt.expectedTotal {
+				t.Errorf("expected TotalTickets=%d, got %d", tt.expectedTotal, data.TotalTickets)
+			}
+		})
+	}
+}
+
 // TestHandleSprintClose_Success verifies the sprint close handler works correctly
 func TestHandleSprintClose_Success(t *testing.T) {
 	srv := &Server{
@@ -5177,10 +5258,11 @@ func TestBoardTemplate_ProcessingPanel_Idle(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
 
-	// Create test data with CurrentTicket nil
+	// Create test data with CurrentTicket nil and some tickets exist
 	data := boardData{
 		Active:        "board",
 		CurrentTicket: nil,
+		TotalTickets:  5,
 		Paused:        true,
 		Processing:    false,
 	}
@@ -5221,6 +5303,56 @@ func TestBoardTemplate_ProcessingPanel_Idle(t *testing.T) {
 	// Verify idle message contains "Worker ready"
 	if !strings.Contains(output, "Worker ready") {
 		t.Error("template should display 'Worker ready' message when idle")
+	}
+}
+
+// TestBoardTemplate_ProcessingPanel_EmptySprintState tests that the processing panel shows empty sprint state when TotalTickets is 0
+func TestBoardTemplate_ProcessingPanel_EmptySprintState(t *testing.T) {
+	srv := createTestServerWithTemplates(t)
+	defer srv.wizardStore.Stop()
+
+	data := boardData{
+		Active:        "board",
+		CurrentTicket: nil,
+		TotalTickets:  0,
+		Paused:        true,
+		Processing:    false,
+	}
+
+	tmpl := srv.tmpls["board.html"]
+	if tmpl == nil {
+		t.Fatal("board.html template not found")
+	}
+
+	var buf strings.Builder
+	if err := tmpl.ExecuteTemplate(&buf, "content", data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, `id="processing-panel"`) {
+		t.Error("template should contain processing-panel element")
+	}
+
+	if !strings.Contains(output, "Sprint is empty") {
+		t.Error("template should display 'Sprint is empty' when TotalTickets is 0")
+	}
+
+	if !strings.Contains(output, "No tickets in this sprint yet") {
+		t.Error("template should display subtitle when TotalTickets is 0")
+	}
+
+	if !strings.Contains(output, `href="/wizard"`) {
+		t.Error("template should contain CTA link to /wizard when TotalTickets is 0")
+	}
+
+	if !strings.Contains(output, "Create First Ticket") {
+		t.Error("template should display 'Create First Ticket' CTA when TotalTickets is 0")
+	}
+
+	if strings.Contains(output, "Worker ready") {
+		t.Error("template should NOT display 'Worker ready' when TotalTickets is 0")
 	}
 }
 

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -51,6 +51,12 @@
 .processing-panel-idle{background:rgba(108,117,125,0.08);border-color:rgba(108,117,125,0.2)}
 .processing-panel-idle .processing-indicator{background:#6c757d;animation:none}
 .processing-idle-text{color:var(--muted);font-size:.85rem}
+.processing-empty-state{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;gap:.75rem;width:100%;padding:1rem 0}
+.processing-empty-icon{font-size:2rem;line-height:1}
+.processing-empty-title{color:var(--text);font-size:1rem;font-weight:600}
+.processing-empty-subtitle{color:var(--muted);font-size:.85rem}
+.processing-empty-cta{display:inline-flex;align-items:center;gap:.35rem;padding:.4rem .8rem;background:var(--accent);color:#fff;border:none;border-radius:6px;font-size:.8rem;font-weight:500;text-decoration:none;cursor:pointer;transition:opacity .15s}
+.processing-empty-cta:hover{opacity:.85}
 .processing-panel-content{display:flex;flex-direction:column;align-items:flex-start;gap:.5rem;width:100%;min-width:0}
 .processing-indicator{width:8px;height:8px;border-radius:50%;background:#3498db;flex-shrink:0;animation:pulse 2s infinite}
 @keyframes pulse{0%,100%{opacity:1}50%{opacity:.4}}
@@ -365,7 +371,7 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
     </div>
 
     <!-- Processing Panel at the bottom of center column -->
-    <div class="processing-panel{{if not .CurrentTicket}} processing-panel-idle{{end}}" id="processing-panel">
+    <div class="processing-panel{{if not .CurrentTicket}} processing-panel-idle{{end}}" id="processing-panel" data-total-tickets="{{.TotalTickets}}">
       <div class="processing-panel-content">
         <span class="processing-indicator"></span>
         {{if .CurrentTicket}}
@@ -389,7 +395,16 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
           <span class="processing-title">{{.CurrentTicket.Title}}</span>
         </a>
         {{else}}
-        <span class="processing-idle-text">No active ticket &mdash; Worker ready</span>
+          {{if eq .TotalTickets 0}}
+          <div class="processing-empty-state">
+            <span class="processing-empty-icon">📋</span>
+            <span class="processing-empty-title">Sprint is empty</span>
+            <span class="processing-empty-subtitle">No tickets in this sprint yet</span>
+            <a href="/wizard" class="processing-empty-cta">+ Create First Ticket</a>
+          </div>
+          {{else}}
+          <span class="processing-idle-text">No active ticket &mdash; Worker ready</span>
+          {{end}}
         {{end}}
       </div>
     </div>

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -355,9 +355,21 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
                 '</a></div>';
         } else {
             panel.className = 'processing-panel processing-panel-idle';
+            var totalTickets = parseInt(panel.getAttribute('data-total-tickets') || '0', 10);
+            var idleContent;
+            if (totalTickets === 0) {
+                idleContent = '<div class="processing-empty-state">' +
+                    '<span class="processing-empty-icon">📋</span>' +
+                    '<span class="processing-empty-title">Sprint is empty</span>' +
+                    '<span class="processing-empty-subtitle">No tickets in this sprint yet</span>' +
+                    '<a href="/wizard" class="processing-empty-cta">+ Create First Ticket</a>' +
+                    '</div>';
+            } else {
+                idleContent = '<span class="processing-idle-text">No active ticket &mdash; Worker ready</span>';
+            }
             panel.innerHTML = '<div class="processing-panel-content">' +
                 '<span class="processing-indicator"></span>' +
-                '<span class="processing-idle-text">No active ticket &mdash; Worker ready</span>' +
+                idleContent +
                 '</div>';
         }
     }


### PR DESCRIPTION
Closes #380

## Problem Description

When the sprint has no tickets at all, the central processing panel shows only "No active ticket — Worker ready" which looks empty, uninviting, and doesn't provide any useful context or call-to-action.

Current behavior:
- Plain text "No active ticket — Worker ready"
- No visual indication that the sprint is completely empty
- No guidance on what to do next

## Proposed Solution

Improve the empty state of the central panel to be more informative and user-friendly:

1. **Detect empty sprint state** - Check if total ticket count is 0
2. **Show friendly empty state** with:
   - Icon or visual element (e.g., 📋 or 🎯)
   - Message like "Sprint is empty" or "No tickets in this sprint"
   - Call-to-action button/link to create first ticket ("+ Create First Ticket")
3. **Keep current message** "No active ticket — Worker ready" only when there ARE tickets but none are being processed

## Files to Modify

- `internal/dashboard/templates/board.html` - Lines 391-393 (processing panel idle state)
- `internal/dashboard/handlers.go` - Add `TotalTickets` field to `boardData` struct (line 48-68)
- `internal/dashboard/handlers.go` - Calculate total in `buildBoardData()` function

## Acceptance Criteria

- [ ] When sprint has 0 tickets, show friendly empty state with icon and CTA button
- [ ] When sprint has tickets but none processing, show current "Worker ready" message
- [ ] CTA button links to `/wizard` for creating new ticket
- [ ] Visual design matches dashboard aesthetic
- [ ] Works in both light and dark mode