### PR TITLE
Add SSE endpoint for streaming step logs

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1024,6 +1027,188 @@ func (s *Server) handleTaskStream(w http.ResponseWriter, r *http.Request) {
 			if props.SessionID == sessionID && props.Status.Type == "idle" {
 				_, _ = fmt.Fprintf(w, "data: {\"done\":true}\n\n")
 				flusher.Flush()
+				return
+			}
+		}
+	}
+}
+
+func sendSSEEvent(w http.ResponseWriter, flusher http.Flusher, event string, data any) {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, jsonData)
+	flusher.Flush()
+}
+
+func (s *Server) handleLogStream(w http.ResponseWriter, r *http.Request) {
+	issueStr := r.PathValue("issue")
+	_, err := strconv.Atoi(issueStr)
+	if err != nil {
+		http.Error(w, "invalid issue number", http.StatusBadRequest)
+		return
+	}
+
+	stepFilter := r.URL.Query().Get("step")
+	follow := r.URL.Query().Get("follow") != "false"
+
+	logDir := filepath.Join(s.rootDir, ".oda", "artifacts", issueStr, "logs")
+
+	info, err := os.Stat(logDir)
+	if err != nil || !info.IsDir() {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		sendSSEEvent(w, flusher, "log:error", map[string]string{
+			"error": "log directory not found for issue " + issueStr,
+		})
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		sendSSEEvent(w, flusher, "log:error", map[string]string{
+			"error": fmt.Sprintf("failed to read log directory: %v", err),
+		})
+		return
+	}
+
+	type fileOffset struct {
+		offset   int64
+		complete bool
+	}
+	fileOffsets := make(map[string]fileOffset)
+
+	var logFiles []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		if stepFilter != "" {
+			stepName := strings.TrimSuffix(name, ".log")
+			if idx := strings.LastIndex(stepName, "_"); idx != -1 {
+				stepName = stepName[idx+1:]
+			}
+			if stepName != stepFilter {
+				continue
+			}
+		}
+		logFiles = append(logFiles, name)
+	}
+
+	sort.Strings(logFiles)
+
+	streamFile := func(filename string) {
+		filepath := filepath.Join(logDir, filename)
+		file, err := os.Open(filepath)
+		if err != nil {
+			sendSSEEvent(w, flusher, "log:error", map[string]string{
+				"error": fmt.Sprintf("failed to open log file %s: %v", filename, err),
+			})
+			return
+		}
+		defer file.Close()
+
+		offset := fileOffsets[filename].offset
+		if offset > 0 {
+			_, err = file.Seek(offset, 0)
+			if err != nil {
+				sendSSEEvent(w, flusher, "log:error", map[string]string{
+					"error": fmt.Sprintf("failed to seek in log file %s: %v", filename, err),
+				})
+				return
+			}
+		}
+
+		scanner := bufio.NewScanner(file)
+		stepName := strings.TrimSuffix(filename, ".log")
+		if idx := strings.LastIndex(stepName, "_"); idx != -1 {
+			stepName = stepName[idx+1:]
+		}
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			timestamp := ""
+			message := line
+			if len(line) > 22 && line[0] == '[' && line[5] == '-' && line[20] == ']' {
+				timestamp = line[1:20]
+				if len(line) > 22 {
+					message = line[22:]
+				}
+			}
+
+			sendSSEEvent(w, flusher, "log:new", map[string]string{
+				"file":      filename,
+				"step":      stepName,
+				"timestamp": timestamp,
+				"message":   message,
+			})
+
+			if strings.Contains(line, "STEP END:") {
+				fileOffsets[filename] = fileOffset{offset: offset, complete: true}
+				sendSSEEvent(w, flusher, "log:complete", map[string]string{
+					"file": filename,
+					"step": stepName,
+				})
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			sendSSEEvent(w, flusher, "log:error", map[string]string{
+				"error": fmt.Sprintf("error reading log file %s: %v", filename, err),
+			})
+			return
+		}
+
+		currentOffset, _ := file.Seek(0, 1)
+		fileOffsets[filename] = fileOffset{offset: currentOffset, complete: false}
+	}
+
+	for _, filename := range logFiles {
+		streamFile(filename)
+	}
+
+	if !follow {
+		return
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-ticker.C:
+			allComplete := true
+			for _, filename := range logFiles {
+				if !fileOffsets[filename].complete {
+					allComplete = false
+					streamFile(filename)
+				}
+			}
+			if allComplete {
 				return
 			}
 		}

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5711,3 +5711,219 @@ func TestBuildBoardData_TotalTickets(t *testing.T) {
 		t.Errorf("expected TotalTickets=0 with no store, got %d", data.TotalTickets)
 	}
 }
