### PR TITLE
[Bug] Fix inconsistent size label emojis in ProcessingPanel and board template

### DIFF
--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -5474,7 +5474,7 @@ func TestBoardTemplate_ProcessingPanel_Visible(t *testing.T) {
 	}
 
 	// Verify size badge is present
-	if !strings.Contains(output, "📏 L") {
+	if !strings.Contains(output, "🐘 L") {
 		t.Error("template should contain size L badge")
 	}
 
@@ -5719,10 +5719,10 @@ func TestBoardTemplate_ProcessingPanel_SizeVariations(t *testing.T) {
 		size          string
 		expectedBadge string
 	}{
-		{"size S", "S", "📏 S"},
-		{"size M", "M", "📏 M"},
-		{"size L", "L", "📏 L"},
-		{"size XL", "XL", "📏 XL"},
+		{"size S", "S", "🐜 S"},
+		{"size M", "M", "🐕 M"},
+		{"size L", "L", "🐘 L"},
+		{"size XL", "XL", "🦕 XL"},
 	}
 
 	for _, tt := range tests {

--- a/internal/dashboard/templates/board.html
+++ b/internal/dashboard/templates/board.html
@@ -545,7 +545,9 @@ document.getElementById('process-modal').addEventListener('click', function(e) {
           </span>
           {{end}}
           {{if .CurrentTicket.Size}}
-          <span class="processing-badge">📏 {{.CurrentTicket.Size}}</span>
+          <span class="processing-badge">
+            {{if eq .CurrentTicket.Size "S"}}🐜{{else if eq .CurrentTicket.Size "M"}}🐕{{else if eq .CurrentTicket.Size "L"}}🐘{{else if eq .CurrentTicket.Size "XL"}}🦕{{else}}📏{{end}} {{.CurrentTicket.Size}}
+          </span>
           {{end}}
         </div>
         <a href="/task/{{.CurrentTicket.Number}}" class="processing-ticket">

--- a/web/src/components/board/ProcessingPanel.tsx
+++ b/web/src/components/board/ProcessingPanel.tsx
@@ -41,9 +41,15 @@ function typeBadge(type: string) {
 }
 
 function sizeBadge(size: string) {
+  const sizeEmojis: Record<string, string> = {
+    S: '\uD83D\uDC1C',
+    M: '\uD83D\uDC15',
+    L: '\uD83D\uDC18',
+    XL: '\uD83E\uDD95',
+  }
   return (
     <span className="text-xs px-2 py-0.5 rounded border border-gray-700 bg-gray-800 text-gray-400">
-      \uD83D\uDCCF {size}
+      {sizeEmojis[size] ?? '\uD83D\uDCCF'} {size}
     </span>
   )
 }


### PR DESCRIPTION
Closes #476

## Description
The size labels in ProcessingPanel.tsx and board.html use the ruler emoji (📏) which looks inconsistent with the animal emojis used in TaskCard.tsx (🐜 S, 🐕 M, 🐘 L, 🦕 XL). This creates visual inconsistency across the dashboard UI.

## Tasks
1. Update `web/src/components/board/ProcessingPanel.tsx` line 46 to use animal emojis matching TaskCard.tsx logic (🐜 for S, 🐕 for M, 🐘 for L, 🦕 for XL)
2. Update `internal/dashboard/templates/board.html` line 468 to use the same animal emoji mapping for size labels
3. Run tests to verify the changes don't break existing functionality: `go test ./internal/dashboard/...` and `npm test` in web directory
4. Check browser console for any encoding errors when rendering the updated emojis

## Files to Modify
- `web/src/components/board/ProcessingPanel.tsx` - Replace ruler emoji with size-appropriate animal emojis in sizeBadge function
- `internal/dashboard/templates/board.html` - Replace ruler emoji with size-appropriate animal emojis in processing badge

## Acceptance Criteria
- [ ] ProcessingPanel displays 🐜 for size S, 🐕 for M, 🐘 for L, 🦕 for XL instead of 📏
- [ ] Board template displays matching animal emojis for size labels
- [ ] All existing tests pass without modification
- [ ] No console errors related to emoji encoding
- [ ] Visual appearance is consistent between TaskCard, ProcessingPanel, and board.html