### PR TITLE
[Feature] Add LLM Provider and Model Info to Artifact Logs

### DIFF
--- a/.oda/config.yaml
+++ b/.oda/config.yaml
@@ -13,6 +13,8 @@ tools:
     e2e_cmd: ""
 pipeline:
     max_retries: 5
+    check_interval: 10
+    check_timeout: 1800
 sprint:
     tasks_per_sprint: 10
     auto_start: false
@@ -20,7 +22,7 @@ llm:
     setup:
         model: nexos-ai/Claude Haiku 4.5
     planning:
-        model: nexos-ai/Claude Opus 4.6
+        model: '"Kimi K2.5"'
     orchestration:
         model: nexos-ai/Kimi K2.5
     code:

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -484,7 +484,7 @@ func (s *Server) recordStep(issueNum int, stepName, response string) {
 	if s.store == nil {
 		return
 	}
-	id, err := s.store.InsertStep(issueNum, stepName, stepName, "")
+	id, err := s.store.InsertStep(issueNum, stepName, stepName, "", "")
 	if err != nil {
 		log.Printf("[Dashboard] failed to insert %s step for #%d: %v", stepName, issueNum, err)
 		return

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -234,6 +234,7 @@ type TaskStep struct {
 	ErrorMsg          string
 	SessionID         string
 	PlanAttachmentURL string
+	LLMModel          string
 	StartedAt         *time.Time
 	FinishedAt        *time.Time
 }
@@ -252,13 +253,13 @@ type IssueCache struct {
 	MergedAt    *time.Time
 }
 
-func (s *Store) InsertStep(issueNumber int, stepName, prompt, sessionID string) (int64, error) {
+func (s *Store) InsertStep(issueNumber int, stepName, prompt, sessionID, llmModel string) (int64, error) {
 	result, err := s.submitWriteWithResult(func() (any, error) {
 		now := time.Now()
 		res, err := s.db.Exec(
-			`INSERT INTO task_steps (issue_number, step_name, status, prompt, session_id, started_at)
-			 VALUES (?, ?, 'running', ?, ?, ?)`,
-			issueNumber, stepName, prompt, sessionID, now,
+			`INSERT INTO task_steps (issue_number, step_name, status, prompt, session_id, llm_model, started_at)
+			 VALUES (?, ?, 'running', ?, ?, ?, ?)`,
+			issueNumber, stepName, prompt, sessionID, llmModel, now,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("inserting task step: %w", err)
@@ -301,7 +302,7 @@ func (s *Store) FailStep(id int64, errMsg string) error {
 
 func (s *Store) GetSteps(issueNumber int) (steps []TaskStep, err error) {
 	rows, err := s.db.Query(
-		`SELECT id, issue_number, step_name, status, prompt, response, error_msg, session_id, plan_attachment_url, started_at, finished_at
+		`SELECT id, issue_number, step_name, status, prompt, response, error_msg, session_id, plan_attachment_url, llm_model, started_at, finished_at
 		 FROM task_steps WHERE issue_number = ? ORDER BY id`, issueNumber,
 	)
 	if err != nil {
@@ -315,7 +316,7 @@ func (s *Store) GetSteps(issueNumber int) (steps []TaskStep, err error) {
 
 	for rows.Next() {
 		var st TaskStep
-		if err := rows.Scan(&st.ID, &st.IssueNumber, &st.StepName, &st.Status, &st.Prompt, &st.Response, &st.ErrorMsg, &st.SessionID, &st.PlanAttachmentURL, &st.StartedAt, &st.FinishedAt); err != nil {
+		if err := rows.Scan(&st.ID, &st.IssueNumber, &st.StepName, &st.Status, &st.Prompt, &st.Response, &st.ErrorMsg, &st.SessionID, &st.PlanAttachmentURL, &st.LLMModel, &st.StartedAt, &st.FinishedAt); err != nil {
 			return nil, fmt.Errorf("scanning task step: %w", err)
 		}
 		steps = append(steps, st)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -166,7 +166,7 @@ func TestGetLastCompletedStep_Migration(t *testing.T) {
 	store := openTestStore(t)
 
 	// Insert old "analyze" step
-	stepID, err := store.InsertStep(100, "analyze", "test prompt", "session-1")
+	stepID, err := store.InsertStep(100, "analyze", "test prompt", "session-1", "")
 	if err != nil {
 		t.Fatalf("inserting analyze step: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestGetLastCompletedStep_Migration(t *testing.T) {
 	}
 
 	// Insert old "plan" step
-	stepID2, err := store.InsertStep(101, "plan", "test prompt 2", "session-2")
+	stepID2, err := store.InsertStep(101, "plan", "test prompt 2", "session-2", "")
 	if err != nil {
 		t.Fatalf("inserting plan step: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestGetLastCompletedStep_Migration(t *testing.T) {
 	}
 
 	// Insert new "technical-planning" step
-	stepID3, err := store.InsertStep(102, "technical-planning", "test prompt 3", "session-3")
+	stepID3, err := store.InsertStep(102, "technical-planning", "test prompt 3", "session-3", "")
 	if err != nil {
 		t.Fatalf("inserting technical-planning step: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestGetStepResponse_Migration(t *testing.T) {
 	store := openTestStore(t)
 
 	// Insert old "plan" step
-	stepID, err := store.InsertStep(200, "plan", "test prompt", "session-1")
+	stepID, err := store.InsertStep(200, "plan", "test prompt", "session-1", "")
 	if err != nil {
 		t.Fatalf("inserting plan step: %v", err)
 	}
@@ -242,7 +242,7 @@ func TestGetStepResponse_Migration(t *testing.T) {
 	}
 
 	// Insert new "technical-planning" step
-	stepID2, err := store.InsertStep(201, "technical-planning", "test prompt 2", "session-2")
+	stepID2, err := store.InsertStep(201, "technical-planning", "test prompt 2", "session-2", "")
 	if err != nil {
 		t.Fatalf("inserting technical-planning step: %v", err)
 	}
@@ -826,7 +826,7 @@ func TestConcurrentMixedWrites_NoBusyErrors(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			// InsertStep and FinishStep
-			stepID, err := store.InsertStep(n, "test-step", "test prompt", "session-1")
+			stepID, err := store.InsertStep(n, "test-step", "test prompt", "session-1", "")
 			if err != nil {
 				errors <- err
 				return

--- a/internal/db/migrations.go
+++ b/internal/db/migrations.go
@@ -61,6 +61,7 @@ var migrations = []string{
 	)`,
 	`CREATE INDEX IF NOT EXISTS idx_stage_change_ledger_issue ON stage_change_ledger(issue_number)`,
 	`CREATE INDEX IF NOT EXISTS idx_stage_change_ledger_changed_at ON stage_change_ledger(changed_at)`,
+	`ALTER TABLE task_steps ADD COLUMN llm_model TEXT NOT NULL DEFAULT ''`,
 }
 
 // columnExists checks if a column exists in a table
@@ -93,6 +94,12 @@ func migrate(db *sql.DB) error {
 		// Special handling for the merged_at migration
 		if strings.Contains(m, "merged_at") {
 			if columnExists(db, "issue_cache", "merged_at") {
+				continue // Skip if column already exists
+			}
+		}
+		// Special handling for the llm_model migration
+		if strings.Contains(m, "llm_model") {
+			if columnExists(db, "task_steps", "llm_model") {
 				continue // Skip if column already exists
 			}
 		}

--- a/internal/mvp/orchestrator.go
+++ b/internal/mvp/orchestrator.go
@@ -402,7 +402,7 @@ func (o *Orchestrator) recordStep(issueNumber int, stepName, response string) {
 	if o.store == nil {
 		return
 	}
-	id, err := o.store.InsertStep(issueNumber, stepName, stepName, "")
+	id, err := o.store.InsertStep(issueNumber, stepName, stepName, "", "")
 	if err != nil {
 		log.Printf("[Orchestrator] failed to insert %s step for #%d: %v", stepName, issueNumber, err)
 		return

--- a/internal/mvp/worker.go
+++ b/internal/mvp/worker.go
@@ -59,6 +59,25 @@ func NewWorker(id int, cfg *config.Config, oc *opencode.Client, gh *github.Clien
 
 // Processes the event synchronously so that GitHub labels, cache, ledger,
 // and WebSocket are updated immediately — not deferred until after Process().
+func (w *Worker) resolveModel(category config.TaskCategory, complexity config.ComplexityLevel, hints map[string]any) string {
+	cfg := w.cfg.Load()
+	var model string
+	switch category {
+	case config.CategoryPlanning:
+		model = cfg.LLM.Planning.Model
+	case config.CategoryCode:
+		model = cfg.LLM.Code.Model
+	default:
+		model = cfg.LLM.Code.Model
+	}
+	if w.router != nil {
+		model = w.router.SelectModel(category, complexity, hints)
+	}
+	return model
+}
+
+// Processes the event synchronously so that GitHub labels, cache, ledger,
+// and WebSocket are updated immediately — not deferred until after Process().
 func (w *Worker) reportStageComplete(stage string, status EventStatus, output string) {
 	if w.orchestrator == nil || w.orchestrator.currentTask == nil {
 		return
@@ -146,7 +165,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 	if resumeFrom <= 0 {
 		log.Printf("[Worker %d] [1/7] Technical planning for #%d...", w.id, task.Issue.Number)
 		stepStart := time.Now()
-		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "technical-planning")
+		llmModel := w.resolveModel(config.CategoryPlanning, config.ComplexityMedium, nil)
+		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "technical-planning", llmModel)
 		if slErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create step logger: %v", w.id, slErr)
 		}
@@ -154,7 +174,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			_ = stepLogger.Start()
 			defer stepLogger.Close()
 		}
-		analysis, implPlan, err = w.technicalPlanning(ctx, task, stepLogger)
+		analysis, implPlan, err = w.technicalPlanning(ctx, task, llmModel, stepLogger)
 		if err != nil {
 			task.Status = StatusFailed
 			task.Result = &TaskResult{Error: fmt.Errorf("technical planning: %w", err)}
@@ -188,7 +208,9 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 		task.Status = StatusCoding
 		log.Printf("[Worker %d] [2/7] Implementing #%d (includes tests)...", w.id, task.Issue.Number)
 		stepStart := time.Now()
-		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "implement")
+		complexity := llm.DetectComplexity(implPlan) //nolint:staticcheck // deprecated but still used
+		llmModel := w.resolveModel(config.CategoryCode, complexity, nil)
+		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "implement", llmModel)
 		if slErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create step logger: %v", w.id, slErr)
 		}
@@ -196,7 +218,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			_ = stepLogger.Start()
 			defer stepLogger.Close()
 		}
-		if err := w.implement(ctx, task, implPlan, stepLogger); err != nil {
+		if err := w.implement(ctx, task, implPlan, llmModel, stepLogger); err != nil {
 			task.Status = StatusFailed
 			task.Result = &TaskResult{Error: fmt.Errorf("implementing: %w", err)}
 			log.Printf("[Worker %d] ✗ FAILED implementing: %v", w.id, err)
@@ -218,7 +240,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 		task.Status = StatusReviewing
 		log.Printf("[Worker %d] [3/7] Code review #%d...", w.id, task.Issue.Number)
 		stepStart := time.Now()
-		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "code-review")
+		llmModel := w.resolveModel(config.CategoryCode, config.ComplexityHigh, map[string]any{"stage": "code-review"})
+		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "code-review", llmModel)
 		if slErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create step logger: %v", w.id, slErr)
 		}
@@ -226,7 +249,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			_ = stepLogger.Start()
 			defer stepLogger.Close()
 		}
-		approved, review, crErr := w.codeReview(ctx, task, "", stepLogger)
+		approved, review, crErr := w.codeReview(ctx, task, "", llmModel, stepLogger)
 		if crErr != nil {
 			task.Status = StatusFailed
 			task.Result = &TaskResult{Error: fmt.Errorf("code review: %w", crErr)}
@@ -243,7 +266,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			task.Status = StatusCoding
 			w.reportStageComplete("coding", EventInProgress, "fixing from AI review")
 			stepStart = time.Now()
-			fixLogger, fixErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "fix-from-review")
+			fixLLMModel := w.resolveModel(config.CategoryCode, config.ComplexityMedium, nil)
+			fixLogger, fixErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "fix-from-review", fixLLMModel)
 			if fixErr != nil {
 				log.Printf("[Worker %d] Warning: failed to create fix logger: %v", w.id, fixErr)
 			}
@@ -251,7 +275,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 				_ = fixLogger.Start()
 				defer fixLogger.Close()
 			}
-			if fixErr := w.fixFromReview(ctx, task, review, fixLogger); fixErr != nil {
+			if fixErr := w.fixFromReview(ctx, task, review, fixLLMModel, fixLogger); fixErr != nil {
 				task.Status = StatusFailed
 				task.Result = &TaskResult{Error: fmt.Errorf("fixing from review: %w", fixErr)}
 				log.Printf("[Worker %d] ✗ FAILED fixing from review: %v", w.id, fixErr)
@@ -272,7 +296,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			}
 			log.Printf("[Worker %d] Re-running code review after fixes...", w.id)
 			stepStart = time.Now()
-			approved, _, crErr = w.codeReview(ctx, task, "", nil)
+			crLLMModel := w.resolveModel(config.CategoryCode, config.ComplexityHigh, map[string]any{"stage": "code-review"})
+			approved, _, crErr = w.codeReview(ctx, task, "", crLLMModel, nil)
 			if crErr != nil {
 				task.Status = StatusFailed
 				task.Result = &TaskResult{Error: fmt.Errorf("code review after fixes: %w", crErr)}
@@ -299,7 +324,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 		task.Status = StatusCreatingPR
 		log.Printf("[Worker %d] [4/7] Creating PR for #%d...", w.id, task.Issue.Number)
 		stepStart := time.Now()
-		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "create-pr")
+		stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "create-pr", "")
 		if slErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create step logger: %v", w.id, slErr)
 		}
@@ -341,7 +366,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			task.Status = StatusCheckingPipeline
 			log.Printf("[Worker %d] [5/7] Checking CI pipeline for #%d (attempt %d/%d)...", w.id, task.Issue.Number, pipelineAttempt+1, maxPipelineRetries)
 			stepStart := time.Now()
-			stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "check-pipeline")
+			stepLogger, slErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "check-pipeline", "")
 			if slErr != nil {
 				log.Printf("[Worker %d] Warning: failed to create step logger: %v", w.id, slErr)
 			}
@@ -369,7 +394,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 
 				task.Status = StatusCoding
 				w.reportStageComplete("coding", EventInProgress, fmt.Sprintf("fixing pipeline failure (attempt %d)", pipelineAttempt))
-				fixLogger, fixErr := worker.NewStepLogger(artifactDir, task.Issue.Number, fmt.Sprintf("fix-pipeline-attempt-%d", pipelineAttempt))
+				fixLLMModel := w.resolveModel(config.CategoryCode, config.ComplexityMedium, nil)
+				fixLogger, fixErr := worker.NewStepLogger(artifactDir, task.Issue.Number, fmt.Sprintf("fix-pipeline-attempt-%d", pipelineAttempt), fixLLMModel)
 				if fixErr != nil {
 					log.Printf("[Worker %d] Warning: failed to create fix logger: %v", w.id, fixErr)
 				}
@@ -377,7 +403,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 					_ = fixLogger.Start()
 					defer fixLogger.Close()
 				}
-				if fixErr := w.implement(ctx, task, implPlan, fixLogger); fixErr != nil {
+				if fixErr := w.implement(ctx, task, implPlan, fixLLMModel, fixLogger); fixErr != nil {
 					task.Status = StatusFailed
 					task.Result = &TaskResult{Error: fmt.Errorf("fixing from pipeline failure: %w", fixErr)}
 					log.Printf("[Worker %d] ✗ FAILED fixing from pipeline failure: %v", w.id, fixErr)
@@ -420,7 +446,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 	for {
 		task.Status = StatusAwaitingApproval
 		log.Printf("[Worker %d] [6/7] Awaiting user approval for #%d (PR: %s)", w.id, task.Issue.Number, prURL)
-		approvalLogger, alErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "awaiting-approval")
+		approvalLogger, alErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "awaiting-approval", "")
 		if alErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create approval logger: %v", w.id, alErr)
 		}
@@ -465,7 +491,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			}
 			w.reportStageComplete("awaiting-approval", EventSuccess, "user approved")
 