+
+func TestHandleLogStream_ValidIssue(t *testing.T) {
+	tmpDir := t.TempDir()
+	logDir := filepath.Join(tmpDir, ".oda", "artifacts", "392", "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	content := "[2026-03-25 14:30:22] STEP START: implement\n[2026-03-25 14:30:23] Working...\n[2026-03-25 14:31:55] STEP END: implement\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143022_implement.log"), []byte(content), 0o644)
+
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/392/stream?follow=false", nil)
+	req.SetPathValue("issue", "392")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected Content-Type=text/event-stream, got %s", rec.Header().Get("Content-Type"))
+	}
+	if rec.Header().Get("Cache-Control") != "no-cache" {
+		t.Errorf("expected Cache-Control=no-cache, got %s", rec.Header().Get("Cache-Control"))
+	}
+	if rec.Header().Get("Connection") != "keep-alive" {
+		t.Errorf("expected Connection=keep-alive, got %s", rec.Header().Get("Connection"))
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: log:new") {
+		t.Error("expected log:new events in response")
+	}
+	if !strings.Contains(body, "event: log:complete") {
+		t.Error("expected log:complete event in response")
+	}
+	if !strings.Contains(body, `"step":"implement"`) {
+		t.Error("expected step name in events")
+	}
+}
+
+func TestHandleLogStream_StepFilter(t *testing.T) {
+	tmpDir := t.TempDir()
+	logDir := filepath.Join(tmpDir, ".oda", "artifacts", "393", "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	content1 := "[2026-03-25 14:30:22] STEP START: analyze\n[2026-03-25 14:30:25] STEP END: analyze\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143022_analyze.log"), []byte(content1), 0o644)
+
+	content2 := "[2026-03-25 14:31:00] STEP START: implement\n[2026-03-25 14:31:55] STEP END: implement\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143100_implement.log"), []byte(content2), 0o644)
+
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/393/stream?step=implement&follow=false", nil)
+	req.SetPathValue("issue", "393")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"step":"implement"`) {
+		t.Error("expected implement step in response")
+	}
+	if strings.Contains(body, `"step":"analyze"`) {
+		t.Error("should not contain analyze step when filtered to implement")
+	}
+}
+
+func TestHandleLogStream_MissingDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/999/stream?follow=false", nil)
+	req.SetPathValue("issue", "999")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected Content-Type=text/event-stream, got %s", rec.Header().Get("Content-Type"))
+	}
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "event: log:error") {
+		t.Error("expected log:error event for missing directory")
+	}
+	if !strings.Contains(body, "log directory not found") {
+		t.Error("expected error message about missing directory")
+	}
+}
+
+func TestHandleLogStream_InvalidIssueNumber(t *testing.T) {
+	tmpDir := t.TempDir()
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/abc/stream", nil)
+	req.SetPathValue("issue", "abc")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleLogStream_EmptyLogsDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	logDir := filepath.Join(tmpDir, ".oda", "artifacts", "394", "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/394/stream?follow=false", nil)
+	req.SetPathValue("issue", "394")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected Content-Type=text/event-stream, got %s", rec.Header().Get("Content-Type"))
+	}
+
+	body := rec.Body.String()
+	if strings.Contains(body, "event: log:new") {
+		t.Error("should not have log:new events for empty directory")
+	}
+}
+
+func TestHandleLogStream_MultipleLogFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	logDir := filepath.Join(tmpDir, ".oda", "artifacts", "395", "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	content1 := "[2026-03-25 14:30:22] STEP START: analyze\n[2026-03-25 14:30:25] STEP END: analyze\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143022_analyze.log"), []byte(content1), 0o644)
+
+	content2 := "[2026-03-25 14:31:00] STEP START: implement\n[2026-03-25 14:31:55] STEP END: implement\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143100_implement.log"), []byte(content2), 0o644)
+
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/395/stream?follow=false", nil)
+	req.SetPathValue("issue", "395")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `"step":"analyze"`) {
+		t.Error("expected analyze step in response")
+	}
+	if !strings.Contains(body, `"step":"implement"`) {
+		t.Error("expected implement step in response")
+	}
+}
+
+func TestHandleLogStream_FollowDisabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	logDir := filepath.Join(tmpDir, ".oda", "artifacts", "396", "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	content := "[2026-03-25 14:30:22] STEP START: test\n[2026-03-25 14:30:23] Working...\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143022_test.log"), []byte(content), 0o644)
+
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/396/stream?follow=false", nil)
+	req.SetPathValue("issue", "396")
+	rec := httptest.NewRecorder()
+
+	done := make(chan bool)
+	go func() {
+		srv.handleLogStream(rec, req)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		body := rec.Body.String()
+		if !strings.Contains(body, "event: log:new") {
+			t.Error("expected log:new events")
+		}
+		if strings.Contains(body, "event: log:complete") {
+			t.Error("should not have log:complete when STEP END is not present")
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("handler should return immediately when follow=false")
+	}
+}
+
+func TestHandleLogStream_SSEHeaders(t *testing.T) {
+	tmpDir := t.TempDir()
+	logDir := filepath.Join(tmpDir, ".oda", "artifacts", "397", "logs")
+	os.MkdirAll(logDir, 0o755)
+
+	content := "[2026-03-25 14:30:22] test message\n"
+	os.WriteFile(filepath.Join(logDir, "20260325_143022_test.log"), []byte(content), 0o644)
+
+	srv := &Server{rootDir: tmpDir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/397/stream?follow=false", nil)
+	req.SetPathValue("issue", "397")
+	rec := httptest.NewRecorder()
+
+	srv.handleLogStream(rec, req)
+
+	if rec.Header().Get("Content-Type") != "text/event-stream" {
+		t.Errorf("expected Content-Type=text/event-stream, got %s", rec.Header().Get("Content-Type"))
+	}
+	if rec.Header().Get("Cache-Control") != "no-cache" {
+		t.Errorf("expected Cache-Control=no-cache, got %s", rec.Header().Get("Cache-Control"))
+	}
+	if rec.Header().Get("Connection") != "keep-alive" {
+		t.Errorf("expected Connection=keep-alive, got %s", rec.Header().Get("Connection"))
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -213,6 +213,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /plan-sprint", s.handlePlanSprint)
 	s.mux.HandleFunc("GET /task/{id}", s.handleTaskDetail)
 	s.mux.HandleFunc("GET /api/task/{id}/stream", s.handleTaskStream)
+	s.mux.HandleFunc("GET /api/logs/{issue}/stream", s.handleLogStream)
 	s.mux.HandleFunc("POST /approve/{id}", s.handleApprove)
 	s.mux.HandleFunc("POST /reject/{id}", s.handleReject)
 	s.mux.HandleFunc("POST /retry/{id}", s.handleRetry)


### PR DESCRIPTION
Closes #394

Create an SSE (Server-Sent Events) endpoint to stream step logs in real-time from `.oda/artifacts/<issue>/logs/`.

The endpoint should allow dashboard users to view live logs as workers execute pipeline steps.

## Endpoint Specification

**URL:** `/api/logs/:issue/stream`

**Method:** GET

**Headers:**
- `Accept: text/event-stream`
- `Cache-Control: no-cache`

**Response:** SSE stream with events:
- `log:new` - new log line added
- `log:complete` - step finished
- `log:error` - error reading logs

**Query Parameters:**
- `step` (optional) - filter by specific step name (e.g., `?step=implement`)
- `follow` (optional) - if true, keep connection open for new logs (default: true)

## Example Usage

```javascript
const eventSource = new EventSource('/api/logs/392/stream');
eventSource.onmessage = (event) => {
  const data = JSON.parse(event.data);
  console.log(data.timestamp, data.level, data.message);
};
```

## Acceptance Criteria
- [ ] Create SSE endpoint `/api/logs/:issue/stream` in dashboard handlers
- [ ] Stream existing log files from `.oda/artifacts/<issue>/logs/`
- [ ] Support filtering by step name via query parameter
- [ ] Handle file tailing for real-time updates (follow mode)
- [ ] Proper SSE headers and event formatting
- [ ] Handle errors gracefully (file not found, permission denied)
- [ ] Close connection when step completes or client disconnects
- [ ] Add tests for the endpoint
- [ ] Update dashboard to consume the endpoint (optional for this ticket)