### PR TITLE
Fix dashboard worker toggle button - expose functions to window and handle JSON parsing

### DIFF
--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -623,7 +623,11 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
     function toggleWorkerComplete(event) {
         if (event.detail.successful) {
             try {
-                const response = JSON.parse(event.detail.xhr.response);
+                // Response might already be parsed by HTMX or might be a JSON string
+                let response = event.detail.xhr.response;
+                if (typeof response === 'string') {
+                    response = JSON.parse(response);
+                }
                 if (response.success) {
                     workerStatus.paused = response.paused;
                     workerStatus.active = response.active;
@@ -681,6 +685,10 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
         refreshBoard: refreshBoard,
         handleWorkerUpdate: handleWorkerUpdate
     };
+    
+    // Expose worker toggle functions for HTMX
+    window.toggleWorkerOptimistic = toggleWorkerOptimistic;
+    window.toggleWorkerComplete = toggleWorkerComplete;
     
     // Auto-connect on page load
     document.addEventListener('DOMContentLoaded', connect);


### PR DESCRIPTION
Closes #448

## Problem
The worker status toggle button in the dashboard footer doesn't change its state when clicked. When user clicks on "Worker is paused. Click to resume worker." button, nothing happens and the state doesn't switch to "idle" or "running".

Browser console shows these errors:
- `Uncaught ReferenceError: toggleWorkerOptimistic is not defined`
- `Uncaught ReferenceError: toggleWorkerComplete is not defined`  
- `Uncaught SyntaxError: "[object Object]" is not valid JSON`

## Root Cause Analysis

### Issue 1: Functions not accessible to HTMX
The JavaScript functions `toggleWorkerOptimistic()` and `toggleWorkerComplete()` are defined inside an IIFE (Immediately Invoked Function Expression) in `internal/dashboard/templates/layout.html`. 

HTMX uses `hx-on::before-request="toggleWorkerOptimistic()"` and `hx-on::after-request="toggleWorkerComplete(event)"` attributes on the worker status button. These handlers look for functions in the global `window` scope, but the functions are trapped inside the IIFE closure and not exposed.

### Issue 2: Double JSON parsing
The `toggleWorkerComplete()` function uses `JSON.parse(event.detail.xhr.response)` to parse the response. However, HTMX automatically parses JSON responses, so `event.detail.xhr.response` is already a JavaScript object, not a string. Attempting to parse it causes a syntax error.

## Implementation Steps

### Step 1: Expose functions to window object

**File:** `internal/dashboard/templates/layout.html`

**Location:** After line 687 (after `window.WebSocketClient = {...}` block and before `// Auto-connect on page load`)

**Add this code:**
```javascript
    // Expose worker toggle functions for HTMX
    window.toggleWorkerOptimistic = toggleWorkerOptimistic;
    window.toggleWorkerComplete = toggleWorkerComplete;
```

The full block should look like:
```javascript
    // Expose for global access
    window.WebSocketClient = {
        connect: connect,
        disconnect: disconnect,
        refreshBoard: refreshBoard,
        handleWorkerUpdate: handleWorkerUpdate
    };
    
    // Expose worker toggle functions for HTMX
    window.toggleWorkerOptimistic = toggleWorkerOptimistic;
    window.toggleWorkerComplete = toggleWorkerComplete;
    
    // Auto-connect on page load
    document.addEventListener('DOMContentLoaded', connect);
```

### Step 2: Fix JSON parsing in toggleWorkerComplete

**File:** `internal/dashboard/templates/layout.html`

**Location:** Lines 623-642, function `toggleWorkerComplete(event)`

**Replace the entire function with:**
```javascript
    function toggleWorkerComplete(event) {
        if (event.detail.successful) {
            try {
                // Response might already be parsed by HTMX or might be a JSON string
                let response = event.detail.xhr.response;
                if (typeof response === 'string') {
                    response = JSON.parse(response);
                }
                if (response.success) {
                    workerStatus.paused = response.paused;
                    workerStatus.active = response.active;
                    updateWorkerStatusUI();
                    refreshBoard();
                } else {
                    handleToggleError(response.error || 'Unknown error');
                }
            } catch (e) {
                console.error('[WorkerToggle] Error parsing response:', e);
                handleToggleError('Invalid response');
            }
        } else {
            handleToggleError('Network error');
        }
    }
```

**Key change:** Added `if (typeof response === 'string')` check before calling `JSON.parse()`.

### Step 3: Rebuild the binary

**CRITICAL:** The HTML templates are embedded in the binary using Go's `embed.FS` (see `internal/dashboard/server.go:23-24`). After editing the template file, you MUST rebuild the binary:

```bash
go build -o oda .
```

Without rebuilding, the server will continue to serve the old embedded version of the template.

### Step 4: Restart the server

```bash
pkill -f "./oda"
./oda &
```

## Verification Steps

1. Open browser DevTools (F12) → Console tab
2. Navigate to `http://localhost:5000/`
3. Verify no JavaScript errors on page load
4. Click the worker status button (showing "paused")
5. Button should change to "idle" or "running" state
6. Click again - should return to "paused"
7. Check console - should be no errors during toggle

## Files Modified
- `internal/dashboard/templates/layout.html` (2 changes)

## Acceptance Criteria
- [ ] Worker toggle button changes state from "paused" to "idle" on click
- [ ] Second click changes state back from "idle" to "paused"
- [ ] No JavaScript errors in browser console during toggle
- [ ] Worker status updates correctly via WebSocket after toggle
- [ ] Button styling updates correctly (border color, text color, icon)