### PR TITLE
[Bug] Fix overflow in bug wizard step 2 - Save button not visible

### DIFF
--- a/internal/dashboard/templates/wizard_page.html
+++ b/internal/dashboard/templates/wizard_page.html
@@ -115,6 +115,8 @@
 }
 
 .wizard-page-content {
+  flex: 1;
+  overflow-y: auto;
   padding: 1.5rem;
 }
 


### PR DESCRIPTION
Closes #415

## Description
In the second step of the "Create New Bug" wizard, the content area lacks proper overflow handling. On smaller screens or when content exceeds the viewport height, the Save button becomes inaccessible as it extends beyond the visible area without scroll capability.

## Tasks
1. Inspect the CSS/styling for the second step container in the bug creation wizard
2. Add `overflow-y: auto` or equivalent scroll behavior to the step content container
3. Ensure the Save button remains visible or accessible via scrolling on all screen sizes
4. Test the fix at various viewport heights (e.g., 600px, 768px, 900px)

## Files to Modify
- `internal/dashboard/static/css/wizard.css` or similar stylesheet — add overflow handling to step containers
- `internal/dashboard/templates/wizard.html` or equivalent — verify container structure allows scrolling

## Acceptance Criteria
1. The second step of the bug creation wizard displays a scrollbar when content exceeds viewport height
2. The Save button is always accessible either immediately visible or via scrolling
3. No content is cut off or inaccessible on screen heights as low as 600px
4. The fix does not break layout on larger screens (no unnecessary scrollbars)