-			mergeLogger, mlErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "merge")
+			mergeLogger, mlErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "merge", "")
 			if mlErr != nil {
 				log.Printf("[Worker %d] Warning: failed to create merge logger: %v", w.id, mlErr)
 			}
@@ -532,7 +558,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 
 		w.reportStageComplete("awaiting-approval", EventFailed, "user declined: "+decision.Reason)
 
-		declineLogger, dlErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "fix-from-decline")
+		declineLLMModel := w.resolveModel(config.CategoryCode, config.ComplexityMedium, nil)
+		declineLogger, dlErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "fix-from-decline", declineLLMModel)
 		if dlErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create decline fix logger: %v", w.id, dlErr)
 		}
@@ -540,7 +567,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			_ = declineLogger.Start()
 			defer declineLogger.Close()
 		}
-		if fixErr := w.fixFromReview(ctx, task, decision.Reason, declineLogger); fixErr != nil {
+		if fixErr := w.fixFromReview(ctx, task, decision.Reason, declineLLMModel, declineLogger); fixErr != nil {
 			task.Status = StatusFailed
 			task.Result = &TaskResult{Error: fmt.Errorf("fixing from decline: %w", fixErr)}
 			log.Printf("[Worker %d] ✗ FAILED fixing from decline: %v", w.id, fixErr)
@@ -562,7 +589,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 		task.Status = StatusReviewing
 		w.reportStageComplete("coding", EventSuccess, "fixes applied after decline")
 
-		reReviewLogger, rrErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "code-review-after-decline")
+		reReviewLLMModel := w.resolveModel(config.CategoryCode, config.ComplexityHigh, map[string]any{"stage": "code-review"})
+		reReviewLogger, rrErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "code-review-after-decline", reReviewLLMModel)
 		if rrErr != nil {
 			log.Printf("[Worker %d] Warning: failed to create re-review logger: %v", w.id, rrErr)
 		}
