### PR TITLE
Add oda issue log command to display stage change ledger history

### DIFF
--- a/cmd/issue.go
+++ b/cmd/issue.go
@@ -1,14 +1,19 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/crazy-goat/one-dev-army/internal/db"
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
 
@@ -22,10 +27,17 @@ type IssueCreateFlags struct {
 	CurrentSprint bool
 }
 
+// IssueLogFlags holds all the flags for the issue log command
+type IssueLogFlags struct {
+	Issue int
+	JSON  bool
+	Limit int
+}
+
 // IssueCommand handles the 'issue' subcommand and its children
-func IssueCommand(args []string, client *github.Client, dashboardPort int) error {
+func IssueCommand(args []string, client *github.Client, dashboardPort int, store *db.Store) error {
 	if len(args) < 1 {
-		return errors.New("issue command requires a subcommand: create")
+		return errors.New("issue command requires a subcommand: create, log")
 	}
 
 	subcommand := args[0]
@@ -34,6 +46,8 @@ func IssueCommand(args []string, client *github.Client, dashboardPort int) error
 	switch subcommand {
 	case "create":
 		return IssueCreateCommand(subArgs, client, dashboardPort)
+	case "log":
+		return IssueLogCommand(subArgs, store, os.Stdout)
 	default:
 		return fmt.Errorf("unknown issue subcommand: %s", subcommand)
 	}
@@ -149,12 +163,118 @@ func validateIssueCreateFlags(flags IssueCreateFlags) error {
 	return nil
 }
 
+// IssueLogCommand handles the 'issue log' subcommand
+func IssueLogCommand(args []string, store *db.Store, w io.Writer) error {
+	flags := IssueLogFlags{}
+
+	fs := flag.NewFlagSet("issue log", flag.ContinueOnError)
+	fs.IntVar(&flags.Issue, "issue", 0, "Issue number")
+	fs.BoolVar(&flags.JSON, "json", false, "Output as JSON")
+	fs.IntVar(&flags.Limit, "limit", 0, "Limit number of entries")
+
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("parsing flags: %w", err)
+	}
+
+	// Positional argument (if --issue not set)
+	if flags.Issue == 0 && fs.NArg() > 0 {
+		n, err := strconv.Atoi(fs.Arg(0))
+		if err != nil {
+			return fmt.Errorf("invalid issue number: %s", fs.Arg(0))
+		}
+		flags.Issue = n
+	}
+
+	if flags.Issue <= 0 {
+		return errors.New("issue number is required: oda issue log <number> or oda issue log --issue <number>")
+	}
+
+	if store == nil {
+		return errors.New("database not available")
+	}
+
+	changes, err := store.GetStageChangesLimit(flags.Issue, flags.Limit)
+	if err != nil {
+		return fmt.Errorf("querying stage changes: %w", err)
+	}
+
+	if len(changes) == 0 {
+		fmt.Fprintf(w, "No stage changes found for issue #%d\n", flags.Issue)
+		return nil
+	}
+
+	if flags.JSON {
+		return formatIssueLogJSON(w, flags.Issue, changes)
+	}
+	return formatIssueLogTable(w, flags.Issue, changes)
+}
+
+func formatIssueLogTable(w io.Writer, issueNumber int, changes []db.StageChange) error {
+	fmt.Fprintf(w, "Stage history for issue #%d (%d entries)\n\n", issueNumber, len(changes))
+	fmt.Fprintf(w, "%-21s %-13s %-13s %-25s %s\n", "TIME", "FROM", "TO", "REASON", "BY")
+
+	for _, c := range changes {
+		from := c.FromStage
+		if from == "" {
+			from = "—"
+		}
+		fmt.Fprintf(w, "%-21s %-13s %-13s %-25s %s\n",
+			c.ChangedAt.Format("2006-01-02 15:04:05"),
+			from,
+			c.ToStage,
+			c.Reason,
+			c.ChangedBy,
+		)
+	}
+	return nil
+}
+
+type issueLogOutput struct {
+	IssueNumber int             `json:"issue_number"`
+	Total       int             `json:"total"`
+	Entries     []issueLogEntry `json:"entries"`
+}
+
+type issueLogEntry struct {
+	ID        int    `json:"id"`
+	FromStage string `json:"from_stage"`
+	ToStage   string `json:"to_stage"`
+	Reason    string `json:"reason"`
+	ChangedBy string `json:"changed_by"`
+	ChangedAt string `json:"changed_at"`
+}
+
+func formatIssueLogJSON(w io.Writer, issueNumber int, changes []db.StageChange) error {
+	entries := make([]issueLogEntry, len(changes))
+	for i, c := range changes {
+		entries[i] = issueLogEntry{
+			ID:        c.ID,
+			FromStage: c.FromStage,
+			ToStage:   c.ToStage,
+			Reason:    c.Reason,
+			ChangedBy: c.ChangedBy,
+			ChangedAt: c.ChangedAt.Format(time.RFC3339),
+		}
+	}
+
+	output := issueLogOutput{
+		IssueNumber: issueNumber,
+		Total:       len(entries),
+		Entries:     entries,
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}
+
 // PrintIssueUsage prints usage information for the issue command
 func PrintIssueUsage() {
 	fmt.Println("Usage: oda issue <subcommand> [options]")
 	fmt.Println()
 	fmt.Println("Subcommands:")
 	fmt.Println("  create    Create a new GitHub issue")
+	fmt.Println("  log       Display stage change history for an issue")
 	fmt.Println()
 	fmt.Println("Issue Create Options:")
 	fmt.Println("  --title string         Issue title (required)")
@@ -164,8 +284,15 @@ func PrintIssueUsage() {
 	fmt.Println("  --type string          Issue type: bug or feature")
 	fmt.Println("  --current-sprint       Assign issue to the current sprint")
 	fmt.Println()
+	fmt.Println("Issue Log Options:")
+	fmt.Println("  --issue int            Issue number (alternative to positional argument)")
+	fmt.Println("  --json                 Output as JSON instead of text table")
+	fmt.Println("  --limit int            Limit number of entries (default: all, newest-first)")
+	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  oda issue create --title \"Fix login bug\" --text \"Users cannot login\" --priority high --type bug --current-sprint")
+	fmt.Println("  oda issue log 42")
+	fmt.Println("  oda issue log --issue 42 --json --limit 10")
 }
 
 // triggerDashboardSync sends an HTTP POST request to the dashboard sync endpoint

--- a/cmd/issue_test.go
+++ b/cmd/issue_test.go
@@ -1,11 +1,17 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/crazy-goat/one-dev-army/internal/db"
 )
 
 func TestValidateIssueCreateFlags(t *testing.T) {
@@ -220,4 +226,220 @@ func TestTriggerDashboardSync_DashboardNotRunning(_ *testing.T) {
 	// Use an unused port to simulate dashboard not running
 	triggerDashboardSync(59999)
 	// Should not panic or return error - function should return gracefully
+}
+
+func openTestStore(t *testing.T) *db.Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	store, err := db.Open(path)
+	if err != nil {
+		t.Fatalf("opening store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestIssueLogCommand_FlagParsing(t *testing.T) {
+	store := openTestStore(t)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "positional argument",
+			args:    []string{"42"},
+			wantErr: false,
+		},
+		{
+			name:    "issue flag",
+			args:    []string{"--issue", "42"},
+			wantErr: false,
+		},
+		{
+			name:    "flag wins over positional",
+			args:    []string{"--issue", "99", "42"},
+			wantErr: false,
+		},
+		{
+			name:    "missing issue number",
+			args:    []string{},
+			wantErr: true,
+			errMsg:  "issue number is required",
+		},
+		{
+			name:    "invalid positional argument",
+			args:    []string{"abc"},
+			wantErr: true,
+			errMsg:  "invalid issue number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := IssueLogCommand(tt.args, store, &buf)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("IssueLogCommand() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("IssueLogCommand() error = %v, want containing %q", err, tt.errMsg)
+				}
+			} else if err != nil {
+				t.Errorf("IssueLogCommand() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestIssueLogCommand_TableOutput(t *testing.T) {
+	store := openTestStore(t)
+
+	// Insert sample stage changes
+	now := time.Now().UTC()
+	err := store.SaveStageChange(42, "", "analysis", "initial stage", "system")
+	if err != nil {
+		t.Fatalf("saving stage change: %v", err)
+	}
+	err = store.SaveStageChange(42, "analysis", "planning", "analysis complete", "orchestrator")
+	if err != nil {
+		t.Fatalf("saving stage change: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = IssueLogCommand([]string{"42"}, store, &buf)
+	if err != nil {
+		t.Fatalf("IssueLogCommand() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Stage history for issue #42") {
+		t.Errorf("output missing header: %s", output)
+	}
+	if !strings.Contains(output, "TIME") {
+		t.Errorf("output missing TIME column: %s", output)
+	}
+	if !strings.Contains(output, "FROM") {
+		t.Errorf("output missing FROM column: %s", output)
+	}
+	if !strings.Contains(output, "TO") {
+		t.Errorf("output missing TO column: %s", output)
+	}
+	if !strings.Contains(output, "—") {
+		t.Errorf("output missing em-dash for empty from_stage: %s", output)
+	}
+	if !strings.Contains(output, "analysis") {
+		t.Errorf("output missing 'analysis' stage: %s", output)
+	}
+	if !strings.Contains(output, "planning") {
+		t.Errorf("output missing 'planning' stage: %s", output)
+	}
+
+	// Verify the output contains the expected time format
+	if !strings.Contains(output, now.Format("2006-01-02")) {
+		t.Errorf("output missing date: %s", output)
+	}
+}
+
+func TestIssueLogCommand_JSONOutput(t *testing.T) {
+	store := openTestStore(t)
+
+	// Insert sample stage changes
+	err := store.SaveStageChange(42, "", "analysis", "initial stage", "system")
+	if err != nil {
+		t.Fatalf("saving stage change: %v", err)
+	}
+	err = store.SaveStageChange(42, "analysis", "planning", "analysis complete", "orchestrator")
+	if err != nil {
+		t.Fatalf("saving stage change: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = IssueLogCommand([]string{"--issue", "42", "--json"}, store, &buf)
+	if err != nil {
+		t.Fatalf("IssueLogCommand() error = %v", err)
+	}
+
+	var output issueLogOutput
+	if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+		t.Fatalf("unmarshaling JSON output: %v", err)
+	}
+
+	if output.IssueNumber != 42 {
+		t.Errorf("issue_number = %d, want 42", output.IssueNumber)
+	}
+	if output.Total != 2 {
+		t.Errorf("total = %d, want 2", output.Total)
+	}
+	if len(output.Entries) != 2 {
+		t.Errorf("entries length = %d, want 2", len(output.Entries))
+	}
+
+	// Verify entries are in correct order (newest first)
+	if output.Entries[0].ToStage != "planning" {
+		t.Errorf("first entry to_stage = %s, want planning", output.Entries[0].ToStage)
+	}
+	if output.Entries[1].ToStage != "analysis" {
+		t.Errorf("second entry to_stage = %s, want analysis", output.Entries[1].ToStage)
+	}
+}
+
+func TestIssueLogCommand_Limit(t *testing.T) {
+	store := openTestStore(t)
+
+	// Insert 5 stage changes
+	for i := range 5 {
+		err := store.SaveStageChange(42, fmt.Sprintf("stage%d", i), fmt.Sprintf("stage%d", i+1), "test", "system")
+		if err != nil {
+			t.Fatalf("saving stage change: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	err := IssueLogCommand([]string{"--issue", "42", "--limit", "2", "--json"}, store, &buf)
+	if err != nil {
+		t.Fatalf("IssueLogCommand() error = %v", err)
+	}
+
+	var output issueLogOutput
+	if err := json.Unmarshal(buf.Bytes(), &output); err != nil {
+		t.Fatalf("unmarshaling JSON output: %v", err)
+	}
+
+	if output.Total != 2 {
+		t.Errorf("total = %d, want 2", output.Total)
+	}
+	if len(output.Entries) != 2 {
+		t.Errorf("entries length = %d, want 2", len(output.Entries))
+	}
+}
+
+func TestIssueLogCommand_EmptyLedger(t *testing.T) {
+	store := openTestStore(t)
+
+	var buf bytes.Buffer
+	err := IssueLogCommand([]string{"42"}, store, &buf)
+	if err != nil {
+		t.Fatalf("IssueLogCommand() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "No stage changes found for issue #42") {
+		t.Errorf("output missing empty message: %s", output)
+	}
+}
+
+func TestIssueLogCommand_NilStore(t *testing.T) {
+	var buf bytes.Buffer
+	err := IssueLogCommand([]string{"42"}, nil, &buf)
+	if err == nil {
+		t.Fatal("IssueLogCommand() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "database not available") {
+		t.Errorf("error = %v, want containing 'database not available'", err)
+	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -746,6 +746,37 @@ func (s *Store) GetStageChanges(issueNumber int) (changes []StageChange, err err
 	return changes, nil
 }
 
+// GetStageChangesLimit returns stage changes for an issue with optional limit
+func (s *Store) GetStageChangesLimit(issueNumber, limit int) (changes []StageChange, err error) {
+	query := `SELECT id, issue_number, from_stage, to_stage, reason, changed_by, changed_at
+		 FROM stage_change_ledger WHERE issue_number = ? ORDER BY changed_at DESC`
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	rows, err := s.db.Query(query, issueNumber)
+	if err != nil {
+		return nil, fmt.Errorf("querying stage changes: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing rows: %w", cerr)
+		}
+	}()
+
+	for rows.Next() {
+		var c StageChange
+		if err := rows.Scan(&c.ID, &c.IssueNumber, &c.FromStage, &c.ToStage, &c.Reason, &c.ChangedBy, &c.ChangedAt); err != nil {
+			return nil, fmt.Errorf("scanning stage change: %w", err)
+		}
+		changes = append(changes, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating stage changes: %w", err)
+	}
+	return changes, nil
+}
+
 // StageChange represents a single stage change record
 type StageChange struct {
 	ID          int

--- a/main.go
+++ b/main.go
@@ -136,7 +136,15 @@ func runIssue(args []string, dir string) error {
 	}
 
 	gh := github.NewClient(cfg.GitHub.Repo)
-	return cmd.IssueCommand(args, gh, cfg.Dashboard.Port)
+
+	dbPath := filepath.Join(dir, ".oda", "metrics.db")
+	store, err := db.Open(dbPath)
+	if err != nil {
+		return fmt.Errorf("opening database: %w", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	return cmd.IssueCommand(args, gh, cfg.Dashboard.Port, store)
 }
 
 func runServe(dir string, debugWebSocket bool) error {


### PR DESCRIPTION
Closes #390

## Problem Description

The `stage_change_ledger` SQLite table records every stage transition for every issue (from_stage, to_stage, reason, changed_by, changed_at), but `GetStageChanges()` is never called anywhere in the codebase — the ledger is write-only. There is no way to inspect the history of a ticket from the CLI.

## Proposed Solution

Add a new CLI subcommand `oda issue log` that queries the `stage_change_ledger` and displays the history for a given issue.

### Interface

```
oda issue log <number> [options]
oda issue log --issue <number> [options]
```

Issue number can be provided as a positional argument or via `--issue` flag. If both are given, the flag wins.

### Flags

| Flag | Description |
|------|-------------|
| `--issue N` | Issue number (alternative to positional argument) |
| `--json` | Output as JSON instead of text table |
| `--limit N` | Limit number of entries (default: all, newest-first) |

### Text output (default)

```
Stage history for issue #42 (5 entries)

TIME                  FROM          TO            REASON                    BY
2026-03-25 15:03:02   AI Review     Code          manual_retry              orchestrator
2026-03-25 15:01:44   Code          AI Review     worker_completed_coding   orchestrator
2026-03-25 14:35:12   Plan          Code          worker_completed_analysis orchestrator
2026-03-25 14:32:01   Backlog       Plan          sync_initial              orchestrator
2026-03-25 14:30:00   —             Backlog       sync_initial              orchestrator
```

### JSON output (`--json`)

```json
{
  "issue_number": 42,
  "total": 5,
  "entries": [
    {
      "id": 12,
      "from_stage": "AI Review",
      "to_stage": "Code",
      "reason": "manual_retry",
      "changed_by": "orchestrator",
      "changed_at": "2026-03-25T15:03:02Z"
    }
  ]
}
```

## Files to Modify

- `internal/db/db.go` — Add `GetStageChangesLimit(issueNumber, limit int)` method with optional `LIMIT` clause. Keep existing `GetStageChanges` unchanged.
- `cmd/issue.go` — Add `IssueLogFlags` struct, `"log"` case in `IssueCommand()` switch, `IssueLogCommand()` function, table and JSON formatters. Update `IssueCommand` signature to accept `*db.Store`. Update `PrintIssueUsage()`.
- `main.go` — Update `runIssue()` to open `db.Store` (path: `<dir>/.oda/metrics.db`) and pass it to `cmd.IssueCommand()`.
- `cmd/issue_test.go` — Tests for flag parsing, output formatting, empty ledger, `--limit`.

## Acceptance Criteria

- [ ] `oda issue log 42` displays text table of stage changes for issue #42
- [ ] `oda issue log --issue 42` works identically to positional form
- [ ] `--json` flag outputs valid JSON with `issue_number`, `total`, and `entries` array
- [ ] `--limit N` restricts output to N most recent entries
- [ ] Empty ledger prints `"No stage changes found for issue #N"` and exits cleanly
- [ ] Missing issue number prints error with usage hint
- [ ] All existing tests continue to pass
- [ ] New tests cover: flag parsing, table output, JSON output, limit, empty state, error cases