### PR TITLE
[Feature] Simplify sprint header by removing yolo 

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5319,9 +5319,9 @@ func TestHandleBoard_SprintNameInHeader(t *testing.T) {
 
 	output := buf.String()
 
-	// Verify the h1 contains the sprint name
-	if !strings.Contains(output, "<h1>Sprint 2026-03-25 07:54</h1>") {
-		t.Errorf("expected h1 to contain sprint name 'Sprint 2026-03-25 07:54', got: %s", output)
+	// Verify the h1 contains just "Sprint" (without timestamp)
+	if !strings.Contains(output, "<h1>Sprint</h1>") {
+		t.Errorf("expected h1 to contain 'Sprint' (without timestamp), got: %s", output)
 	}
 
 	// Verify the old subtitle p element is NOT present

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -258,7 +258,7 @@
 
 <div class="board-header">
   <div>
-    <h1>{{if .SprintName}}{{.SprintName}}{{else}}Sprint Board{{end}}</h1>
+    <h1>{{if .SprintName}}Sprint{{else}}Sprint Board{{end}}</h1>
   </div>
   {{if gt .TotalTickets 0}}
   <div class="sprint-status">


### PR DESCRIPTION
Closes #472

## Description
The sprint board header currently displays the full timestamp-based sprint name (e.g., "Sprint 2026-03-27 06:49") along with a YOLO mode indicator. Since the YOLO mode is already shown in the bottom status bar, the header should be simplified to display only "Sprint name"

## Tasks
1. Modify `internal/dashboard/templates/board.html` line 199 to strip the timestamp from `.SprintName` before displaying it in the h1 element
2. Update `internal/dashboard/handlers_test.go` test cases to expect "Sprint" instead of the full timestamp-based name in the header
3. Verify the YOLO mode indicator remains visible only in the bottom bar and does not appear in the sprint header

## Files to Modify
- `internal/dashboard/templates/board.html` — Update h1 element to display simplified sprint name without timestamp
- `internal/dashboard/handlers_test.go` — Update test expectations for sprint name display

## Acceptance Criteria
- [ ] Sprint header displays only "Sprint" without the timestamp (e.g., "Sprint" instead of "Sprint 2026-03-27 06:49")
- [ ] YOLO mode indicator does not appear in the sprint header
- [ ] YOLO mode indicator remains visible in the bottom status bar
- [ ] When no active sprint exists, "Sprint Board" fallback text is still displayed correctly
- [ ] All existing tests pass with updated expectations