### PR TITLE
Fix duplicate issue number in artifact log path

### DIFF
--- a/internal/worker/step_logger.go
+++ b/internal/worker/step_logger.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -21,7 +20,7 @@ type StepLogger struct {
 }
 
 func NewStepLogger(artifactDir string, issueNum int, stepName string) (*StepLogger, error) {
-	logDir := filepath.Join(artifactDir, strconv.Itoa(issueNum), "logs")
+	logDir := filepath.Join(artifactDir, "logs")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating log directory %s: %w", logDir, err)
 	}

--- a/internal/worker/step_logger_test.go
+++ b/internal/worker/step_logger_test.go
@@ -29,7 +29,7 @@ func TestStepLogger_CreatesLogFile(t *testing.T) {
 		t.Errorf("expected stepName='test-step', got %s", logger.stepName)
 	}
 
-	expectedLogDir := filepath.Join(artifactDir, "123", "logs")
+	expectedLogDir := filepath.Join(artifactDir, "logs")
 	if logger.logDir != expectedLogDir {
 		t.Errorf("expected logDir=%s, got %s", expectedLogDir, logger.logDir)
 	}


### PR DESCRIPTION
Closes #398

Bug: Issue number appears twice in artifact log path.

## Current Behavior
Log files are created at:
```
.oda/artifacts/396/396/logs/20260325_192045_technical-planning.log
```

The issue number `396` appears twice in the path.

## Expected Behavior
Log files should be at:
```
.oda/artifacts/396/logs/20260325_192045_technical-planning.log
```

## Root Cause
In `internal/mvp/worker.go`:
- `createArtifactDir(396)` returns `.oda/artifacts/396`
- This is passed to `NewStepLogger(artifactDir, 396, ...)`
- `NewStepLogger` does: `filepath.Join(artifactDir, "396", "logs")`
- Result: `.oda/artifacts/396/396/logs`

The issue number is added twice:
1. By `createArtifactDir` creating `.oda/artifacts/<issue>/`
2. By `NewStepLogger` adding `<issue>/` again

## Fix Options
Option A: Change `createArtifactDir` to return `.oda/artifacts/` without issue number
Option B: Change `NewStepLogger` to not add issue number (use artifactDir directly)

## Acceptance Criteria
- [ ] Log paths have issue number only once: `.oda/artifacts/<issue>/logs/`
- [ ] All existing step logs still work correctly
- [ ] No regression in artifact directory creation
- [ ] Tests updated if needed