### PR TITLE
Auto-detect new sprint/milestone changes in SyncService

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -143,3 +143,11 @@ Issues with these labels block new work:
 - Progress saved to SQLite database after each step
 - On restart, resumes from last completed step
 - Branch and worktree preserved across restarts
+
+### Milestone Auto-Detection
+
+The sync service automatically detects when a new sprint (milestone) is created:
+- Every 30 seconds, checks if the oldest open milestone has changed
+- When a new sprint is detected, immediately switches to sync issues from the new sprint
+- No restart required - seamless transition between sprints
+- Orchestrator independently fetches the latest milestone each iteration

--- a/internal/dashboard/sync.go
+++ b/internal/dashboard/sync.go
@@ -13,6 +13,7 @@ import (
 type GitHubClient interface {
 	ListIssuesWithPRStatus(milestone string) ([]github.Issue, error)
 	AddLabel(issueNum int, label string) error
+	GetOldestOpenMilestone() (*github.Milestone, error)
 }
 
 // Store defines the interface for database operations needed by SyncService
@@ -150,14 +151,33 @@ func (s *SyncService) syncNow() {
 
 // doSync performs the actual synchronization work
 func (s *SyncService) doSync() {
-	milestone := s.GetActiveMilestone()
-	if milestone == "" {
-		log.Println("[SyncService] No active milestone set, skipping sync")
+	if s.gh == nil {
+		log.Println("[SyncService] No GitHub client set, skipping sync")
 		return
 	}
 
-	if s.gh == nil {
-		log.Println("[SyncService] No GitHub client set, skipping sync")
+	// Check for milestone change first
+	currentMilestone := s.GetActiveMilestone()
+	latestMilestone, err := s.gh.GetOldestOpenMilestone()
+	switch {
+	case err != nil:
+		log.Printf("[SyncService] Error checking for new milestone: %v", err)
+	case latestMilestone == nil:
+		// No open milestones at all
+		if currentMilestone != "" {
+			log.Printf("[SyncService] No open milestones found (was: %s), stopping sync", currentMilestone)
+			s.SetActiveMilestone("")
+		}
+		return
+	case latestMilestone.Title != currentMilestone:
+		log.Printf("[SyncService] Milestone change detected: %s (was: %s)",
+			latestMilestone.Title, currentMilestone)
+		s.SetActiveMilestone(latestMilestone.Title)
+	}
+
+	milestone := s.GetActiveMilestone()
+	if milestone == "" {
+		log.Println("[SyncService] No active milestone set, skipping sync")
 		return
 	}
 

--- a/internal/dashboard/sync_milestone_test.go
+++ b/internal/dashboard/sync_milestone_test.go
@@ -1,0 +1,237 @@
+package dashboard
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/crazy-goat/one-dev-army/internal/github"
+)
+
+// mockGitHubClientWithMilestone extends mockGitHubClient to support milestone switching
+type mockGitHubClientWithMilestone struct {
+	mockGitHubClient
+	milestones     []*github.Milestone
+	milestoneIndex int
+	milestoneErr   error
+}
+
+func (m *mockGitHubClientWithMilestone) GetOldestOpenMilestone() (*github.Milestone, error) {
+	if m.milestoneErr != nil {
+		return nil, m.milestoneErr
+	}
+	if m.milestoneIndex >= len(m.milestones) {
+		return nil, nil
+	}
+	milestone := m.milestones[m.milestoneIndex]
+	return milestone, nil
+}
+
+func (m *mockGitHubClientWithMilestone) setNextMilestone(index int) {
+	m.milestoneIndex = index
+}
+
+func TestSyncService_AutoDetectsNewMilestone(t *testing.T) {
+	milestoneA := &github.Milestone{Number: 1, Title: "Sprint 1"}
+	milestoneB := &github.Milestone{Number: 2, Title: "Sprint 2"}
+
+	gh := &mockGitHubClientWithMilestone{
+		milestones: []*github.Milestone{milestoneA, milestoneB},
+	}
+	gh.issues = []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open"},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+
+	// First sync - should detect and set Sprint 1
+	gh.setNextMilestone(0)
+	service.syncNow()
+
+	if got := service.GetActiveMilestone(); got != "Sprint 1" {
+		t.Errorf("Expected milestone 'Sprint 1' after first sync, got %q", got)
+	}
+
+	// Second sync - should auto-detect and switch to Sprint 2
+	gh.setNextMilestone(1)
+	service.syncNow()
+
+	if got := service.GetActiveMilestone(); got != "Sprint 2" {
+		t.Errorf("Expected milestone 'Sprint 2' after second sync, got %q", got)
+	}
+}
+
+func TestSyncService_HandlesNoMilestone(t *testing.T) {
+	gh := &mockGitHubClientWithMilestone{
+		milestones: []*github.Milestone{},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+	service.SetActiveMilestone("Sprint 1")
+
+	// Sync with no milestones available
+	gh.setNextMilestone(0)
+	service.syncNow()
+
+	// Should clear the active milestone
+	if got := service.GetActiveMilestone(); got != "" {
+		t.Errorf("Expected empty milestone when none available, got %q", got)
+	}
+
+	// Should not cache any issues
+	if len(store.cachedIssues) != 0 {
+		t.Errorf("Expected 0 cached issues when no milestone, got %d", len(store.cachedIssues))
+	}
+}
+
+func TestSyncService_HandlesMilestoneClosedExternally(t *testing.T) {
+	milestoneA := &github.Milestone{Number: 1, Title: "Sprint 1"}
+	milestoneB := &github.Milestone{Number: 2, Title: "Sprint 2"}
+
+	gh := &mockGitHubClientWithMilestone{
+		milestones: []*github.Milestone{milestoneA, milestoneB},
+	}
+	gh.issues = []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open"},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+
+	// Start with Sprint 1
+	service.SetActiveMilestone("Sprint 1")
+
+	// Simulate Sprint 1 being closed externally - now Sprint 2 is the oldest open
+	gh.setNextMilestone(1)
+	service.syncNow()
+
+	// Should automatically switch to Sprint 2
+	if got := service.GetActiveMilestone(); got != "Sprint 2" {
+		t.Errorf("Expected milestone 'Sprint 2' after external close, got %q", got)
+	}
+}
+
+func TestSyncService_SameMilestoneNoChange(t *testing.T) {
+	milestoneA := &github.Milestone{Number: 1, Title: "Sprint 1"}
+
+	gh := &mockGitHubClientWithMilestone{
+		milestones: []*github.Milestone{milestoneA, milestoneA},
+	}
+	gh.issues = []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open"},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+
+	// Set Sprint 1 as active
+	service.SetActiveMilestone("Sprint 1")
+
+	// Sync - milestone hasn't changed
+	gh.setNextMilestone(0)
+	service.syncNow()
+
+	// Should still be Sprint 1
+	if got := service.GetActiveMilestone(); got != "Sprint 1" {
+		t.Errorf("Expected milestone 'Sprint 1' to remain unchanged, got %q", got)
+	}
+
+	// Should have cached issues
+	if len(store.cachedIssues) != 1 {
+		t.Errorf("Expected 1 cached issue, got %d", len(store.cachedIssues))
+	}
+}
+
+func TestSyncService_SameTitleDifferentNumber(t *testing.T) {
+	// Simulate milestone recreation with same title but different number
+	milestoneA := &github.Milestone{Number: 1, Title: "Sprint 1"}
+	milestoneB := &github.Milestone{Number: 2, Title: "Sprint 1"}
+
+	gh := &mockGitHubClientWithMilestone{
+		milestones: []*github.Milestone{milestoneA, milestoneB},
+	}
+	gh.issues = []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open"},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+
+	// Start with original Sprint 1 (number 1)
+	service.SetActiveMilestone("Sprint 1")
+
+	// Simulate milestone recreation - same title, different number
+	gh.setNextMilestone(1)
+	service.syncNow()
+
+	// Title is the same, so no change detected (this is expected behavior)
+	if got := service.GetActiveMilestone(); got != "Sprint 1" {
+		t.Errorf("Expected milestone 'Sprint 1' (same title), got %q", got)
+	}
+}
+
+func TestSyncService_MilestoneErrorHandling(t *testing.T) {
+	gh := &mockGitHubClientWithMilestone{
+		milestoneErr: errors.New("github api error"),
+	}
+	gh.issues = []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open"},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+	service.SetActiveMilestone("Sprint 1")
+
+	// Sync with error in milestone detection
+	service.syncNow()
+
+	// Should continue with existing milestone
+	if got := service.GetActiveMilestone(); got != "Sprint 1" {
+		t.Errorf("Expected milestone 'Sprint 1' to remain after error, got %q", got)
+	}
+
+	// Should still sync issues from existing milestone
+	if len(store.cachedIssues) != 1 {
+		t.Errorf("Expected 1 cached issue despite milestone error, got %d", len(store.cachedIssues))
+	}
+}
+
+func TestSyncService_NoMilestoneThenNewMilestoneAppears(t *testing.T) {
+	milestoneA := &github.Milestone{Number: 1, Title: "Sprint 1"}
+
+	gh := &mockGitHubClientWithMilestone{
+		milestones: []*github.Milestone{nil, milestoneA},
+	}
+	gh.issues = []github.Issue{
+		{Number: 1, Title: "Issue 1", State: "open"},
+	}
+
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+
+	// First sync - no milestones available
+	gh.setNextMilestone(0)
+	service.syncNow()
+
+	if got := service.GetActiveMilestone(); got != "" {
+		t.Errorf("Expected empty milestone initially, got %q", got)
+	}
+
+	// Clear store for second sync
+	store.clearCachedIssues()
+
+	// Second sync - new milestone appears
+	gh.setNextMilestone(1)
+	service.syncNow()
+
+	// Should detect and set the new milestone
+	if got := service.GetActiveMilestone(); got != "Sprint 1" {
+		t.Errorf("Expected milestone 'Sprint 1' after new milestone appears, got %q", got)
+	}
+
+	// Should sync issues from the new milestone
+	if len(store.cachedIssues) != 1 {
+		t.Errorf("Expected 1 cached issue from new milestone, got %d", len(store.cachedIssues))
+	}
+}

--- a/internal/dashboard/sync_test.go
+++ b/internal/dashboard/sync_test.go
@@ -11,10 +11,11 @@ import (
 
 // mockGitHubClient is a test double for GitHubClient interface
 type mockGitHubClient struct {
-	mu        sync.Mutex
-	issues    []github.Issue
-	listErr   error
-	milestone string
+	mu              sync.Mutex
+	issues          []github.Issue
+	listErr         error
+	milestone       string
+	oldestMilestone *github.Milestone
 }
 
 func (m *mockGitHubClient) ListIssuesWithPRStatus(milestone string) ([]github.Issue, error) {
@@ -32,6 +33,15 @@ func (m *mockGitHubClient) ListIssuesWithPRStatus(milestone string) ([]github.Is
 
 func (*mockGitHubClient) AddLabel(_ int, _ string) error {
 	return nil
+}
+
+func (m *mockGitHubClient) GetOldestOpenMilestone() (*github.Milestone, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.oldestMilestone != nil {
+		return m.oldestMilestone, nil
+	}
+	return nil, nil
 }
 
 // mockStore is a test double for Store interface
@@ -110,6 +120,7 @@ func TestSyncService_StartStop(t *testing.T) {
 		issues: []github.Issue{
 			{Number: 1, Title: "Issue 1", State: "open"},
 		},
+		oldestMilestone: &github.Milestone{Number: 1, Title: "Sprint 1"},
 	}
 	store := &mockStore{}
 	service := NewSyncService(gh, store, nil, nil)
@@ -135,7 +146,9 @@ func TestSyncService_StartStop(t *testing.T) {
 }
 
 func TestSyncService_Start_AlreadyRunning(t *testing.T) {
-	gh := &mockGitHubClient{}
+	gh := &mockGitHubClient{
+		oldestMilestone: &github.Milestone{Number: 1, Title: "Sprint 1"},
+	}
 	store := &mockStore{}
 	service := NewSyncService(gh, store, nil, nil)
 	service.SetActiveMilestone("Sprint 1")
@@ -241,6 +254,7 @@ func TestSyncService_syncNow_Success(t *testing.T) {
 			{Number: 2, Title: "Issue 2", State: "closed"},
 			{Number: 3, Title: "Issue 3", State: "open"},
 		},
+		oldestMilestone: &github.Milestone{Number: 1, Title: "Sprint 1"},
 	}
 	store := &mockStore{}
 	service := NewSyncService(gh, store, nil, nil)
@@ -263,6 +277,7 @@ func TestSyncService_SyncNow_ManualTrigger(t *testing.T) {
 		issues: []github.Issue{
 			{Number: 1, Title: "Issue 1"},
 		},
+		oldestMilestone: &github.Milestone{Number: 1, Title: "Sprint 1"},
 	}
 	store := &mockStore{}
 	service := NewSyncService(gh, store, nil, nil)
@@ -338,6 +353,7 @@ func TestSyncService_syncNow_FetchesPRStatus(t *testing.T) {
 			{Number: 2, Title: "Merged Issue", State: "CLOSED", PRMerged: true, MergedAt: &mergedAt},
 			{Number: 3, Title: "Closed Issue", State: "CLOSED"},
 		},
+		oldestMilestone: &github.Milestone{Number: 1, Title: "Sprint 1"},
 	}
 	store := &mockStore{}
 	service := NewSyncService(gh, store, nil, nil)


### PR DESCRIPTION
Closes #482

## Problem

Currently, the SyncService caches the active milestone only once at startup and never updates it. When a new sprint is created (via GitHub UI or other means), the Orchestrator correctly detects it in each loop iteration using `GetOldestOpenMilestone()`, but the SyncService continues syncing issues from the old sprint.

This causes:
- New issues in the new sprint never get cached
- Orchestrator finds 0 candidates even though issues exist
- ODA appears "stuck" and won't pick up new work
- Requires manual restart of ODA to fix

## Solution

Add milestone auto-detection to SyncService's 30-second sync cycle:
1. Before syncing issues, check if the oldest open milestone has changed
2. If a new milestone is detected, automatically switch to it
3. Handle edge cases: no milestones (all closed), milestone closed externally
4. Update both SyncService and GitHub client's active milestone

## Edge Cases to Handle

1. **No active milestone** - When all milestones are closed, stop syncing and log warning
2. **Milestone closed externally** - When someone closes milestone via GitHub UI, detect next open milestone
3. **Close sprint via dashboard** - Already works (handlers.go:835-840), verify it still works after changes
4. **Same milestone title, different number** - Handle case where milestone is recreated with same name

## Implementation Plan

See: `docs/plans/2026-03-27-auto-detect-milestone.md`

Key changes:
- Extend `GitHubClient` interface in `internal/dashboard/sync.go` to include `GetOldestOpenMilestone()`
- Add milestone detection logic in `doSync()` method
- Update mock in tests to support new interface method
- Add comprehensive tests for milestone switching and edge cases

## Acceptance Criteria

- [ ] SyncService automatically detects new milestones within 30 seconds
- [ ] When new sprint is created via GitHub UI, ODA starts syncing its issues without restart
- [ ] When all milestones are closed, SyncService stops syncing gracefully
- [ ] Close sprint via dashboard still works correctly
- [ ] All existing tests pass
- [ ] New tests added for milestone auto-detection
- [ ] Lint passes: `golangci-lint run ./...`
- [ ] Documentation updated in `docs/workflow.md`