### PR TITLE
[Feature] Toggle worker state by clicking worker in bottom bar

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2701,6 +2701,60 @@ func (s *Server) handleWorkerStatus(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
+// handleWorkerToggle toggles the worker state between running and paused
+func (s *Server) handleWorkerToggle(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	if s.orchestrator == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"success": false,
+			"error":   "orchestrator not configured",
+			"paused":  true,
+		}); err != nil {
+			log.Printf("[Dashboard] Error encoding JSON: %v", err)
+		}
+		return
+	}
+
+	isPaused := s.orchestrator.IsPaused()
+
+	if isPaused {
+		s.orchestrator.Start()
+		log.Println("[Dashboard] Worker started via toggle")
+	} else {
+		s.orchestrator.Pause()
+		log.Println("[Dashboard] Worker paused via toggle")
+	}
+
+	newPaused := s.orchestrator.IsPaused()
+	isProcessing := s.orchestrator.IsProcessing()
+
+	if s.hub != nil {
+		status := "paused"
+		if !newPaused {
+			status = "active"
+		}
+		s.hub.BroadcastWorkerUpdate("worker-1", status, 0, "", "", 0)
+	}
+
+	statusMsg := "started"
+	if newPaused {
+		statusMsg = "paused"
+	}
+
+	response := map[string]any{
+		"success": true,
+		"paused":  newPaused,
+		"active":  isProcessing,
+		"message": "Worker " + statusMsg,
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("[Dashboard] Error encoding JSON: %v", err)
+	}
+}
+
 // handleYoloToggle toggles the YOLO mode setting and returns an HTMX fragment
 func (s *Server) handleYoloToggle(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -6139,3 +6139,94 @@ func TestBoardTemplate_CSSLayout(t *testing.T) {
 		t.Error("processing-panel should NOT have max-height:250px (grid row handles sizing)")
 	}
 }
