### PR TITLE
[Feature] Build on master only for tags, not every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    tags:
+      - '*'
   pull_request:
     branches: [main, master]
 


### PR DESCRIPTION
Closes #424

## Description
The current CI/CD configuration triggers a build on every commit to the master branch. This needs to be changed so that builds on master are only triggered when a tag is pushed, reducing unnecessary CI runs and resource usage.

## Tasks
1. Locate the CI/CD configuration file (likely `.github/workflows/build.yml` or similar)
2. Modify the workflow trigger conditions to remove `push` events on master branch
3. Add or verify that `push` events with tags are configured to trigger builds
4. Test the configuration by verifying the workflow syntax with `gh workflow view` or similar

## Files to Modify
- `.github/workflows/*.yml` - Update trigger conditions to build only on tags, not on every commit to master

## Acceptance Criteria
1. Pushing a regular commit to master does NOT trigger a build
2. Pushing a tag to master DOES trigger a build
3. Pull requests to master continue to trigger builds as before
4. The workflow file passes YAML syntax validation