### PR TITLE
[Feature] Add sprint auto_start option to settings page

### DIFF
--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2486,6 +2486,7 @@ type settingsData struct {
 	WorkerCount     int
 	Config          config.LLMConfig
 	YoloMode        bool
+	SprintAutoStart bool
 	Success         bool
 	Errors          []string
 	AvailableModels []opencode.ProviderModel
@@ -2512,6 +2513,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, _ *http.Request) {
 		WorkerCount:     workerCount,
 		Config:          cfg.LLM,
 		YoloMode:        cfg.YoloMode,
+		SprintAutoStart: cfg.Sprint.AutoStart,
 		AvailableModels: s.modelsCache,
 	}
 
@@ -2571,6 +2573,9 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 	// Parse yolo_mode checkbox (checkbox returns "on" when checked, empty when unchecked)
 	cfg.YoloMode = r.FormValue("yolo_mode") == "on"
 
+	// Parse sprint_auto_start checkbox (checkbox returns "on" when checked, empty when unchecked)
+	cfg.Sprint.AutoStart = r.FormValue("sprint_auto_start") == "on"
+
 	// Note: We intentionally do NOT call ValidateAndFallbackModels here.
 	// The user's exact selections are saved to config. Runtime fallback
 	// happens in the LLM router when models are actually used.
@@ -2608,6 +2613,7 @@ func (s *Server) handleSaveSettings(w http.ResponseWriter, r *http.Request) {
 		WorkerCount:     workerCount,
 		Config:          cfg.LLM,
 		YoloMode:        cfg.YoloMode,
+		SprintAutoStart: cfg.Sprint.AutoStart,
 		Success:         true,
 		AvailableModels: s.modelsCache,
 	}
@@ -2634,6 +2640,7 @@ func (s *Server) renderSettingsWithErrors(w http.ResponseWriter, _ *http.Request
 		WorkerCount:     workerCount,
 		Config:          cfg.LLM,
 		YoloMode:        cfg.YoloMode,
+		SprintAutoStart: cfg.Sprint.AutoStart,
 		Errors:          errors,
 		AvailableModels: s.modelsCache,
 	}

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -6285,3 +6285,202 @@ func TestHandleWorkerToggle_NoOrchestrator(t *testing.T) {
 		t.Errorf("error = %v, want 'orchestrator not configured'", resp["error"])
 	}
 }
