### PR TITLE
[Bug] Fix Create Another button redirecting to wrong wizard URL

### DIFF
--- a/internal/dashboard/templates/wizard_create.html
+++ b/internal/dashboard/templates/wizard_create.html
@@ -60,12 +60,12 @@
   <div class="form-actions">
     {{if .IsPage}}
     <a href="/" class="btn btn-primary">Close Wizard</a>
-    <a href="/wizard?type={{.Type}}" class="btn btn-success">+ Create Another</a>
+    <a href="/wizard/new?type={{.Type}}" class="btn btn-success">+ Create Another</a>
     {{else}}
     <button type="button" class="btn btn-primary" onclick="closeWizardModal()">
       Close Wizard
     </button>
-    <button type="button" class="btn btn-success" onclick="closeWizardModal(); window.location.href='/wizard?type={{.Type}}'">
+    <button type="button" class="btn btn-success" onclick="closeWizardModal(); window.location.href='/wizard/new?type={{.Type}}'">
       + Create Another
     </button>
     {{end}}


### PR DESCRIPTION
Closes #417

## Description
The "Create Another" button on the wizard completion page redirects to `/wizard?type={{.Type}}` instead of `/wizard/new?type={{.Type}}`. This causes users to land on the wizard selection page without proper formatting instead of the new issue creation form.

## Tasks
1. Open `internal/dashboard/templates/wizard_create.html` and locate the "Create Another" button on line 63
2. Change the href from `/wizard?type={{.Type}}` to `/wizard/new?type={{.Type}}` in the page version of the button
3. Locate the modal version of the button on line 68-69 and update the same URL pattern
4. Run the dashboard tests to verify the fix: `go test ./internal/dashboard/... -v -run TestWizard`

## Files to Modify
- `internal/dashboard/templates/wizard_create.html` - Update "Create Another" button URLs from `/wizard?type=` to `/wizard/new?type=` on lines 63 and 69

## Acceptance Criteria
1. Clicking "Create Another" button redirects to `/wizard/new?type=feature` (or bug) with proper form layout
2. The wizard page displays the correct initial form with all styling and formatting intact
3. Both page mode (line 63) and modal mode (line 69) buttons work correctly
4. Existing tests pass after the change