### PR TITLE
Align processing panel content to top and add ticket metadata badges

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5645,7 +5645,7 @@ func TestBoardTemplate_ProcessingPanel_PartialLabels(t *testing.T) {
 	}
 }
 
-// TestBoardTemplate_ProcessingPanel_LayoutOrder tests that labels appear before ticket in the HTML structure
+// TestBoardTemplate_ProcessingPanel_LayoutOrder tests that ticket appears before labels in the HTML structure
 func TestBoardTemplate_ProcessingPanel_LayoutOrder(t *testing.T) {
 	srv := createTestServerWithTemplates(t)
 	defer srv.wizardStore.Stop()
@@ -5676,7 +5676,7 @@ func TestBoardTemplate_ProcessingPanel_LayoutOrder(t *testing.T) {
 
 	output := buf.String()
 
-	// Verify that processing-labels appears before processing-ticket in the HTML
+	// Verify that processing-ticket appears before processing-labels in the HTML
 	labelsIdx := strings.Index(output, `class="processing-labels"`)
 	ticketIdx := strings.Index(output, `class="processing-ticket"`)
 
@@ -5688,8 +5688,8 @@ func TestBoardTemplate_ProcessingPanel_LayoutOrder(t *testing.T) {
 		t.Error("template should contain processing-ticket element")
 	}
 
-	if labelsIdx != -1 && ticketIdx != -1 && labelsIdx > ticketIdx {
-		t.Error("processing-labels should appear BEFORE processing-ticket in the HTML structure")
+	if labelsIdx != -1 && ticketIdx != -1 && ticketIdx > labelsIdx {
+		t.Error("processing-ticket should appear BEFORE processing-labels in the HTML structure")
 	}
 
 	// Verify new CSS classes are present

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -51,7 +51,7 @@
 .badge-merged{background:#6f42c1;color:white;font-size:.65rem;padding:.1rem .4rem;border-radius:4px;display:inline-flex;align-items:center;gap:.25rem}
 .badge-closed{background:#6c757d;color:white;font-size:.65rem;padding:.1rem .4rem;border-radius:4px;display:inline-flex;align-items:center;gap:.25rem}
 .processing-panel-title{font-size:.75rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);margin-bottom:.5rem;display:flex;align-items:center;gap:.5rem}
-.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:.5rem 1rem;display:flex;align-items:center;min-height:0;z-index:10;overflow-y:auto}
+.processing-panel{background:rgba(52,152,219,0.08);border:1px solid rgba(52,152,219,0.2);border-radius:8px;padding:1rem 1rem .5rem;display:flex;align-items:flex-start;min-height:0;z-index:10;overflow-y:auto}
 .processing-panel-idle{background:rgba(108,117,125,0.08);border-color:rgba(108,117,125,0.2)}
 .processing-panel-idle .processing-indicator{background:#6c757d;animation:none}
 .processing-idle-text{color:var(--muted);font-size:.85rem}
@@ -335,6 +335,10 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
         <div class="processing-panel-title">Processing</div>
         <span class="processing-indicator"></span>
         {{if .CurrentTicket}}
+        <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
+          <span class="processing-id">#{{.CurrentTicket.Number}}</span>
+          <span class="processing-title">{{.CurrentTicket.Title}}</span>
+        </a>
         <div class="processing-labels">
           {{if .CurrentTicket.Priority}}
           <span class="processing-badge processing-priority-{{.CurrentTicket.Priority}}">
@@ -350,10 +354,6 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
           <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
           {{end}}
         </div>
-        <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">
-          <span class="processing-id">#{{.CurrentTicket.Number}}</span>
-          <span class="processing-title">{{.CurrentTicket.Title}}</span>
-        </a>
         {{else}}
         {{if eq .TotalTickets 0}}
         <div class="processing-empty-labels">


### PR DESCRIPTION
Closes #452

## Description

Update the processing panel layout on the dashboard to improve visual hierarchy and information display:

1. **Align content to top** - Change `align-items: center` to `align-items: flex-start` in the processing panel
2. **Add top padding** - Add `padding-top: 1rem` for better visual spacing
3. **Display ticket metadata badges** - Show Priority, Type, and Size badges (e.g., 🟡 Medium, 🐛 Bug, 📏 S) in the processing panel
4. **Show ticket number and title** - Display the ticket number (e.g., #450) in the left-top area of the processing panel, followed by the ticket title below it

## Current Behavior
- Processing panel content is vertically centered
- No ticket metadata is displayed when a ticket is being processed
- The panel only shows "Processing" title and indicator

## Expected Behavior
- Processing panel content aligned to the top
- Badges showing ticket priority, type, and size
- Ticket number prominently displayed in the upper left
- Ticket title displayed below the number

## Acceptance Criteria
- [ ] Processing panel content is aligned to top (flex-start)
- [ ] Badges (Priority, Type, Size) are visible in the processing panel
- [ ] Ticket number is displayed in the upper left corner of the processing panel
- [ ] Ticket title is displayed below the ticket number in the processing panel
- [ ] Changes are visible and working on the dashboard

## Technical Notes
- Modify CSS in `internal/dashboard/templates/board.html`
- Update `.processing-panel` styles
- Ensure badges use existing `.processing-badge` classes