+
+// TestHandleSettings_SprintAutoStart tests that SprintAutoStart is correctly loaded from config
+func TestHandleSettings_SprintAutoStart(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a config file with sprint auto_start enabled
+	configContent := `llm:
+  setup:
+    model: test-provider/test-model
+  planning:
+    model: test-provider/test-model
+  orchestration:
+    model: test-provider/test-model
+  code:
+    model: test-provider/test-model
+  code-heavy:
+    model: test-provider/test-model
+sprint:
+  auto_start: true
+`
+	configPath := filepath.Join(odaDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Test GET /settings
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	srv.handleSettings(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+
+	// Verify the checkbox is checked in the response
+	body := rec.Body.String()
+	if !strings.Contains(body, `id="sprint_auto_start"`) {
+		t.Error("response should contain sprint_auto_start checkbox")
+	}
+	if !strings.Contains(body, `name="sprint_auto_start"`) {
+		t.Error("response should contain sprint_auto_start form field")
+	}
+}
+
+// TestHandleSaveSettings_SprintAutoStart tests saving sprint_auto_start setting
+func TestHandleSaveSettings_SprintAutoStart(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a minimal config file with sprint auto_start initially false
+	configContent := `llm:
+  setup:
+    model: test-provider/test-model
+  planning:
+    model: test-provider/test-model
+  orchestration:
+    model: test-provider/test-model
+  code:
+    model: test-provider/test-model
+  code-heavy:
+    model: test-provider/test-model
+sprint:
+  auto_start: false
+`
+	configPath := filepath.Join(odaDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Test POST /settings with sprint_auto_start enabled
+	form := url.Values{}
+	form.Set("setup_model", "test-provider/test-model")
+	form.Set("planning_model", "test-provider/test-model")
+	form.Set("orchestration_model", "test-provider/test-model")
+	form.Set("code_model", "test-provider/test-model")
+	form.Set("code_heavy_model", "test-provider/test-model")
+	form.Set("sprint_auto_start", "on") // Enable auto_start
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify success message
+	body := rec.Body.String()
+	if !strings.Contains(body, "Settings saved successfully") {
+		t.Error("response should contain success message")
+	}
+
+	// Verify config was saved with auto_start: true
+	savedData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read saved config: %v", err)
+	}
+
+	savedContent := string(savedData)
+	if !strings.Contains(savedContent, "auto_start: true") {
+		t.Errorf("saved config should contain 'auto_start: true', got:\n%s", savedContent)
+	}
+}
+
+// TestHandleSaveSettings_SprintAutoStartDisabled tests saving with sprint_auto_start unchecked
+func TestHandleSaveSettings_SprintAutoStartDisabled(t *testing.T) {
+	// Create a temporary directory for config
+	tmpDir := t.TempDir()
+
+	// Create .oda directory
+	odaDir := filepath.Join(tmpDir, ".oda")
+	if err := os.MkdirAll(odaDir, 0755); err != nil {
+		t.Fatalf("failed to create .oda directory: %v", err)
+	}
+
+	// Create a config file with sprint auto_start initially true
+	configContent := `llm:
+  setup:
+    model: test-provider/test-model
+  planning:
+    model: test-provider/test-model
+  orchestration:
+    model: test-provider/test-model
+  code:
+    model: test-provider/test-model
+  code-heavy:
+    model: test-provider/test-model
+sprint:
+  auto_start: true
+`
+	configPath := filepath.Join(odaDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	// Create server with templates
+	srv := createTestServerWithTemplates(t)
+	srv.rootDir = tmpDir
+	defer srv.wizardStore.Stop()
+
+	// Test POST /settings without sprint_auto_start (unchecked)
+	form := url.Values{}
+	form.Set("setup_model", "test-provider/test-model")
+	form.Set("planning_model", "test-provider/test-model")
+	form.Set("orchestration_model", "test-provider/test-model")
+	form.Set("code_model", "test-provider/test-model")
+	form.Set("code_heavy_model", "test-provider/test-model")
+	// Note: sprint_auto_start is NOT set, simulating unchecked checkbox
+
+	req := httptest.NewRequest(http.MethodPost, "/settings", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	srv.handleSaveSettings(rec, req)
+
+	// Should return 200 OK
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify config was saved with auto_start: false
+	savedData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read saved config: %v", err)
+	}
+
+	savedContent := string(savedData)
+	if !strings.Contains(savedContent, "auto_start: false") {
+		t.Errorf("saved config should contain 'auto_start: false', got:\n%s", savedContent)
+	}
+}

--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -76,6 +76,18 @@
       </div>
     </div>
     
+    <!-- Sprint Settings -->
+    <div class="category-section">
+      <h2>Sprint Settings</h2>
+      <div class="form-group checkbox-group">
+        <label class="checkbox-label">
+          <input type="checkbox" id="sprint_auto_start" name="sprint_auto_start" value="on" {{if .SprintAutoStart}}checked{{end}}>
+          <span class="checkbox-text">Auto-start sprints</span>
+        </label>
+        <small>When enabled, new sprints automatically start upon creation</small>
+      </div>
+    </div>
+    
     <div class="form-actions">
       <button type="submit" class="btn btn-primary">Save Settings</button>
     </div>


### PR DESCRIPTION
Closes #456

## Description
Add the `sprint.auto_start` configuration option to the dashboard settings page at `/settings`. This boolean setting controls whether new sprints automatically start upon creation and should be editable through the web UI.

## Tasks
1. Add `auto_start` boolean field to the settings form in the dashboard settings template
2. Update the settings handler to read and persist the `sprint.auto_start` value
3. Pre-populate the form field with the current value from the configuration
4. Test that toggling the setting saves correctly and persists after page reload

## Files to Modify
- `internal/dashboard/templates/settings.html` — Add checkbox input for `sprint.auto_start`
- `internal/dashboard/handlers/settings.go` — Handle reading and saving the auto_start value
- `internal/config/config.go` — Ensure sprint.auto_start field exists and is properly typed

## Acceptance Criteria
1. The settings page displays a toggle/checkbox for "Auto-start sprints" 
2. The checkbox reflects the current value from the config file
3. Saving settings updates the `sprint.auto_start` value in the configuration
4. Invalid or missing values default to `false`