### PR TITLE
[Feature] Compress Linux release binary to tar.gz archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,15 @@ jobs:
           chmod +x oda-linux-amd64
           ./oda-linux-amd64 --help
 
+      - name: Compress Linux binary
+        run: |
+          tar -czf oda-linux-amd64.tar.gz oda-linux-amd64
+          ls -lh oda-linux-amd64.tar.gz
+
       - name: Upload binary to release
         uses: softprops/action-gh-release@v2
         with:
-          files: oda-linux-amd64
+          files: oda-linux-amd64.tar.gz
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
         env:


### PR DESCRIPTION
Closes #428

## Description
The current GitHub Actions workflow builds the Linux binary and attaches it directly to the release. To improve distribution and follow common conventions, the binary should be compressed into a tar.gz archive before being added to the release assets.

## Tasks
1. Locate the GitHub Actions workflow file that handles the master tag build and release creation
2. Add a step to compress the built Linux binary into a tar.gz archive using `tar -czf`
3. Update the release asset upload step to use the compressed tar.gz file instead of the raw binary
4. Verify the workflow syntax and test the compression step locally if possible

## Files to Modify
- `.github/workflows/*.yml` or similar - Add compression step before release upload and update asset path to point to the tar.gz file

## Acceptance Criteria
1. When a master tag is pushed, the Linux binary is automatically compressed into a tar.gz archive
2. The release contains the compressed tar.gz file instead of the raw binary
3. The tar.gz archive can be extracted successfully and the binary runs without issues
4. The workflow completes without errors and the release asset is properly attached