### PR TITLE
[Bug] Fix template error on /wizard page - missing YoloMode field

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2200,6 +2200,20 @@ func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
 	if s.pool != nil {
 		workerCount = len(s.pool())
 	}
+
+	// Load config to get yolo mode status (same pattern as buildBoardData)
+	yoloMode := false
+	if s.rootDir != "" {
+		if cfg, err := config.Load(s.rootDir); err == nil {
+			yoloMode = cfg.YoloMode
+		}
+	}
+
+	// Check runtime override (takes precedence over config file)
+	if s.yoloOverride != nil {
+		yoloMode = *s.yoloOverride
+	}
+
 	data := struct {
 		Active             string
 		OpenCodePort       int
@@ -2210,6 +2224,7 @@ func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
 		IsPage             bool
 		ShowBreakdownStep  bool
 		NeedsTypeSelection bool
+		YoloMode           bool
 	}{
 		Active:             "wizard",
 		OpenCodePort:       s.webPort,
@@ -2220,6 +2235,7 @@ func (s *Server) handleWizardPage(w http.ResponseWriter, r *http.Request) {
 		IsPage:             true,
 		ShowBreakdownStep:  false,
 		NeedsTypeSelection: needsTypeSelection,
+		YoloMode:           yoloMode,
 	}
 
 	if session != nil {


### PR DESCRIPTION
Closes #429

## Description
The footer on the /wizard page is broken due to a template error. The layout.html template attempts to access a `.YoloMode` field that doesn't exist in the wizard page's data struct, causing the page to display a template execution error instead of rendering properly.

## Tasks
1. Add `YoloMode` field to the wizard page data struct in `internal/dashboard/wizard.go`
2. Set the `YoloMode` value when rendering the wizard template
3. Verify the /wizard page renders without template errors

## Files to Modify
- `internal/dashboard/wizard.go` — Add `YoloMode` field to the wizard data struct and ensure it's populated when rendering

## Acceptance Criteria
1. The /wizard page loads without template errors
2. The footer displays correctly on the wizard page
3. No regression in other pages that use layout.html template