### PR TITLE
Fix PR body escaping for special characters in CreatePR

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -159,7 +160,23 @@ func (c *Client) RemoveLabel(issueNum int, label string) error {
 }
 
 func (c *Client) CreatePR(branch, title, body string) (string, error) {
-	out, err := c.gh("pr", "create", "--head", branch, "--title", title, "--body", body)
+	// Create temporary file for body content to avoid shell escaping issues
+	tmpFile, err := os.CreateTemp("", "oda-pr-body-*.md")
+	if err != nil {
+		return "", fmt.Errorf("creating temp file for PR body: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(body); err != nil {
+		tmpFile.Close()
+		return "", fmt.Errorf("writing PR body to temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("closing temp file: %w", err)
+	}
+
+	out, err := c.gh("pr", "create", "--head", branch, "--title", title, "--body-file", tmpFile.Name())
 	if err != nil {
 		return "", fmt.Errorf("creating PR for branch %s: %w", branch, err)
 	}

--- a/internal/github/issues_test.go
+++ b/internal/github/issues_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"os"
 	"testing"
 )
 
@@ -164,4 +165,93 @@ func stringSlicesEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// TestCreatePRBodyHandling tests that CreatePR properly handles special characters in PR body
+// by verifying the temp file creation logic works correctly
+func TestCreatePRBodyHandling(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "body with double quotes",
+			body: `This PR fixes the "bug" in the system`,
+		},
+		{
+			name: "body with backticks and code",
+			body: "Use `http://localhost:5002` for testing",
+		},
+		{
+			name: "body with unicode characters",
+			body: "Fixed the navigation → settings flow",
+		},
+		{
+			name: "body with newlines",
+			body: "Line 1\nLine 2\nLine 3",
+		},
+		{
+			name: "body with markdown formatting",
+			body: "## Changes\n\n- [x] Fixed bug\n- [ ] Add tests",
+		},
+		{
+			name: "body with code block",
+			body: "```go\nfunc main() {\n  fmt.Println(\"hello\")\n}\n```",
+		},
+		{
+			name: "empty body",
+			body: "",
+		},
+		{
+			name: "body with single quotes",
+			body: "It's working now",
+		},
+		{
+			name: "body with mixed special chars",
+			body: "Fix \"bug\" with \n```code``` and → arrow",
+		},
+		{
+			name: "body with dollar signs",
+			body: "Price is $100 and $200",
+		},
+		{
+			name: "body with backslashes",
+			body: "Path is C:\\Users\\test\\file.txt",
+		},
+		{
+			name: "body with tabs",
+			body: "Column1\tColumn2\tColumn3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test that we can create a temp file and write the body content
+			// This validates the approach used in CreatePR
+			tmpFile, err := os.CreateTemp("", "oda-pr-body-*.md")
+			if err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			defer os.Remove(tmpFile.Name())
+
+			if _, err := tmpFile.WriteString(tt.body); err != nil {
+				tmpFile.Close()
+				t.Fatalf("Failed to write body to temp file: %v", err)
+			}
+
+			if err := tmpFile.Close(); err != nil {
+				t.Fatalf("Failed to close temp file: %v", err)
+			}
+
+			// Read back and verify content
+			content, err := os.ReadFile(tmpFile.Name())
+			if err != nil {
+				t.Fatalf("Failed to read temp file: %v", err)
+			}
+
+			if string(content) != tt.body {
+				t.Errorf("Body content mismatch:\ngot: %q\nwant: %q", string(content), tt.body)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #487

## Problem

When ODA creates a Pull Request via `gh pr create`, the issue body is passed directly as the `--body` argument without proper escaping. This can cause failures when the issue body contains special characters like:

- Double quotes (`"`) - can break the command argument structure
- Backticks (`` ` ``) - may be interpreted by shell
- Unicode characters (e.g., `→`) - may cause encoding issues
- Newlines and markdown formatting

## Current Behavior

In `internal/github/issues.go:162`:
```go
out, err := c.gh("pr", "create", "--head", branch, "--title", title, "--body", body)
```

The `body` string is passed directly to `exec.Command()` without escaping. While `exec.Command()` doesn't use shell interpretation, the `gh` CLI may still have issues with unescaped special characters in the `--body` argument.

## Example Failure Case

Issue #462 had body containing:
- Backticks around code: `` `http://localhost:5002` ``
- Unicode arrow: `→`
- Markdown checkboxes: `[x]`

This resulted in:
```
pull request create failed: GraphQL: No commits between master and oda-462-...
```

While the error message suggests "no commits", the root cause may be related to how the body is formatted when creating the PR.

## Expected Behavior

The PR body should be properly escaped/quoted to handle:
1. Double quotes within the text
2. Backticks and other shell-sensitive characters
3. Unicode characters
4. Multi-line markdown content

## Proposed Solutions

### Option 1: Use file-based body (Recommended)
Write the body to a temporary file and use `--body-file` flag:
```go
bodyFile := "/tmp/pr_body_" + branch + ".md"
ioutil.WriteFile(bodyFile, []byte(body), 0644)
out, err := c.gh("pr", "create", "--head", branch, "--title", title, "--body-file", bodyFile)
os.Remove(bodyFile)
```

### Option 2: Proper string escaping
Escape special characters in the body before passing to command:
- Replace `"` with `\"`
- Handle newlines properly
- Consider base64 encoding for complex content

## Acceptance Criteria

- [ ] PR creation works reliably with any issue body content
- [ ] Special characters (quotes, backticks, unicode) don't break PR creation
- [ ] Multi-line markdown bodies are preserved correctly
- [ ] All existing tests pass
- [ ] Add test cases for bodies with special characters
- [ ] Linter passes: `golangci-lint run ./...`

## Files to Modify

- `internal/github/issues.go` - `CreatePR` function
- `internal/github/issues_test.go` - add tests for special characters

## Related

Issue #462 failed during PR creation, potentially due to this problem.