### PR TITLE
[Bug] Add missing emoji to Approve+Merge stage display

### DIFF
--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -425,7 +425,7 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
           {{if .Labels}}<div class="card-meta"><div class="card-labels">{{range .Labels}}{{if not (labelIcon .)}}<span class="label">{{.}}</span>{{end}}{{end}}</div></div>{{end}}
           {{if .Assignee}}<div class="card-meta"><div class="card-assignee">@{{.Assignee}}</div></div>{{end}}
           <div class="card-actions">
-            <form method="post" action="/approve-merge/{{.ID}}"><button type="submit" class="btn btn-success">Approve & Merge</button></form>
+            <form method="post" action="/approve-merge/{{.ID}}"><button type="submit" class="btn btn-success">✅ Approve & Merge</button></form>
             <button type="button" class="btn btn-danger" onclick="openDeclineModal({{.ID}}, '{{.Title}}')">Decline</button>
           </div>
         </div>

--- a/web/src/components/board/TaskCard.tsx
+++ b/web/src/components/board/TaskCard.tsx
@@ -205,7 +205,7 @@ export function TaskCard({ card, column, columnKey }: TaskCardProps) {
               disabled={approveMerge.isPending}
               className="px-2 py-1 text-xs rounded bg-green-600 hover:bg-green-500 text-white font-medium transition-colors disabled:opacity-50"
             >
-              &check; Approve+Merge
+              ✅ Approve+Merge
             </button>
             <button
               type="button"

--- a/web/src/components/task/ActionButtons.tsx
+++ b/web/src/components/task/ActionButtons.tsx
@@ -62,7 +62,7 @@ export function ActionButtons({ issueNumber, status }: ActionButtonsProps) {
               disabled={approveMerge.isPending}
               className="px-4 py-2 rounded-lg bg-green-600 hover:bg-green-500 text-white font-medium text-sm transition-colors disabled:opacity-50"
             >
-              &check; Approve &amp; Merge
+              ✅ Approve &amp; Merge
             </button>
             <button
               type="button"


### PR DESCRIPTION
Closes #470

## Description
The Approve+Merge stage or button in the dashboard UI is missing its emoji indicator, breaking visual consistency with other pipeline stages that all display emojis.

## Tasks
1. Locate the Approve+Merge UI component in the dashboard package
2. Add the appropriate emoji (✅ or similar) to the Approve+Merge label or button
3. Verify the emoji displays correctly in both light and dark mode
4. Check that the emoji is properly escaped/rendered in HTML templates

## Files to Modify
- `internal/dashboard/templates/` — Add emoji to Approve+Merge stage display
- `internal/dashboard/static/css/` — Verify emoji styling if needed

## Acceptance Criteria
1. Approve+Merge stage displays an emoji consistent with other stages (e.g., ✅)
2. Emoji renders correctly in the dashboard UI
3. No visual regression in button sizing or layout
4. Emoji displays properly in both light and dark color schemes