### PR TITLE
[Bug] Fix markdown formatting in wizard-generated review issues

### DIFF
--- a/internal/dashboard/api_v2.go
+++ b/internal/dashboard/api_v2.go
@@ -1500,7 +1500,7 @@ func (s *Server) handleWizardCreateIssueV2(w http.ResponseWriter, r *http.Reques
 		title = title[:77] + "..."
 	}
 
-	issueBody := session.TechnicalPlanning
+	issueBody := CleanupMarkdown(session.TechnicalPlanning)
 	issueNum, err := s.gh.CreateIssue(title, issueBody, labels)
 	if err != nil {
 		log.Printf("[API v2] Error creating single issue: %v", err)

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -2074,7 +2074,7 @@ func (s *Server) handleWizardCreateSingle(w http.ResponseWriter, r *http.Request
 	}
 
 	// Create the single issue
-	body := session.TechnicalPlanning
+	body := CleanupMarkdown(session.TechnicalPlanning)
 	issueNum, err := s.gh.CreateIssue(title, body, labels)
 	if err != nil {
 		log.Printf("[Wizard] Error creating single issue: %v", err)

--- a/internal/dashboard/markdown.go
+++ b/internal/dashboard/markdown.go
@@ -1,0 +1,220 @@
+package dashboard
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	// trailingWhitespaceRegex matches trailing whitespace on lines
+	trailingWhitespaceRegex = regexp.MustCompile(`[ \t]+$`)
+
+	// multipleBlankLinesRegex matches 3+ consecutive newlines
+	multipleBlankLinesRegex = regexp.MustCompile(`\n{3,}`)
+
+	// codeBlockRegex matches code blocks (both fenced and indented)
+	codeBlockFenceRegex = regexp.MustCompile("^```")
+)
+
+// CleanupMarkdown fixes common markdown formatting issues in LLM-generated content.
+// It normalizes line endings, fixes code blocks, normalizes headings, fixes list
+// formatting, ensures proper section spacing, and removes trailing whitespace.
+func CleanupMarkdown(content string) string {
+	if content == "" {
+		return ""
+	}
+
+	content = normalizeLineEndings(content)
+	content = fixCodeBlocks(content)
+	content = normalizeHeadings(content)
+	content = fixListFormatting(content)
+	content = ensureSectionSpacing(content)
+	content = removeTrailingWhitespace(content)
+	content = normalizeMultipleBlankLines(content)
+	content = ensureFinalNewline(content)
+
+	return content
+}
+
+// ValidateMarkdown checks if markdown has structural issues and returns a list of errors.
+func ValidateMarkdown(content string) []string {
+	var errors []string
+
+	if content == "" {
+		return errors
+	}
+
+	// Check for unclosed code blocks
+	lines := strings.Split(content, "\n")
+	inCodeBlock := false
+	codeBlockStart := 0
+
+	for i, line := range lines {
+		if codeBlockFenceRegex.MatchString(line) {
+			if inCodeBlock {
+				inCodeBlock = false
+			} else {
+				inCodeBlock = true
+				codeBlockStart = i + 1
+			}
+		}
+	}
+
+	if inCodeBlock {
+		errors = append(errors, "Unclosed code block starting at line "+strconv.Itoa(codeBlockStart))
+	}
+
+	// Check for improper heading levels (should start with ## for sections)
+	for i, line := range lines {
+		if strings.HasPrefix(line, "# ") && !strings.HasPrefix(line, "## ") {
+			// Single # heading found - might be okay for title, but warn
+			errors = append(errors, "Line "+strconv.Itoa(i+1)+" uses single # heading (should use ## for sections)")
+		}
+	}
+
+	return errors
+}
+
+// normalizeLineEndings converts all line endings to \n
+func normalizeLineEndings(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	return content
+}
+
+// fixCodeBlocks ensures proper code block formatting
+func fixCodeBlocks(content string) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+	inCodeBlock := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check for code block fence
+		if strings.HasPrefix(trimmed, "```") {
+			// Ensure proper spacing around code blocks
+			if len(result) > 0 && result[len(result)-1] != "" {
+				result = append(result, "")
+			}
+			result = append(result, line)
+			inCodeBlock = !inCodeBlock
+			continue
+		}
+
+		result = append(result, line)
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// normalizeHeadings ensures consistent heading levels
+func normalizeHeadings(content string) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check if this is a heading
+		if strings.HasPrefix(trimmed, "#") {
+			// Ensure blank line before heading (except at start)
+			if i > 0 && len(result) > 0 && result[len(result)-1] != "" {
+				result = append(result, "")
+			}
+
+			result = append(result, line)
+
+			// Ensure blank line after heading
+			result = append(result, "")
+		} else {
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// fixListFormatting normalizes list markers and spacing
+func fixListFormatting(content string) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+	inList := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check if this is a list item
+		isBullet := strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ")
+		isNumbered := regexp.MustCompile(`^\d+\.\s`).MatchString(trimmed)
+		isCheckbox := strings.HasPrefix(trimmed, "- [") || strings.HasPrefix(trimmed, "* [")
+
+		switch {
+		case isBullet || isNumbered || isCheckbox:
+			if !inList && i > 0 && len(result) > 0 && result[len(result)-1] != "" {
+				// Add blank line before list starts
+				result = append(result, "")
+			}
+			inList = true
+
+			// Normalize bullet markers to "- "
+			if strings.HasPrefix(trimmed, "* ") {
+				line = strings.Replace(line, "* ", "- ", 1)
+			}
+
+			result = append(result, line)
+		default:
+			inList = false
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// ensureSectionSpacing adds proper spacing between sections
+func ensureSectionSpacing(content string) string {
+	// Split by sections (lines starting with ##)
+	lines := strings.Split(content, "\n")
+	var result []string
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "## ") {
+			// This is a section heading
+			if i > 0 && len(result) > 0 && result[len(result)-1] != "" {
+				// Add blank line before section
+				result = append(result, "")
+			}
+			result = append(result, line)
+			// Add blank line after section heading
+			result = append(result, "")
+		} else {
+			result = append(result, line)
+		}
+	}
+
+	return strings.Join(result, "\n")
+}
+
+// removeTrailingWhitespace removes trailing whitespace from all lines
+func removeTrailingWhitespace(content string) string {
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		lines[i] = trailingWhitespaceRegex.ReplaceAllString(line, "")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// normalizeMultipleBlankLines collapses 3+ consecutive newlines to 2
+func normalizeMultipleBlankLines(content string) string {
+	return multipleBlankLinesRegex.ReplaceAllString(content, "\n\n")
+}
+
+// ensureFinalNewline ensures content ends with exactly one newline
+func ensureFinalNewline(content string) string {
+	content = strings.TrimRight(content, "\n")
+	return content + "\n"
+}

--- a/internal/dashboard/markdown_test.go
+++ b/internal/dashboard/markdown_test.go
@@ -1,0 +1,366 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCleanupMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty content",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple content",
+			input:    "Hello world",
+			expected: "Hello world\n",
+		},
+		{
+			name:     "content with CRLF line endings",
+			input:    "Line 1\r\nLine 2\r\nLine 3",
+			expected: "Line 1\nLine 2\nLine 3\n",
+		},
+		{
+			name:     "content with CR line endings",
+			input:    "Line 1\rLine 2\rLine 3",
+			expected: "Line 1\nLine 2\nLine 3\n",
+		},
+		{
+			name:     "trailing whitespace",
+			input:    "Line with trailing spaces   \nAnother line\t\t",
+			expected: "Line with trailing spaces\nAnother line\n",
+		},
+		{
+			name:     "multiple blank lines",
+			input:    "Line 1\n\n\n\n\nLine 2",
+			expected: "Line 1\n\nLine 2\n",
+		},
+		{
+			name:     "section heading without spacing",
+			input:    "## Description\nSome text\n## Tasks\nMore text",
+			expected: "## Description\n\nSome text\n\n## Tasks\n\nMore text\n",
+		},
+		{
+			name:     "bullet list with asterisks",
+			input:    "* Item 1\n* Item 2\n* Item 3",
+			expected: "- Item 1\n- Item 2\n- Item 3\n",
+		},
+		{
+			name:     "numbered list",
+			input:    "1. First\n2. Second\n3. Third",
+			expected: "1. First\n2. Second\n3. Third\n",
+		},
+		{
+			name:     "checkbox list",
+			input:    "- [ ] Task 1\n- [x] Task 2",
+			expected: "- [ ] Task 1\n- [x] Task 2\n",
+		},
+		{
+			name:     "code block",
+			input:    "```go\nfunc main() {}\n```",
+			expected: "```go\nfunc main() {}\n\n```\n",
+		},
+		{
+			name:     "mixed content",
+			input:    "## Description\r\nSome text   \n\n\n\n## Tasks\n* Task 1\n* Task 2\n\n## Files\n1. file.go\n2. file2.go",
+			expected: "## Description\n\nSome text\n\n## Tasks\n\n- Task 1\n- Task 2\n\n## Files\n\n1. file.go\n2. file2.go\n",
+		},
+		{
+			name:     "content without final newline",
+			input:    "Some content",
+			expected: "Some content\n",
+		},
+		{
+			name:     "content with multiple final newlines",
+			input:    "Some content\n\n\n",
+			expected: "Some content\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CleanupMarkdown(tt.input)
+			if result != tt.expected {
+				t.Errorf("CleanupMarkdown() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateMarkdown(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty content",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "valid markdown",
+			input:    "## Description\n\nSome text\n",
+			expected: []string{},
+		},
+		{
+			name:     "unclosed code block",
+			input:    "```go\nfunc main() {}",
+			expected: []string{"Unclosed code block starting at line 1"},
+		},
+		{
+			name:     "closed code block",
+			input:    "```go\nfunc main() {}\n```",
+			expected: []string{},
+		},
+		{
+			name:     "single level heading",
+			input:    "# Title\n\n## Description\n\nText",
+			expected: []string{"Line 1 uses single # heading (should use ## for sections)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ValidateMarkdown(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("ValidateMarkdown() returned %d errors, want %d", len(result), len(tt.expected))
+				return
+			}
+			for i, err := range result {
+				if !strings.Contains(err, tt.expected[i]) {
+					t.Errorf("ValidateMarkdown() error[%d] = %q, should contain %q", i, err, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeLineEndings(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "CRLF to LF",
+			input:    "Line 1\r\nLine 2\r\n",
+			expected: "Line 1\nLine 2\n",
+		},
+		{
+			name:     "CR to LF",
+			input:    "Line 1\rLine 2\r",
+			expected: "Line 1\nLine 2\n",
+		},
+		{
+			name:     "mixed line endings",
+			input:    "Line 1\r\nLine 2\rLine 3\n",
+			expected: "Line 1\nLine 2\nLine 3\n",
+		},
+		{
+			name:     "already LF",
+			input:    "Line 1\nLine 2\n",
+			expected: "Line 1\nLine 2\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeLineEndings(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeLineEndings() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveTrailingWhitespace(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "spaces at end",
+			input:    "Line with spaces   ",
+			expected: "Line with spaces",
+		},
+		{
+			name:     "tabs at end",
+			input:    "Line with tabs\t\t",
+			expected: "Line with tabs",
+		},
+		{
+			name:     "mixed whitespace",
+			input:    "Line with mixed \t \t",
+			expected: "Line with mixed",
+		},
+		{
+			name:     "multiple lines",
+			input:    "Line 1  \nLine 2\t\nLine 3",
+			expected: "Line 1\nLine 2\nLine 3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := removeTrailingWhitespace(tt.input)
+			if result != tt.expected {
+				t.Errorf("removeTrailingWhitespace() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeMultipleBlankLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "three newlines",
+			input:    "Line 1\n\n\nLine 2",
+			expected: "Line 1\n\nLine 2",
+		},
+		{
+			name:     "four newlines",
+			input:    "Line 1\n\n\n\nLine 2",
+			expected: "Line 1\n\nLine 2",
+		},
+		{
+			name:     "two newlines (OK)",
+			input:    "Line 1\n\nLine 2",
+			expected: "Line 1\n\nLine 2",
+		},
+		{
+			name:     "one newline (OK)",
+			input:    "Line 1\nLine 2",
+			expected: "Line 1\nLine 2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeMultipleBlankLines(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizeMultipleBlankLines() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnsureFinalNewline(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no newline",
+			input:    "content",
+			expected: "content\n",
+		},
+		{
+			name:     "one newline",
+			input:    "content\n",
+			expected: "content\n",
+		},
+		{
+			name:     "multiple newlines",
+			input:    "content\n\n\n",
+			expected: "content\n",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureFinalNewline(tt.input)
+			if result != tt.expected {
+				t.Errorf("ensureFinalNewline() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFixListFormatting(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "asterisk to dash",
+			input:    "* Item 1\n* Item 2",
+			expected: "- Item 1\n- Item 2",
+		},
+		{
+			name:     "dash stays dash",
+			input:    "- Item 1\n- Item 2",
+			expected: "- Item 1\n- Item 2",
+		},
+		{
+			name:     "numbered list",
+			input:    "1. First\n2. Second",
+			expected: "1. First\n2. Second",
+		},
+		{
+			name:     "checkbox list",
+			input:    "- [ ] Unchecked\n- [x] Checked",
+			expected: "- [ ] Unchecked\n- [x] Checked",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := fixListFormatting(tt.input)
+			if result != tt.expected {
+				t.Errorf("fixListFormatting() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnsureSectionSpacing(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "section without spacing",
+			input:    "Text\n## Section\nMore text",
+			expected: "Text\n\n## Section\n\nMore text",
+		},
+		{
+			name:     "section at start",
+			input:    "## Section\nText",
+			expected: "## Section\n\nText",
+		},
+		{
+			name:     "multiple sections",
+			input:    "## First\nText\n## Second\nMore",
+			expected: "## First\n\nText\n\n## Second\n\nMore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureSectionSpacing(tt.input)
+			if result != tt.expected {
+				t.Errorf("ensureSectionSpacing() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/prompts/dashboard/issue_generation.md
+++ b/internal/prompts/dashboard/issue_generation.md
@@ -34,6 +34,37 @@ The "description" field is a markdown document with exactly these sections:
 ## Acceptance Criteria
 [2-5 specific, verifiable criteria for completion, in English. Include edge cases and error scenarios where applicable — what should happen with invalid inputs, empty states, or error conditions.]
 
+MARKDOWN FORMATTING RULES:
+- Use ## for all section headings (Description, Tasks, Files to Modify, Acceptance Criteria)
+- Add blank line before and after each heading
+- Use proper list formatting: "- " for bullet lists, "1. " for numbered lists
+- Add blank line between list items for readability
+- Use ``` for code blocks with language identifier when applicable
+- Ensure all code blocks are properly closed
+- No trailing whitespace on any line
+- End document with a single newline
+
+EXAMPLE OF PROPER FORMATTING:
+
+## Description
+
+This is the description text.
+
+## Tasks
+
+1. First task with details
+2. Second task with details
+
+## Files to Modify
+
+- internal/example/file.go - Add new function
+- internal/example/other.go - Update existing logic
+
+## Acceptance Criteria
+
+- [ ] Criterion one
+- [ ] Criterion two
+
 CRITICAL RULES:
 - ALL text MUST be in English — title, description, tasks, criteria, everything
 - NO implementation code, algorithms, or design patterns


### PR DESCRIPTION
Closes #468

## Description
The markdown formatting used in review issues created by the wizard produces poorly formatted output that doesn't render well on GitHub. The current formatter generates markdown with inconsistent spacing, improper heading levels, or formatting that breaks GitHub's markdown rendering. This makes review issues hard to read and unprofessional.

## Tasks
1. Analyze the current markdown output format in `internal/prompts/dashboard/issue_generation.md` to identify formatting issues
2. Review how the `TechnicalPlanning` field content is formatted before being sent to GitHub in `internal/dashboard/handlers.go` around line 2077
3. Fix the markdown template in `internal/prompts/dashboard/issue_generation.md` to ensure proper GitHub-flavored markdown formatting
4. Add markdown validation or cleanup logic in `internal/dashboard/handlers.go` before issue creation if needed
5. Test the fix by creating a sample issue and verifying it renders correctly on GitHub

## Files to Modify
- `internal/prompts/dashboard/issue_generation.md` — Fix markdown template formatting rules and examples
- `internal/dashboard/handlers.go` — Add markdown cleanup/validation before issue creation (around line 2077 where `session.TechnicalPlanning` is used)
- `internal/dashboard/prompts.go` — Review and fix any markdown formatting in schema descriptions if needed

## Acceptance Criteria
- [ ] Review issues created by the wizard display correctly on GitHub with proper markdown rendering
- [ ] All sections (Description, Tasks, Files to Modify, Acceptance Criteria) are properly formatted with consistent heading levels
- [ ] No broken markdown syntax (unclosed code blocks, improper list formatting, etc.)
- [ ] The markdown passes a markdown linter without errors
- [ ] Sample issue created for testing renders correctly in GitHub's issue view