### PR TITLE
[Bug] Fix worker control button labels from sprint to worker

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -2097,12 +2097,12 @@ func TestBoardActions_ContainsExpectedButtons(t *testing.T) {
 
 	body := rec.Body.String()
 
-	// Verify board-actions section contains expected sprint control buttons
-	// Note: Start Sprint and Pause Sprint are mutually exclusive (conditional on .Paused)
-	hasStartSprint := strings.Contains(body, "Start Sprint")
-	hasPauseSprint := strings.Contains(body, "Pause Sprint")
-	if !hasStartSprint && !hasPauseSprint {
-		t.Error("board-actions section missing both Start Sprint and Pause Sprint buttons - should have one")
+	// Verify board-actions section contains expected worker control buttons
+	// Note: Start Worker and Pause Worker are mutually exclusive (conditional on .Paused)
+	hasStartWorker := strings.Contains(body, "Start Worker")
+	hasPauseWorker := strings.Contains(body, "Pause Worker")
+	if !hasStartWorker && !hasPauseWorker {
+		t.Error("board-actions section missing both Start Worker and Pause Worker buttons - should have one")
 	}
 
 	// These buttons should always be present

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -81,11 +81,11 @@
   <div class="board-actions">
     {{if .Paused}}
     <form method="post" action="/api/sprint/start" style="display:inline">
-      <button type="submit" class="btn btn-success">Start Sprint</button>
+      <button type="submit" class="btn btn-success">Start Worker</button>
     </form>
     {{else}}
     <form method="post" action="/api/sprint/pause" style="display:inline">
-      <button type="submit" class="btn btn-danger">Pause Sprint</button>
+      <button type="submit" class="btn btn-danger">Pause Worker</button>
     </form>
     {{end}}
     <button type="button" id="sync-btn" class="btn" onclick="triggerSync()">


### PR DESCRIPTION
Closes #410

## Description
The dashboard UI currently displays "start sprint" and "pause sprint" buttons, but the correct terminology should be "start worker" and "pause worker" since these controls manage individual worker processes, not sprint cycles. This terminology mismatch causes confusion for users operating the orchestration system.

## Tasks
1. Locate the dashboard template files containing "start sprint" and "pause sprint" button labels
2. Update button text from "start sprint" to "start worker" in the dashboard UI
3. Update button text from "pause sprint" to "pause worker" in the dashboard UI
4. Verify the changes render correctly in the dashboard

## Files to Modify
- `internal/dashboard/templates/` - Update button labels in dashboard HTML templates (exact file path to be determined during implementation)

## Acceptance Criteria
1. Dashboard displays "start worker" button instead of "start sprint"
2. Dashboard displays "pause worker" button instead of "pause sprint"
3. Button functionality remains unchanged (only labels updated)
4. No other references to "sprint" remain in worker control context