### PR TITLE
[Bug] Fix "Create Another" button URL on wizard completion page

### DIFF
--- a/internal/dashboard/templates/wizard_create.html
+++ b/internal/dashboard/templates/wizard_create.html
@@ -60,12 +60,12 @@
   <div class="form-actions">
     {{if .IsPage}}
     <a href="/" class="btn btn-primary">Close Wizard</a>
-    <a href="/wizard/new?type={{.Type}}" class="btn btn-success">+ Create Another</a>
+    <a href="/wizard" class="btn btn-success">+ Create Another</a>
     {{else}}
     <button type="button" class="btn btn-primary" onclick="closeWizardModal()">
       Close Wizard
     </button>
-    <button type="button" class="btn btn-success" onclick="closeWizardModal(); window.location.href='/wizard/new?type={{.Type}}'">
+    <button type="button" class="btn btn-success" onclick="closeWizardModal(); window.location.href='/wizard'">
       + Create Another
     </button>
     {{end}}


### PR DESCRIPTION
Closes #431

## Description
The "+ Create Another" button on the wizard completion page ("Issue Created Successfully") links to the old URL `/wizard/new?type={{.Type}}` instead of the new wizard landing page at `/wizard`. This occurs in both the page view and modal view of the completion step.

## Tasks
1. Update line 63 in `internal/dashboard/templates/wizard_create.html` to change the href from `/wizard/new?type={{.Type}}` to `/wizard`
2. Update line 68 in `internal/dashboard/templates/wizard_create.html` to change the window.location.href from `/wizard/new?type={{.Type}}` to `/wizard`
3. Verify the fix by checking that both "+ Create Another" buttons now navigate to `/wizard`

## Files to Modify
- `internal/dashboard/templates/wizard_create.html` - Update two button links (line 63 for page view, line 68 for modal view)

## Acceptance Criteria
1. The "+ Create Another" button in page view (line 63) navigates to `/wizard` instead of `/wizard/new?type=feature`
2. The "+ Create Another" button in modal view (line 68) navigates to `/wizard` instead of `/wizard/new?type=feature`
3. Both buttons work correctly for both feature and bug issue types
4. No other wizard functionality is affected by this change