+
+// TestHandleWorkerToggle_Success_Start tests toggling from paused to running
+func TestHandleWorkerToggle_Success_Start(t *testing.T) {
+	orch := &mvp.Orchestrator{}
+	// Manually set paused to true to simulate initial state
+	orch.Pause()
+	s := &Server{orchestrator: orch}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/worker/toggle", nil)
+	w := httptest.NewRecorder()
+
+	s.handleWorkerToggle(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp["success"] != true {
+		t.Errorf("success = %v, want true", resp["success"])
+	}
+
+	// After toggle from paused, should be unpaused (running)
+	if resp["paused"] != false {
+		t.Errorf("paused = %v, want false", resp["paused"])
+	}
+
+	if resp["message"] != "Worker started" {
+		t.Errorf("message = %v, want 'Worker started'", resp["message"])
+	}
+}
+
+// TestHandleWorkerToggle_Success_Pause tests toggling from running to paused
+func TestHandleWorkerToggle_Success_Pause(t *testing.T) {
+	orch := &mvp.Orchestrator{}
+	orch.Start() // Start first so we can pause
+	s := &Server{orchestrator: orch}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/worker/toggle", nil)
+	w := httptest.NewRecorder()
+
+	s.handleWorkerToggle(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp["success"] != true {
+		t.Errorf("success = %v, want true", resp["success"])
+	}
+
+	if resp["paused"] != true {
+		t.Errorf("paused = %v, want true", resp["paused"])
+	}
+}
+
+// TestHandleWorkerToggle_NoOrchestrator tests error handling when orchestrator is nil
+func TestHandleWorkerToggle_NoOrchestrator(t *testing.T) {
+	s := &Server{orchestrator: nil}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/worker/toggle", nil)
+	w := httptest.NewRecorder()
+
+	s.handleWorkerToggle(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if resp["success"] != false {
+		t.Errorf("success = %v, want false", resp["success"])
+	}
+
+	if resp["error"] != "orchestrator not configured" {
+		t.Errorf("error = %v, want 'orchestrator not configured'", resp["error"])
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -269,6 +269,9 @@ func (s *Server) routes() {
 	// Worker status endpoint
 	s.mux.HandleFunc("GET /api/worker-status", s.handleWorkerStatus)
 
+	// Worker toggle endpoint
+	s.mux.HandleFunc("POST /api/worker/toggle", s.handleWorkerToggle)
+
 	// Settings endpoints
 	s.mux.HandleFunc("GET /settings", s.handleSettings)
 	s.mux.HandleFunc("POST /settings", s.handleSaveSettings)

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -84,6 +84,13 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
 .worker-status-tooltip::after{content:'';position:absolute;top:100%;right:1rem;border:6px solid transparent;border-top-color:var(--surface)}
 .worker-status-tooltip::before{content:'';position:absolute;top:100%;right:calc(1rem - 1px);border:7px solid transparent;border-top-color:var(--border)}
 
+/* Clickable worker status */
+.worker-status-container.clickable{cursor:pointer;transition:background-color .2s,border-color .2s,transform .1s}
+.worker-status-container.clickable:hover{background:var(--border);border-color:var(--accent)}
+.worker-status-container.clickable:active{transform:scale(.95)}
+.worker-status-container.running{border-color:var(--green);box-shadow:0 0 0 1px var(--green)}
+.worker-status-container.paused{border-color:var(--orange);box-shadow:0 0 0 1px var(--orange)}
+
 /* YOLO mode indicator */
 .yolo-mode-container{position:relative;display:inline-flex;align-items:center;gap:.5rem;padding:.25rem .5rem;border-radius:4px;background:var(--red);border:1px solid var(--red);color:#fff;font-weight:600;font-size:.75rem;margin-right:.75rem;animation:yolo-pulse 2s ease-in-out infinite;cursor:pointer;transition:opacity .2s}
 .yolo-mode-container:hover{opacity:.8}
@@ -127,7 +134,12 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
     </button>
   </div>
   <div class="footer-right" style="display:flex;align-items:center;gap:.75rem">
-  <div class="worker-status-container" id="worker-status-container">
+  <div class="worker-status-container clickable" id="worker-status-container"
+       hx-post="/api/worker/toggle"
+       hx-swap="none"
+       hx-trigger="click"
+       hx-on::before-request="toggleWorkerOptimistic()"
+       hx-on::after-request="toggleWorkerComplete(event)">
     <div class="worker-status-dot" id="worker-status-dot"></div>
     <span style="font-size:.75rem;color:var(--muted)">Worker</span>
     <div class="worker-status-tooltip" id="worker-status-tooltip">
@@ -293,19 +305,23 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
     
     function updateWorkerStatusUI() {
         const dot = document.getElementById('worker-status-dot');
+        const container = document.getElementById('worker-status-container');
         const stateEl = document.getElementById('worker-tooltip-state');
         const stepEl = document.getElementById('worker-tooltip-step');
         const issueEl = document.getElementById('worker-tooltip-issue');
         const timeEl = document.getElementById('worker-tooltip-time');
         
-        if (!dot) return;
+        if (!dot || !container) return;
         
-        // Update dot appearance
         dot.classList.remove('active', 'paused');
+        container.classList.remove('running', 'paused');
+        
         if (workerStatus.active && !workerStatus.paused) {
             dot.classList.add('active');
+            container.classList.add('running');
         } else if (workerStatus.paused && workerStatus.active) {
             dot.classList.add('paused');
+            container.classList.add('paused');
         }
         
         // Update tooltip content
@@ -409,6 +425,56 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
             .then(response => response.json())
             .then(data => handleWorkerUpdate(data))
             .catch(err => console.error('[WorkerStatus] Error fetching status:', err));
+    }
+    
+    // Worker toggle functionality
+    function toggleWorkerOptimistic() {
+        const container = document.getElementById('worker-status-container');
+        const dot = document.getElementById('worker-status-dot');
+        
+        if (workerStatus.paused) {
+            container.classList.remove('paused');
+            container.classList.add('running');
+            dot.classList.remove('paused');
+            dot.classList.add('active');
+        } else {
+            container.classList.remove('running');
+            container.classList.add('paused');
+            dot.classList.remove('active');
+            dot.classList.add('paused');
+        }
+    }
+    
+    function toggleWorkerComplete(event) {
+        if (event.detail.successful) {
+            try {
+                const response = JSON.parse(event.detail.xhr.response);
+                if (response.success) {
+                    workerStatus.paused = response.paused;
+                    workerStatus.active = response.active;
+                    updateWorkerStatusUI();
+                    refreshBoard();
+                } else {
+                    handleToggleError(response.error || 'Unknown error');
+                }
+            } catch (e) {
+                console.error('[WorkerToggle] Error parsing response:', e);
+                handleToggleError('Invalid response');
+            }
+        } else {
+            handleToggleError('Network error');
+        }
+    }
+    
+    function handleToggleError(errorMsg) {
+        console.error('[WorkerToggle] Error:', errorMsg);
+        fetchWorkerStatus();
+        const container = document.getElementById('worker-status-container');
+        const originalBorder = container.style.borderColor;
+        container.style.borderColor = 'var(--red)';
+        setTimeout(() => {
+            container.style.borderColor = originalBorder;
+        }, 2000);
     }
     
     // Fetch initial status on page load


### PR DESCRIPTION
Closes #439

## Description
Add click interaction to worker items displayed on the dashboard's bottom status bar. Clicking a worker should toggle its state between running and paused, providing quick manual control without navigating to a separate management page.

## Tasks
1. Add click event handler to worker elements in dashboard bottom bar template (`internal/dashboard/templates/`)
2. Create backend API endpoint to toggle worker state (start/pause) in worker management package
3. Implement worker state toggle logic in worker controller/service layer
4. Add visual feedback (cursor pointer, hover state) to worker elements in CSS/template
5. Update worker status display to reflect running/paused states with appropriate indicators

## Files to Modify
- `internal/dashboard/templates/dashboard.html` — Add click handlers and visual indicators to worker bar items
- `internal/dashboard/handlers.go` — Add HTTP handler for worker toggle endpoint
- `internal/worker/manager.go` or `internal/worker/controller.go` — Implement start/pause toggle logic
- `internal/dashboard/static/css/dashboard.css` — Add hover states and cursor styling for clickable workers

## Acceptance Criteria
1. Clicking a running worker in the bottom bar pauses it and updates the visual indicator
2. Clicking a paused worker in the bottom bar starts it and updates the visual indicator
3. Worker state changes are persisted and reflected in the backend
4. Visual feedback (pointer cursor, hover highlight) indicates workers are clickable
5. Invalid worker IDs or network errors show an appropriate error message without crashing the UI