### PR TITLE
Close Sprint button visible when sprint has no tickets

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -170,7 +170,8 @@ func (s *Server) buildBoardData(_ *http.Request) boardData {
 		len(data.AIReview) == 0 &&
 		len(data.CheckPipeline) == 0 &&
 		len(data.Approve) == 0 &&
-		len(data.Merge) == 0 {
+		len(data.Merge) == 0 &&
+		(len(data.Done) > 0 || len(data.Failed) > 0) {
 		data.CanCloseSprint = true
 	}
 

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -3390,8 +3390,10 @@ func TestBuildBoardData_CanCloseSprint_False_WhenProcessing(t *testing.T) {
 		len(data.Plan) == 0 &&
 		len(data.Code) == 0 &&
 		len(data.AIReview) == 0 &&
+		len(data.CheckPipeline) == 0 &&
 		len(data.Approve) == 0 &&
-		len(data.Merge) == 0 {
+		len(data.Merge) == 0 &&
+		(len(data.Done) > 0 || len(data.Failed) > 0) {
 		data.CanCloseSprint = true
 	}
 
@@ -3411,45 +3413,59 @@ func TestBuildBoardData_CanCloseSprint_False_WhenActiveTasks(t *testing.T) {
 		aiReview      []taskCard
 		approve       []taskCard
 		merge         []taskCard
+		done          []taskCard
+		failed        []taskCard
 		expectedClose bool
 	}{
 		{
 			name:          "tasks in Blocked column",
 			blocked:       []taskCard{{ID: 1, Title: "Blocked task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
 			name:          "tasks in Backlog column",
 			backlog:       []taskCard{{ID: 1, Title: "Backlog task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
 			name:          "tasks in Plan column",
 			plan:          []taskCard{{ID: 1, Title: "Plan task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
 			name:          "tasks in Code column",
 			code:          []taskCard{{ID: 1, Title: "Code task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
 			name:          "tasks in AI Review column",
 			aiReview:      []taskCard{{ID: 1, Title: "AI Review task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
 			name:          "tasks in Approve column",
 			approve:       []taskCard{{ID: 1, Title: "Approve task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
 			name:          "tasks in Merge column",
 			merge:         []taskCard{{ID: 1, Title: "Merge task"}},
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: false,
 		},
 		{
-			name:          "no tasks in active columns",
+			name:          "no tasks in active columns but no done/failed tickets",
+			expectedClose: false,
+		},
+		{
+			name:          "no tasks in active columns with done tickets",
+			done:          []taskCard{{ID: 100, Title: "Done task"}},
 			expectedClose: true,
 		},
 	}
@@ -3466,8 +3482,8 @@ func TestBuildBoardData_CanCloseSprint_False_WhenActiveTasks(t *testing.T) {
 				AIReview:   tt.aiReview,
 				Approve:    tt.approve,
 				Merge:      tt.merge,
-				Done:       []taskCard{{ID: 100, Title: "Done task"}},
-				Failed:     []taskCard{{ID: 101, Title: "Failed task"}},
+				Done:       tt.done,
+				Failed:     tt.failed,
 			}
 
 			// Apply the same logic as in buildBoardData
@@ -3477,8 +3493,10 @@ func TestBuildBoardData_CanCloseSprint_False_WhenActiveTasks(t *testing.T) {
 				len(data.Plan) == 0 &&
 				len(data.Code) == 0 &&
 				len(data.AIReview) == 0 &&
+				len(data.CheckPipeline) == 0 &&
 				len(data.Approve) == 0 &&
-				len(data.Merge) == 0 {
+				len(data.Merge) == 0 &&
+				(len(data.Done) > 0 || len(data.Failed) > 0) {
 				data.CanCloseSprint = true
 			}
 
@@ -3486,6 +3504,40 @@ func TestBuildBoardData_CanCloseSprint_False_WhenActiveTasks(t *testing.T) {
 				t.Errorf("expected CanCloseSprint=%v, got %v", tt.expectedClose, data.CanCloseSprint)
 			}
 		})
+	}
+}
+
+// TestBuildBoardData_CanCloseSprint_False_WhenEmptySprint verifies CanCloseSprint is false when sprint has no tickets at all
+func TestBuildBoardData_CanCloseSprint_False_WhenEmptySprint(t *testing.T) {
+	data := boardData{
+		Active:     "board",
+		Processing: false,
+		Blocked:    []taskCard{},
+		Backlog:    []taskCard{},
+		Plan:       []taskCard{},
+		Code:       []taskCard{},
+		AIReview:   []taskCard{},
+		Approve:    []taskCard{},
+		Merge:      []taskCard{},
+		Done:       []taskCard{},
+		Failed:     []taskCard{},
+	}
+
+	if !data.Processing &&
+		len(data.Blocked) == 0 &&
+		len(data.Backlog) == 0 &&
+		len(data.Plan) == 0 &&
+		len(data.Code) == 0 &&
+		len(data.AIReview) == 0 &&
+		len(data.CheckPipeline) == 0 &&
+		len(data.Approve) == 0 &&
+		len(data.Merge) == 0 &&
+		(len(data.Done) > 0 || len(data.Failed) > 0) {
+		data.CanCloseSprint = true
+	}
+
+	if data.CanCloseSprint {
+		t.Error("expected CanCloseSprint to be false when sprint has no tickets at all")
 	}
 }
 


### PR DESCRIPTION
Closes #379

## Bug Description

The "Close Sprint" button is visible on the dashboard even when the sprint contains no tickets at all. The button should only appear when there are completed or failed tickets that warrant closing the sprint.

## Root Cause

In `internal/dashboard/handlers.go:162-171`, the `CanCloseSprint` condition only checks that all active columns (Backlog, Plan, Code, etc.) are empty, but does **not** verify that any tickets exist in the `Done` or `Failed` columns.

```go
// Current (buggy) condition:
if !data.Processing &&
    len(data.Blocked) == 0 &&
    len(data.Backlog) == 0 &&
    len(data.Plan) == 0 &&
    len(data.Code) == 0 &&
    len(data.AIReview) == 0 &&
    len(data.CheckPipeline) == 0 &&
    len(data.Approve) == 0 &&
    len(data.Merge) == 0 {
    data.CanCloseSprint = true  // ← no tickets needed!
}
```

## Expected Behavior

The button should only be visible when there is at least one ticket in `Done` or `Failed` columns, indicating the sprint had work that was completed.

## Acceptance Criteria

- [ ] "Close Sprint" button is hidden when sprint has zero tickets
- [ ] "Close Sprint" button is visible when at least one ticket is in `Done` or `Failed`
- [ ] Existing tests updated to reflect correct behavior
- [ ] Add test for empty sprint case (`CanCloseSprint = false`)