### PR TITLE
[Bug] Worker status text click does not update UI after toggle

### DIFF
--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -114,6 +114,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
   color: var(--muted);
   min-width: 50px;
   text-align: center;
+  pointer-events: none;
 }
 
 /* Idle state */
@@ -190,6 +191,7 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
   min-width: 200px;
   z-index: 1000;
   opacity: 1;
+  pointer-events: none;
 }
 
 .worker-status-tooltip-header {


### PR DESCRIPTION
Closes #446

## Description
Clicking on the worker status text label (`.worker-status-text`) triggers the worker toggle API call successfully, but the UI does not update to reflect the new status. The backend responds correctly (e.g., worker is now idle), but the interface continues to show the previous error state instead of updating the visual indicator.

## Tasks
1. Investigate event propagation from `.worker-status-text` child element to parent `.worker-status-container` with HTMX trigger
2. Check if click events on the text span properly bubble up to trigger the `hx-post="/api/worker/toggle"` request
3. Verify that `toggleWorkerComplete(event)` handler correctly updates `workerStatus` object and calls `updateWorkerStatusUI()`
4. Test the fix by clicking directly on the status text and confirming the UI updates to show the correct worker state (Idle/Running/Paused)

## Files to Modify
- `internal/dashboard/templates/layout.html` - Fix event handling on worker status text element or adjust HTMX trigger configuration

## Acceptance Criteria
- [ ] Clicking on the worker status text ("Idle", "Running", or "Paused") correctly toggles the worker state
- [ ] After clicking, the UI immediately updates to show the correct status color and label
- [ ] The worker status container CSS classes (idle/running/paused) are correctly applied after toggle
- [ ] Error state (red border) only appears when the API request actually fails, not on successful toggles