### PR TITLE
[Bug] Fix gh api command failing with unknown -R flag during sprint close

### DIFF
--- a/.oda/config.yaml
+++ b/.oda/config.yaml
@@ -24,7 +24,7 @@ llm:
     planning:
         model: nexos-ai/Kimi K2.5
     orchestration:
-        model: '"openrouter/stepfun/step-3.5-flash:free"'
+        model: "openrouter/stepfun/step-3.5-flash:free"
     code:
         model: nexos-ai/Kimi K2.5
     code-heavy:

--- a/internal/github/tags.go
+++ b/internal/github/tags.go
@@ -23,7 +23,7 @@ type Tag struct {
 // If no tags exist, returns defaultVersion and nil error
 func (c *Client) GetLatestTag() (string, error) {
 	// Fetch all tags using gh CLI
-	out, err := c.gh("api", "repos/"+c.Repo+"/git/refs/tags")
+	out, err := c.ghNoRepo("api", "repos/"+c.Repo+"/git/refs/tags")
 	if err != nil {
 		// Check if it's a 404 (no tags exist)
 		if strings.Contains(err.Error(), "404") {
@@ -77,7 +77,7 @@ func (c *Client) GetLatestTag() (string, error) {
 
 // TagExists checks if a tag already exists in the repository
 func (c *Client) TagExists(tagName string) (bool, error) {
-	_, err := c.gh("api", "repos/"+c.Repo+"/git/refs/tags/"+tagName)
+	_, err := c.ghNoRepo("api", "repos/"+c.Repo+"/git/refs/tags/"+tagName)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil
@@ -90,7 +90,7 @@ func (c *Client) TagExists(tagName string) (bool, error) {
 // CreateTag creates a new annotated tag on the specified branch
 func (c *Client) CreateTag(tagName, branch, message string) error {
 	// First, get the SHA of the latest commit on the branch
-	out, err := c.gh("api", "repos/"+c.Repo+"/git/ref/heads/"+branch)
+	out, err := c.ghNoRepo("api", "repos/"+c.Repo+"/git/ref/heads/"+branch)
 	if err != nil {
 		return fmt.Errorf("fetching branch %s: %w", branch, err)
 	}


### PR DESCRIPTION
Closes #422

## Description
The sprint closing functionality fails because the `gh api` command doesn't support the `-R` flag when the API endpoint already includes the full repository path. The error occurs in the tag management functions when checking tag existence or fetching the latest tag.

## Tasks
1. Change `c.gh()` to `c.ghNoRepo()` in `internal/github/tags.go` line 26 for the `GetLatestTag` function
2. Change `c.gh()` to `c.ghNoRepo()` in `internal/github/tags.go` line 80 for the `TagExists` function  
3. Change `c.gh()` to `c.ghNoRepo()` in `internal/github/tags.go` line 93 for the `CreateTag` function
4. Run `go test ./internal/github/...` to verify the changes don't break existing tests
5. Run `golangci-lint run ./...` to ensure code quality

## Files to Modify
- `internal/github/tags.go` - Replace `c.gh()` with `c.ghNoRepo()` on lines 26, 80, and 93 to remove the unsupported `-R` flag from `gh api` commands

## Acceptance Criteria
1. Sprint closing completes without the "unknown shorthand flag: 'R' in -R" error
2. Tag existence check works correctly for both existing and non-existing tags
3. Latest tag fetching returns the correct semantic version or default "0.0.0" when no tags exist
4. All existing tests pass
5. Linting passes with no errors