### PR TITLE
Add 40/60 height split to board center column

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5952,14 +5952,17 @@ func TestBoardTemplate_CSSLayout(t *testing.T) {
 
 	output := buf.String()
 
-	// Verify board-center-columns has flex:1 1 auto (not flex:0 0 auto)
+	// Verify board-center uses grid with 40/60 split
+	if !strings.Contains(output, "display:grid;grid-template-rows:40% 60%") {
+		t.Error("board-center should use display:grid with grid-template-rows:40% 60%")
+	}
+
+	// Verify board-center-columns does NOT have flex properties (grid parent handles sizing)
 	if strings.Contains(output, ".board-center-columns{") {
-		// Extract the CSS rule for board-center-columns
-		if !strings.Contains(output, "flex:1 1 auto") {
-			t.Error("board-center-columns should have flex:1 1 auto to fill available space")
+		if strings.Contains(output, "flex:1 1 auto") {
+			t.Error("board-center-columns should NOT have flex:1 1 auto (grid parent handles sizing)")
 		}
-		// Verify it does NOT have flex:0 0 auto
-		if strings.Contains(output, ".board-center-columns{display:grid;grid-template-columns:repeat(6,1fr);gap:1rem;flex:0 0 auto") {
+		if strings.Contains(output, "flex:0 0 auto") {
 			t.Error("board-center-columns should NOT have flex:0 0 auto")
 		}
 	} else {
@@ -5979,31 +5982,17 @@ func TestBoardTemplate_CSSLayout(t *testing.T) {
 		t.Error("board-center-columns should use repeat(6,1fr) for 6 pipeline columns")
 	}
 
-	// Verify processing-panel has flex:0 0 auto (not flex:1)
+	// Verify processing-panel does NOT have flex:0 0 auto (grid parent handles sizing)
 	if strings.Contains(output, ".processing-panel{") {
-		if !strings.Contains(output, "flex:0 0 auto") {
-			t.Error("processing-panel should have flex:0 0 auto to prevent growing")
-		}
-		// Verify it does NOT have flex:1
-		if strings.Contains(output, ".processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;display:flex;align-items:center;flex:1") {
-			t.Error("processing-panel should NOT have flex:1")
+		if strings.Contains(output, "flex:0 0 auto") {
+			t.Error("processing-panel should NOT have flex:0 0 auto (grid parent handles sizing)")
 		}
 	} else {
 		t.Error("processing-panel CSS rule not found")
 	}
 
-	// Verify processing-panel has max-height:250px
-	if !strings.Contains(output, "max-height:250px") {
-		t.Error("processing-panel should have max-height:250px to cap its height")
-	}
-
-	// Verify processing-panel has min-height:150px (not 200px)
-	if strings.Contains(output, "min-height:200px") {
-		t.Error("processing-panel should have min-height:150px not 200px")
-	}
-
-	// Verify mobile media query has correct constraints
-	if !strings.Contains(output, "min-height:120px;max-height:200px") {
-		t.Error("mobile media query should set processing-panel min-height:120px and max-height:200px")
+	// Verify processing-panel does NOT have fixed min/max height (grid handles sizing)
+	if strings.Contains(output, ".processing-panel{") && strings.Contains(output, "max-height:250px") {
+		t.Error("processing-panel should NOT have max-height:250px (grid row handles sizing)")
 	}
 }

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -3,7 +3,7 @@
 <style>
 .board-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem;flex-wrap:wrap;gap:.5rem;flex-shrink:0}
 .board-actions{display:flex;gap:.5rem;flex-wrap:wrap;align-items:center}
-@media (max-width:768px){.board-header{flex-direction:column;align-items:flex-start}.board-actions{width:100%;justify-content:flex-start}.processing-title{font-size:1rem}.processing-panel{min-height:120px;max-height:200px}}
+@media (max-width:768px){.board-header{flex-direction:column;align-items:flex-start}.board-actions{width:100%;justify-content:flex-start}.processing-title{font-size:1rem}}
 .board{display:grid;grid-template-columns:15% 1fr 15%;gap:1rem;flex:1;min-height:0}
 .board-left{display:flex;flex-direction:column;gap:0.5rem;min-height:0}
 .board-left .column{flex:1 1 50%;min-height:0;overflow-y:auto;scroll-behavior:smooth}
@@ -12,8 +12,8 @@
 .stacked-column{display:flex;flex-direction:column;gap:0.5rem;min-height:0;height:calc(100vh - 200px)}
 .stacked-column .column{flex:1 1 50%;min-height:0;overflow-y:auto;scroll-behavior:smooth}
 .stacked-column .column-title{position:sticky;top:0;background:var(--surface);z-index:1}
-.board-center{display:flex;flex-direction:column;gap:1rem;min-height:0}
-.board-center-columns{display:grid;grid-template-columns:repeat(6,1fr);gap:1rem;flex:1 1 auto;min-height:0;overflow-y:auto}
+.board-center{display:grid;grid-template-rows:40% 60%;gap:1rem;min-height:0}
+.board-center-columns{display:grid;grid-template-columns:repeat(6,1fr);gap:1rem;min-height:0;overflow-y:auto}
 .board-center .column{min-height:0;overflow-y:auto;scroll-behavior:smooth;height:100%}
 .column{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:.75rem}
 .column-title{font-size:.8rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin-bottom:.75rem;display:flex;justify-content:space-between;align-items:center}
@@ -50,7 +50,7 @@
 .card .card-pr a:hover{text-decoration:underline}
 .badge-merged{background:#6f42c1;color:white;font-size:.65rem;padding:.1rem .4rem;border-radius:4px;display:inline-flex;align-items:center;gap:.25rem}
 .badge-closed{background:#6c757d;color:white;font-size:.65rem;padding:.1rem .4rem;border-radius:4px;display:inline-flex;align-items:center;gap:.25rem}
-.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;display:flex;align-items:center;flex:0 0 auto;min-height:150px;max-height:250px;z-index:10;overflow-y:auto}
+.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;display:flex;align-items:center;min-height:0;z-index:10;overflow-y:auto}
 .processing-panel-idle{background:rgba(108,117,125,0.08);border-color:rgba(108,117,125,0.2)}
 .processing-panel-idle .processing-indicator{background:#6c757d;animation:none}
 .processing-idle-text{color:var(--muted);font-size:.85rem}


### PR DESCRIPTION
Closes #404

Add a 40/60 height split to the center column of the sprint board to better utilize vertical space.

## Current State
The center column (`.board-center`) currently uses flex layout without defined height proportions. The 6 pipeline columns (Plan, Code, AI Review, Check Pipeline, Approve, Merge) and the processing panel at the bottom share space without clear proportions.

## Desired Change
Split the center column vertically:
- **40%** - Pipeline columns row (`.board-center-columns` with 6 columns)
- **60%** - Processing panel (`#processing-panel`)

This will give more visual prominence to the currently processing ticket while still keeping the pipeline columns visible.

## Implementation Notes
- Modify `.board-center` CSS in `internal/dashboard/templates/board.html`
- Options:
  1. Change to `display: grid` with `grid-template-rows: 40% 60%`
  2. Or use flex with `flex: 40` and `flex: 60` on child elements
- The processing panel currently has `flex: 0 0 auto` which needs adjustment

## Acceptance Criteria
- [ ] Center column displays with 40/60 vertical split
- [ ] Pipeline columns (top) take ~40% of available height
- [ ] Processing panel (bottom) takes ~60% of available height
- [ ] Layout works correctly on different screen sizes
- [ ] No visual regressions in other board columns