### PR TITLE
Fix live streaming of LLM responses to step logs

### DIFF
--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -1024,7 +1025,13 @@ func (w *Worker) llmStep(_ context.Context, task *Task, stepName, prompt, llm st
 	task.AddChatMessage("user", prompt)
 
 	model := opencode.ParseModelRef(llm)
-	msg, err := w.oc.SendMessage(session.ID, prompt, model, nil)
+
+	var output io.Writer
+	if logger != nil {
+		output = logger
+	}
+
+	msg, err := w.oc.SendMessage(session.ID, prompt, model, output)
 	if err != nil {
 		if w.store != nil && stepID > 0 {
 			_ = w.store.FailStep(stepID, err.Error())
@@ -1033,6 +1040,7 @@ func (w *Worker) llmStep(_ context.Context, task *Task, stepName, prompt, llm st
 	}
 
 	if logger != nil {
+		logger.Logf("--- Streamed output ends ---")
 		logger.LogLLMResponse(msg)
 	}
 

--- a/internal/worker/step_logger.go
+++ b/internal/worker/step_logger.go
@@ -125,6 +125,21 @@ func (l *StepLogger) Logf(format string, args ...any) {
 	l.logf(format, args...)
 }
 
+func (l *StepLogger) Write(p []byte) (int, error) {
+	if l == nil {
+		return len(p), nil
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.file == nil {
+		return len(p), nil
+	}
+
+	return l.file.Write(p)
+}
+
 func (l *StepLogger) End(success bool, output string) error {
 	if l == nil {
 		return nil

--- a/internal/worker/step_logger_test.go
+++ b/internal/worker/step_logger_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -390,6 +391,112 @@ func TestStepLogger_Truncate(t *testing.T) {
 		result := Truncate(tt.input, tt.maxLen)
 		if result != tt.expected {
 			t.Errorf("Truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, result, tt.expected)
+		}
+	}
+}
+
+func TestStepLogger_Write(t *testing.T) {
+	tmpDir := t.TempDir()
+	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
+
+	logger, err := NewStepLogger(artifactDir, 400, "test-step")
+	if err != nil {
+		t.Fatalf("NewStepLogger failed: %v", err)
+	}
+
+	if err := logger.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	n, err := logger.Write([]byte("streaming chunk 1"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if n != 17 {
+		t.Errorf("expected 17 bytes written, got %d", n)
+	}
+
+	n, err = logger.Write([]byte(" chunk 2"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if n != 8 {
+		t.Errorf("expected 8 bytes written, got %d", n)
+	}
+
+	logger.End(true, "")
+	logger.Close()
+
+	entries, _ := os.ReadDir(logger.logDir)
+	content, _ := os.ReadFile(filepath.Join(logger.logDir, entries[0].Name()))
+
+	if !strings.Contains(string(content), "streaming chunk 1 chunk 2") {
+		t.Error("log should contain streamed chunks concatenated")
+	}
+}
+
+func TestStepLogger_Write_NilSafety(t *testing.T) {
+	var logger *StepLogger
+
+	n, err := logger.Write([]byte("test"))
+	if err != nil {
+		t.Errorf("Write on nil logger should not error, got: %v", err)
+	}
+	if n != 4 {
+		t.Errorf("Write on nil logger should return len(p)=%d, got %d", 4, n)
+	}
+
+	logger, _ = NewStepLogger(t.TempDir(), 1, "test")
+
+	n, err = logger.Write([]byte("test"))
+	if err != nil {
+		t.Errorf("Write before Start should not error, got: %v", err)
+	}
+	if n != 4 {
+		t.Errorf("Write before Start should return len(p)=%d, got %d", 4, n)
+	}
+}
+
+func TestStepLogger_ImplementsIOWriter(_ *testing.T) {
+	var _ io.Writer = (*StepLogger)(nil)
+}
+
+func TestStepLogger_ConcurrentWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
+
+	logger, err := NewStepLogger(artifactDir, 401, "test-step")
+	if err != nil {
+		t.Fatalf("NewStepLogger failed: %v", err)
+	}
+
+	if err := logger.Start(); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	done := make(chan bool, 10)
+	for i := range 10 {
+		go func(n int) {
+			chunk := fmt.Sprintf("chunk-%d ", n)
+			logger.Write([]byte(chunk))
+			done <- true
+		}(i)
+	}
+
+	for range 10 {
+		<-done
+	}
+
+	logger.End(true, "")
+	logger.Close()
+
+	entries, _ := os.ReadDir(logger.logDir)
+	content, _ := os.ReadFile(filepath.Join(logger.logDir, entries[0].Name()))
+
+	for i := range 10 {
+		expected := fmt.Sprintf("chunk-%d", i)
+		if !strings.Contains(string(content), expected) {
+			t.Errorf("log should contain '%s'", expected)
 		}
 	}
 }


### PR DESCRIPTION
Closes #396

Fix live streaming of LLM responses to step logs. Currently, LLM responses are only logged at the end of the step, not in real-time as they arrive.

## Current Behavior
In `internal/mvp/worker.go`, the `llmStep` function calls:
```go
msg, err := w.oc.SendMessage(session.ID, prompt, model, nil)
```

The `nil` parameter means no output writer is provided, so the entire LLM response is buffered and only logged after completion. This results in:
- Empty log files during long-running steps
- All content appearing at once at the end
- No visibility into progress during execution

## Expected Behavior
LLM responses should be streamed to the log file in real-time as chunks arrive from the API.

## Proposed Solution
1. Create a custom `io.Writer` that writes to `StepLogger` 
2. Pass this writer to `SendMessage` instead of `nil`
3. The writer should buffer chunks and flush to the log file periodically
4. Handle tool calls and results that arrive mid-stream

## Acceptance Criteria
- [ ] LLM text chunks are written to log file as they arrive (not at the end)
- [ ] Tool calls are logged immediately when they start
- [ ] Tool results are logged immediately when they complete
- [ ] Log file shows progress during long-running steps
- [ ] No regression in existing functionality
- [ ] Tests updated to verify streaming behavior