@@ -570,7 +598,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 			_ = reReviewLogger.Start()
 			defer reReviewLogger.Close()
 		}
-		approved, review, crErr := w.codeReview(ctx, task, prURL, reReviewLogger)
+		approved, review, crErr := w.codeReview(ctx, task, prURL, reReviewLLMModel, reReviewLogger)
 		if crErr != nil {
 			task.Status = StatusFailed
 			task.Result = &TaskResult{Error: fmt.Errorf("code review after decline: %w", crErr)}
@@ -583,7 +611,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 		if !approved {
 			task.Status = StatusCoding
 			w.reportStageComplete("coding", EventInProgress, "fixing from re-review after decline")
-			reFixLogger, rfErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "fix-from-re-review")
+			reFixLLMModel := w.resolveModel(config.CategoryCode, config.ComplexityMedium, nil)
+			reFixLogger, rfErr := worker.NewStepLogger(artifactDir, task.Issue.Number, "fix-from-re-review", reFixLLMModel)
 			if rfErr != nil {
 				log.Printf("[Worker %d] Warning: failed to create re-fix logger: %v", w.id, rfErr)
 			}
@@ -591,7 +620,7 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 				_ = reFixLogger.Start()
 				defer reFixLogger.Close()
 			}
-			if fixErr := w.fixFromReview(ctx, task, review, reFixLogger); fixErr != nil {
+			if fixErr := w.fixFromReview(ctx, task, review, reFixLLMModel, reFixLogger); fixErr != nil {
 				task.Status = StatusFailed
 				task.Result = &TaskResult{Error: fmt.Errorf("fixing from re-review: %w", fixErr)}
 				if reFixLogger != nil {
@@ -617,13 +646,8 @@ func (w *Worker) Process(ctx context.Context, task *Task) error {
 	}
 }
 
-func (w *Worker) technicalPlanning(ctx context.Context, task *Task, logger *worker.StepLogger) (analysis, implPlan string, err error) {
+func (w *Worker) technicalPlanning(ctx context.Context, task *Task, llmModel string, logger *worker.StepLogger) (analysis, implPlan string, err error) {
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPTechnicalPlanning), task.Issue.Number, task.Issue.Title, task.Issue.Body, task.Issue.Number)
-
-	llmModel := w.cfg.Load().LLM.Planning.Model
-	if w.router != nil {
-		llmModel = w.router.SelectModel(config.CategoryPlanning, config.ComplexityMedium, nil)
-	}
 
 	response, err := w.llmStep(ctx, task, "technical-planning", prompt, llmModel, logger)
 	if err != nil {
@@ -696,7 +720,7 @@ func parseTechnicalPlanningResponse(response string) (analysis, plan string) {
 	return analysis, plan
 }
 
-func (w *Worker) implement(ctx context.Context, task *Task, planStr string, logger *worker.StepLogger) error {
+func (w *Worker) implement(ctx context.Context, task *Task, planStr, llmModel string, logger *worker.StepLogger) error {
 	w.oc.SetDirectory(task.Worktree)
 
 	comments, err := w.gh.ListComments(task.Issue.Number)
@@ -720,12 +744,6 @@ func (w *Worker) implement(ctx context.Context, task *Task, planStr string, logg
 	}
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPImplementation), task.Issue.Number, task.Issue.Title, planStr, task.Worktree, testCmd, task.Issue.Number, task.Issue.Number, task.Issue.Number, task.Issue.Number, task.Issue.Number)
 
-	llmModel := w.cfg.Load().LLM.Code.Model
-	if w.router != nil {
-		complexity := llm.DetectComplexity(planStr) //nolint:staticcheck // deprecated but still used
-		llmModel = w.router.SelectModel(config.CategoryCode, complexity, nil)
-	}
-
 	_, err = w.llmStep(ctx, task, "implement", prompt, llmModel, logger)
 	if err != nil {
 		return err
@@ -745,7 +763,7 @@ func (w *Worker) ensureCommit(task *Task) {
 	_ = out
 }
 
-func (w *Worker) fixFromReview(ctx context.Context, task *Task, review string, logger *worker.StepLogger) error {
+func (w *Worker) fixFromReview(ctx context.Context, task *Task, review, llmModel string, logger *worker.StepLogger) error {
 	w.oc.SetDirectory(task.Worktree)
 
 	testCmd := w.cfg.Load().Tools.TestCmd
@@ -753,11 +771,6 @@ func (w *Worker) fixFromReview(ctx context.Context, task *Task, review string, l
 		testCmd = "go test ./..."
 	}
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPFixFromReview), task.Issue.Number, task.Issue.Title, task.Worktree, testCmd, review)
-
-	llmModel := w.cfg.Load().LLM.Code.Model
-	if w.router != nil {
-		llmModel = w.router.SelectModel(config.CategoryCode, config.ComplexityMedium, nil)
-	}
 
 	_, err := w.llmStep(ctx, task, "fix-from-review", prompt, llmModel, logger)
 	if err != nil {
@@ -785,7 +798,7 @@ type crResult struct {
 	Verdict     string   `json:"verdict"`
 }
 
-func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string, logger *worker.StepLogger) (approved bool, review string, err error) {
+func (w *Worker) codeReview(ctx context.Context, task *Task, prURL, llmModel string, logger *worker.StepLogger) (approved bool, review string, err error) {
 	prompt := fmt.Sprintf(prompts.MustGet(prompts.MVPCodeReview), task.Issue.Number, task.Issue.Title, prURL, w.gh.Repo, task.Issue.Number)
 
 	sessionTitle := fmt.Sprintf("code-review-%d", task.Issue.Number)
@@ -803,7 +816,7 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string, logge
 
 	var stepID int64
 	if w.store != nil {
-		id, sErr := w.store.InsertStep(task.Issue.Number, "code-review", prompt, session.ID)
+		id, sErr := w.store.InsertStep(task.Issue.Number, "code-review", prompt, session.ID, llmModel)
 		if sErr != nil {
 			log.Printf("[Worker %d] failed to insert step: %v", w.id, sErr)
 		} else {
@@ -812,12 +825,6 @@ func (w *Worker) codeReview(ctx context.Context, task *Task, prURL string, logge
 	}
 
 	task.AddChatMessage("user", prompt)
-
-	llmModel := w.cfg.Load().LLM.Code.Model
-	if w.router != nil {
-		hints := map[string]any{"stage": "code-review"}
-		llmModel = w.router.SelectModel(config.CategoryCode, config.ComplexityHigh, hints)
-	}
 
 	model := opencode.ParseModelRef(llmModel)
 	var result crResult
@@ -854,7 +861,7 @@ func (w *Worker) createPR(_ context.Context, task *Task, logger *worker.StepLogg
 
 	var stepID int64
 	if w.store != nil {
-		id, err := w.store.InsertStep(task.Issue.Number, "create-pr", fmt.Sprintf("push %s + create PR", task.Branch), "")
+		id, err := w.store.InsertStep(task.Issue.Number, "create-pr", fmt.Sprintf("push %s + create PR", task.Branch), "", "")
 		if err != nil {
 			log.Printf("[Worker %d] failed to insert create-pr step: %v", w.id, err)
 		} else {
@@ -1014,7 +1021,7 @@ func (w *Worker) llmStep(_ context.Context, task *Task, stepName, prompt, llm st
 
 	var stepID int64
 	if w.store != nil {
-		id, sErr := w.store.InsertStep(task.Issue.Number, stepName, prompt, session.ID)
+		id, sErr := w.store.InsertStep(task.Issue.Number, stepName, prompt, session.ID, llm)
 		if sErr != nil {
 			log.Printf("[Worker %d] failed to insert step: %v", w.id, sErr)
 		} else {

--- a/internal/worker/step_logger.go
+++ b/internal/worker/step_logger.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,20 +15,34 @@ type StepLogger struct {
 	file      *os.File
 	issueNum  int
 	stepName  string
+	provider  string
+	model     string
 	startTime time.Time
 	logDir    string
 	mu        sync.Mutex
 }
 
-func NewStepLogger(artifactDir string, issueNum int, stepName string) (*StepLogger, error) {
+func NewStepLogger(artifactDir string, issueNum int, stepName string, llmModel string) (*StepLogger, error) {
 	logDir := filepath.Join(artifactDir, "logs")
 	if err := os.MkdirAll(logDir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating log directory %s: %w", logDir, err)
 	}
 
+	var provider, model string
+	if llmModel != "" {
+		if p, m, ok := strings.Cut(llmModel, "/"); ok {
+			provider = p
+			model = m
+		} else {
+			model = llmModel
+		}
+	}
+
 	return &StepLogger{
 		issueNum: issueNum,
 		stepName: stepName,
+		provider: provider,
+		model:    model,
 		logDir:   logDir,
 	}, nil
 }
@@ -57,6 +72,12 @@ func (l *StepLogger) Start() error {
 	l.file = file
 	l.logf("STEP START: %s", l.stepName)
 	l.logf("Issue: #%d", l.issueNum)
+	if l.provider != "" {
+		l.logf("Provider: %s", l.provider)
+	}
+	if l.model != "" {
+		l.logf("Model: %s", l.model)
+	}
 	l.logf("Start Time: %s", l.startTime.Format("2006-01-02 15:04:05"))
 	l.logf("---")
 

--- a/internal/worker/step_logger_test.go
+++ b/internal/worker/step_logger_test.go
@@ -16,7 +16,7 @@ func TestStepLogger_CreatesLogFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 123, "test-step")
+	logger, err := NewStepLogger(artifactDir, 123, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestStepLogger_StartAndEnd(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 456, "technical-planning")
+	logger, err := NewStepLogger(artifactDir, 456, "technical-planning", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestStepLogger_EndFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 789, "implement")
+	logger, err := NewStepLogger(artifactDir, 789, "implement", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestStepLogger_LogLLMResponse_TextOnly(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 100, "test-step")
+	logger, err := NewStepLogger(artifactDir, 100, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestStepLogger_LogLLMResponse_WithToolCall(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 101, "test-step")
+	logger, err := NewStepLogger(artifactDir, 101, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestStepLogger_LogLLMResponse_WithToolResult(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 102, "test-step")
+	logger, err := NewStepLogger(artifactDir, 102, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -255,7 +255,7 @@ func TestStepLogger_LogLLMResponse_WithToolError(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 103, "test-step")
+	logger, err := NewStepLogger(artifactDir, 103, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -300,7 +300,7 @@ func TestStepLogger_NilSafety(t *testing.T) {
 	logger.End(true, "")
 	logger.Close()
 
-	logger, _ = NewStepLogger(t.TempDir(), 1, "test")
+	logger, _ = NewStepLogger(t.TempDir(), 1, "test", "")
 	logger.LogLLMResponse(nil)
 	logger.Logf("test")
 	logger.End(true, "")
@@ -311,7 +311,7 @@ func TestStepLogger_Logf(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 200, "test-step")
+	logger, err := NewStepLogger(artifactDir, 200, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -341,7 +341,7 @@ func TestStepLogger_ConcurrentWrites(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 300, "test-step")
+	logger, err := NewStepLogger(artifactDir, 300, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -399,7 +399,7 @@ func TestStepLogger_Write(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 400, "test-step")
+	logger, err := NewStepLogger(artifactDir, 400, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}
@@ -446,7 +446,7 @@ func TestStepLogger_Write_NilSafety(t *testing.T) {
 		t.Errorf("Write on nil logger should return len(p)=%d, got %d", 4, n)
 	}
 
-	logger, _ = NewStepLogger(t.TempDir(), 1, "test")
+	logger, _ = NewStepLogger(t.TempDir(), 1, "test", "")
 
 	n, err = logger.Write([]byte("test"))
 	if err != nil {
@@ -461,11 +461,95 @@ func TestStepLogger_ImplementsIOWriter(_ *testing.T) {
 	var _ io.Writer = (*StepLogger)(nil)
 }
 
+func TestStepLogger_ProviderModelInLog(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewStepLogger(dir, 42, "implement", "anthropic/claude-sonnet-4")
+	if err != nil {
+		t.Fatalf("NewStepLogger: %v", err)
+	}
+	defer logger.Close()
+
+	if err := logger.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = logger.End(true, "")
+
+	files, _ := filepath.Glob(filepath.Join(dir, "logs", "*.log"))
+	if len(files) != 1 {
+		t.Fatalf("expected 1 log file, got %d", len(files))
+	}
+	content, _ := os.ReadFile(files[0])
+	logStr := string(content)
+
+	if !strings.Contains(logStr, "Provider: anthropic") {
+		t.Errorf("log should contain 'Provider: anthropic', got:\n%s", logStr)
+	}
+	if !strings.Contains(logStr, "Model: claude-sonnet-4") {
+		t.Errorf("log should contain 'Model: claude-sonnet-4', got:\n%s", logStr)
+	}
+}
+
+func TestStepLogger_NoModelOmitsProviderModel(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewStepLogger(dir, 42, "create-pr", "")
+	if err != nil {
+		t.Fatalf("NewStepLogger: %v", err)
+	}
+	defer logger.Close()
+
+	if err := logger.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = logger.End(true, "")
+
+	files, _ := filepath.Glob(filepath.Join(dir, "logs", "*.log"))
+	if len(files) != 1 {
+		t.Fatalf("expected 1 log file, got %d", len(files))
+	}
+	content, _ := os.ReadFile(files[0])
+	logStr := string(content)
+
+	if strings.Contains(logStr, "Provider:") {
+		t.Errorf("log should NOT contain 'Provider:' for empty model, got:\n%s", logStr)
+	}
+	if strings.Contains(logStr, "Model:") {
+		t.Errorf("log should NOT contain 'Model:' for empty model, got:\n%s", logStr)
+	}
+}
+
+func TestStepLogger_ModelWithoutProvider(t *testing.T) {
+	dir := t.TempDir()
+	logger, err := NewStepLogger(dir, 42, "test-step", "gpt-4o")
+	if err != nil {
+		t.Fatalf("NewStepLogger: %v", err)
+	}
+	defer logger.Close()
+
+	if err := logger.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = logger.End(true, "")
+
+	files, _ := filepath.Glob(filepath.Join(dir, "logs", "*.log"))
+	if len(files) != 1 {
+		t.Fatalf("expected 1 log file, got %d", len(files))
+	}
+	content, _ := os.ReadFile(files[0])
+	logStr := string(content)
+
+	if strings.Contains(logStr, "Provider:") {
+		t.Errorf("log should NOT contain 'Provider:' for model without slash, got:\n%s", logStr)
+	}
+	if !strings.Contains(logStr, "Model: gpt-4o") {
+		t.Errorf("log should contain 'Model: gpt-4o', got:\n%s", logStr)
+	}
+}
+
 func TestStepLogger_ConcurrentWrite(t *testing.T) {
 	tmpDir := t.TempDir()
 	artifactDir := filepath.Join(tmpDir, ".oda", "artifacts")
 
-	logger, err := NewStepLogger(artifactDir, 401, "test-step")
+	logger, err := NewStepLogger(artifactDir, 401, "test-step", "")
 	if err != nil {
 		t.Fatalf("NewStepLogger failed: %v", err)
 	}


### PR DESCRIPTION
Closes #408

## Description

Pipeline artifact logs (stored in `.oda/artifacts/<issue>/logs/`) do not currently record which LLM provider and model were used for each step. The `llmModel` string is resolved in each pipeline step function but is never passed to `StepLogger` or written to log files. Adding this information will make it clear which model performed each step, aiding debugging and cost attribution.

## Tasks

1. Add `provider` and `model` fields to the `StepLogger` struct in `internal/worker/step_logger.go`.
2. Update the `NewStepLogger` constructor in `internal/worker/step_logger.go` to accept a model string parameter (in `"provider/model"` format) and populate the new fields.
3. Update `LogStart()` in `internal/worker/step_logger.go` to include `Provider:` and `Model:` lines in the step start header block.
4. Update all `NewStepLogger` call sites in `internal/mvp/worker.go` to pass the resolved `llmModel` string for each pipeline step (technical-planning, implement, code-review, fix-from-review, etc.).
5. For non-LLM steps (create-pr, check-pipeline, merge, awaiting-approval) pass an empty string or `"n/a"` as the model parameter so the log header omits or marks those lines accordingly.
6. Update `StepLogger` tests in `internal/worker/step_logger_test.go` to verify provider and model appear in log output.
7. Update the `TaskStep` struct in `internal/db/db.go` to include an `LLMModel` field and persist it via `InsertStep()`.
8. Add a migration in `internal/db/migrations.go` to add an `llm_model` column to the `task_steps` table.
9. Update `InsertStep()` and `store.InsertStep()` call sites in `internal/mvp/worker.go` to pass the model string.

## Files to Modify

- `internal/worker/step_logger.go` — Add provider/model fields, update constructor and `LogStart()`
- `internal/worker/step_logger_test.go` — Add tests for new provider/model log output
- `internal/mvp/worker.go` — Pass model string to `NewStepLogger` and `InsertStep()` at all call sites
- `internal/db/db.go` — Add `LLMModel` field to `TaskStep`, update `InsertStep()` query
- `internal/db/migrations.go` — Add migration for `llm_model` column on `task_steps`

## Acceptance Criteria

1. Every LLM-backed step log file in `.oda/artifacts/<issue>/logs/` contains `Provider:` and `Model:` lines in the step start header.
2. Non-LLM steps (e.g., create-pr, merge) either omit the provider/model lines or display `n/a`.
3. The `task_steps` SQLite table stores the model identifier for each step, queryable via `SELECT llm_model FROM task_steps`.
4. Existing log files and database rows without the new field are handled gracefully (no crashes on NULL or missing data).
5. All existing tests pass and new tests verify provider/model presence in log output.