### PR TITLE
[Bug] Fix + New Ticket button URL in processing panel

### DIFF
--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -371,7 +371,7 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
         <div class="processing-empty-message">
           <span class="processing-empty-title">No tickets in sprint</span>
           <span class="processing-empty-subtitle">Create your first ticket to get started</span>
-          <a href="/wizard/new?type=feature" class="processing-cta">+ New Ticket</a>
+          <a href="/wizard" class="processing-cta">+ New Ticket</a>
         </div>
         {{else}}
         <span class="processing-idle-text">No active ticket &mdash; Worker ready</span>

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -373,7 +373,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
                     '<div class="processing-empty-message">' +
                     '<span class="processing-empty-title">No tickets in sprint</span>' +
                     '<span class="processing-empty-subtitle">Create your first ticket to get started</span>' +
-                    '<a href="/wizard/new?type=feature" class="processing-cta">+ New Ticket</a>' +
+                    '<a href="/wizard" class="processing-cta">+ New Ticket</a>' +
                     '</div></div>';
             } else {
                 panel.innerHTML = '<div class="processing-panel-content">' +


### PR DESCRIPTION
Closes #438

## Description
The "+ New Ticket" button in the processing panel on the dashboard currently links to `/wizard/new?type=feature` instead of the correct URL `/wizard`. This causes users to land on the wrong page when trying to create a new ticket from the processing panel.

## Tasks
1. Fix the URL in `internal/dashboard/templates/board.html` line 374 - change `href="/wizard/new?type=feature"` to `href="/wizard"`
2. Fix the URL in `internal/dashboard/templates/layout.html` line 376 - change `href="/wizard/new?type=feature"` to `href="/wizard"`
3. Run tests to verify the dashboard templates render correctly

## Files to Modify
- `internal/dashboard/templates/board.html` - Update the + New Ticket button href from `/wizard/new?type=feature` to `/wizard`
- `internal/dashboard/templates/layout.html` - Update the + New Ticket button href in the JavaScript template string from `/wizard/new?type=feature` to `/wizard`

## Acceptance Criteria
- [ ] Clicking the "+ New Ticket" button in the processing panel navigates to `/wizard`
- [ ] The fix works in both the server-rendered board template and the client-side updated layout template
- [ ] All existing dashboard tests pass
- [ ] No other buttons or links are affected by this change