### PR TITLE
[Feature] Auto-build Linux binary and attach to release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.0'
+
+      - name: Cache Go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Build Linux AMD64 binary
+        run: |
+          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o oda-linux-amd64 .
+          chmod +x oda-linux-amd64
+          ./oda-linux-amd64 --help
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: oda-linux-amd64
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes #426

## Description
When a tag is pushed to the master branch, the CI pipeline should automatically build a Linux binary and attach it to the GitHub release. This automates the release process and ensures consistent, reproducible builds for Linux users.

## Tasks
1. Create `.github/workflows/release.yml` workflow file with trigger on tag push to master
2. Add job to checkout code and set up Go 1.25 environment
3. Add build step to compile Linux AMD64 binary with `go build -o oda-linux-amd64 ./cmd/oda`
4. Configure step to upload the binary as a release asset using `gh release upload` or `softprops/action-gh-release`
5. Test workflow by pushing a test tag to verify binary is attached to release

## Files to Modify
- `.github/workflows/release.yml` (new file) — GitHub Actions workflow for automated releases

## Acceptance Criteria
1. Pushing a tag to master triggers the release workflow automatically
2. Workflow completes successfully and produces a working Linux AMD64 binary
3. Binary is automatically attached to the GitHub release page with the correct tag
4. Binary filename follows pattern `oda-linux-amd64` or includes version tag
5. Workflow fails gracefully with clear error messages if build or upload fails