### PR TITLE
Add configurable screen wake lock to prevent dashboard from sleeping

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,3 +20,31 @@ Config lives in `.oda/config.yaml`. Key sections:
 - `llm.*` — per-mode model configuration with strong/weak variants
 - `pipeline.max_retries` — max retry attempts before escalating to user
 - `sprint.auto_start` — automatically start sprint on ODA startup (default: `false`)
+- `dashboard.keep_screen_on` — prevent screen sleep when dashboard is open (default: `false`)
+
+## Dashboard Settings
+
+### keep_screen_on
+
+When set to `true`, the dashboard will request a screen wake lock when the page loads, preventing the screen from sleeping/turning off. This is useful for:
+- Monitoring active processing tasks
+- Displaying the board on a shared screen/monitor
+- Keeping an eye on sprint progress during work
+
+```yaml
+dashboard:
+  port: 7000
+  keep_screen_on: true  # Prevent screen sleep
+```
+
+Users can still toggle this on/off from the dashboard UI. The wake lock is automatically released when:
+- The user switches to another tab
+- The user closes the browser tab
+- The user clicks the "Keep Screen On" button to disable it
+
+**Browser Support:**
+- Chrome/Edge: Full support
+- Firefox: 128+
+- Safari: iOS 16.4+ / macOS 14.4+
+
+For unsupported browsers, the toggle button will be disabled with a tooltip explaining the limitation.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,8 @@ type GitHub struct {
 }
 
 type Dashboard struct {
-	Port int `yaml:"port"`
+	Port         int  `yaml:"port"`
+	KeepScreenOn bool `yaml:"keep_screen_on"`
 }
 
 type Workers struct {

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -69,6 +69,7 @@ type boardData struct {
 	CanPlanSprint        bool
 	CurrentTicket        *currentTicketInfo
 	YoloMode             bool
+	KeepScreenOn         bool
 	Blocked              []taskCard
 	Backlog              []taskCard
 	Plan                 []taskCard
@@ -113,12 +114,21 @@ func (s *Server) buildBoardData(_ *http.Request) boardData {
 		yoloMode = *s.yoloOverride
 	}
 
+	// Load config to get keep_screen_on setting
+	keepScreenOn := false
+	if s.rootDir != "" {
+		if cfg, err := config.Load(s.rootDir); err == nil {
+			keepScreenOn = cfg.Dashboard.KeepScreenOn
+		}
+	}
+
 	data := boardData{
 		Active:       "board",
 		OpenCodePort: s.webPort,
 		WorkerCount:  workerCount,
 		Paused:       true,
 		YoloMode:     yoloMode,
+		KeepScreenOn: keepScreenOn,
 	}
 
 	if s.orchestrator != nil {

--- a/internal/dashboard/handlers_test.go
+++ b/internal/dashboard/handlers_test.go
@@ -1047,11 +1047,13 @@ func TestLayoutNavigationButtons(t *testing.T) {
 		OpenCodePort int
 		WorkerCount  int
 		YoloMode     bool
+		KeepScreenOn bool
 	}{
 		Active:       "board",
 		OpenCodePort: 5001,
 		WorkerCount:  1,
 		YoloMode:     false,
+		KeepScreenOn: false,
 	}
 
 	// We need to define a content template for the layout to work

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -258,6 +258,28 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
 .yolo-mode-tooltip-content{font-size:.8rem;line-height:1.4;color:var(--muted)}
 .yolo-mode-tooltip::after{content:'';position:absolute;top:100%;right:1rem;border:6px solid transparent;border-top-color:var(--surface)}
 .yolo-mode-tooltip::before{content:'';position:absolute;top:100%;right:calc(1rem - 1px);border:7px solid transparent;border-top-color:var(--border)}
+
+/* Wake Lock toggle styles */
+#wake-lock-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+#wake-lock-toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+#wake-lock-toggle.active:hover {
+  opacity: 0.9;
+}
+
+#wake-lock-toggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 </style>
 </head>
 <body>
@@ -268,6 +290,10 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
     <a href="/settings" {{if eq .Active "settings"}}class="active"{{end}}>Settings</a>
   </div>
   <div class="nav-actions">
+    <button id="wake-lock-toggle" class="btn" onclick="toggleWakeLock()" title="Prevent screen sleep">
+      <span id="wake-lock-icon">🌙</span>
+      <span id="wake-lock-text">Keep Screen On</span>
+    </button>
     <button class="btn" onclick="window.open('http://localhost:{{.OpenCodePort}}', '_blank')">Chat</button>
     <a href="/wizard" class="btn btn-primary">+ New Issue</a>
   </div>
@@ -345,6 +371,11 @@ footer{background:var(--surface);border-top:1px solid var(--border);padding:.5re
   </div>
 </footer>
 <script>
+// Dashboard configuration from server
+window.dashboardConfig = {
+    keepScreenOn: {{.KeepScreenOn}}
+};
+
 (function() {
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = wsProtocol + '//' + window.location.host + '/ws';
@@ -1148,6 +1179,147 @@ function triggerSync() {
             text.textContent = 'Sync';
         });
 }
+
+// Screen Wake Lock Manager
+(function() {
+    'use strict';
+    
+    class WakeLockManager {
+        constructor() {
+            this.wakeLock = null;
+            this.enabled = false;
+            this.isSupported = 'wakeLock' in navigator;
+        }
+        
+        async requestWakeLock() {
+            if (!this.isSupported) {
+                console.warn('[WakeLock] Screen Wake Lock API not supported');
+                return false;
+            }
+            
+            try {
+                this.wakeLock = await navigator.wakeLock.request('screen');
+                this.enabled = true;
+                
+                this.wakeLock.addEventListener('release', () => {
+                    console.log('[WakeLock] Screen Wake Lock released');
+                    this.wakeLock = null;
+                    this.enabled = false;
+                    updateWakeLockUI();
+                });
+                
+                console.log('[WakeLock] Screen Wake Lock active');
+                return true;
+            } catch (err) {
+                console.error('[WakeLock] Failed to acquire wake lock:', err);
+                this.enabled = false;
+                return false;
+            }
+        }
+        
+        async releaseWakeLock() {
+            if (this.wakeLock) {
+                try {
+                    await this.wakeLock.release();
+                    this.wakeLock = null;
+                    this.enabled = false;
+                    console.log('[WakeLock] Screen Wake Lock released manually');
+                    return true;
+                } catch (err) {
+                    console.error('[WakeLock] Failed to release wake lock:', err);
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        async toggle() {
+            if (this.enabled) {
+                await this.releaseWakeLock();
+            } else {
+                await this.requestWakeLock();
+            }
+            updateWakeLockUI();
+            return this.enabled;
+        }
+        
+        async reacquireIfEnabled() {
+            if (this.enabled && !this.wakeLock) {
+                await this.requestWakeLock();
+                updateWakeLockUI();
+            }
+        }
+    }
+    
+    // Global wake lock manager instance
+    window.wakeLockManager = new WakeLockManager();
+    
+    // UI update function
+    function updateWakeLockUI() {
+        const toggle = document.getElementById('wake-lock-toggle');
+        const icon = document.getElementById('wake-lock-icon');
+        const text = document.getElementById('wake-lock-text');
+        
+        if (!toggle || !icon || !text) return;
+        
+        if (wakeLockManager.enabled) {
+            toggle.classList.add('active');
+            icon.textContent = '☀️';
+            text.textContent = 'Screen On';
+            toggle.title = 'Click to allow screen sleep';
+        } else {
+            toggle.classList.remove('active');
+            icon.textContent = '🌙';
+            text.textContent = 'Keep Screen On';
+            toggle.title = wakeLockManager.isSupported 
+                ? 'Click to prevent screen sleep' 
+                : 'Screen Wake Lock not supported in this browser';
+        }
+        
+        // Disable button if not supported
+        if (!wakeLockManager.isSupported) {
+            toggle.disabled = true;
+            toggle.title = 'Screen Wake Lock API not supported in this browser';
+        }
+    }
+    
+    // Global toggle function
+    window.toggleWakeLock = async function() {
+        if (!wakeLockManager.isSupported) {
+            alert('Screen Wake Lock API is not supported in your browser.\n\nSupported browsers:\n- Chrome/Edge (all versions)\n- Firefox 128+\n- Safari 16.4+ (iOS) / 14.4+ (macOS)');
+            return;
+        }
+        
+        await wakeLockManager.toggle();
+    };
+    
+    // Handle visibility changes (re-acquire when tab becomes visible)
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') {
+            wakeLockManager.reacquireIfEnabled();
+        }
+    });
+    
+    // Initialize UI on page load
+    document.addEventListener('DOMContentLoaded', () => {
+        updateWakeLockUI();
+        
+        // Auto-enable if configured in dashboard config
+        const dashboardConfig = window.dashboardConfig || {};
+        if (dashboardConfig.keepScreenOn && wakeLockManager.isSupported) {
+            wakeLockManager.requestWakeLock().then(() => {
+                updateWakeLockUI();
+            });
+        }
+    });
+    
+    // Release wake lock when page is unloaded
+    window.addEventListener('beforeunload', () => {
+        if (wakeLockManager.enabled) {
+            wakeLockManager.releaseWakeLock();
+        }
+    });
+})();
 </script>
 </body>
 </html>{{end}}


### PR DESCRIPTION
Closes #498

## Problem

When using the ODA dashboard for extended periods (e.g., monitoring sprint progress, watching processing status), the screen goes to sleep/turns off after the system's default timeout. This is inconvenient for users who want to keep the dashboard visible at all times, especially when:
- Monitoring active processing tasks
- Displaying the board on a shared screen/monitor
- Keeping an eye on sprint progress during work

## Proposed Solution

Add a configurable option to prevent screen sleep using the Screen Wake Lock API. This should be:
1. **Optional** - disabled by default (opt-in for security/battery reasons)
2. **Configurable** - via `config.yaml` 
3. **Toggleable** - users can enable/disable from the dashboard UI

## Technical Implementation

### 1. Config Option

Add to `config.yaml`:
```yaml
dashboard:
    port: 7000
    keep_screen_on: false  # New option, default false
```

Update `internal/config/config.go`:
```go
type Dashboard struct {
    Port         int  `yaml:"port"`
    KeepScreenOn bool `yaml:"keep_screen_on"`
}
```

### 2. Frontend Implementation

Add Screen Wake Lock API support to the dashboard JavaScript:

```javascript
// Screen Wake Lock management
class WakeLockManager {
    constructor() {
        this.wakeLock = null;
        this.enabled = false;
    }

    async requestWakeLock() {
        if ('wakeLock' in navigator) {
            try {
                this.wakeLock = await navigator.wakeLock.request('screen');
                this.wakeLock.addEventListener('release', () => {
                    console.log('Screen Wake Lock released');
                    this.wakeLock = null;
                });
                this.enabled = true;
                console.log('Screen Wake Lock active');
            } catch (err) {
                console.error('Failed to acquire wake lock:', err);
                this.enabled = false;
            }
        } else {
            console.warn('Screen Wake Lock API not supported');
        }
    }

    async releaseWakeLock() {
        if (this.wakeLock) {
            await this.wakeLock.release();
            this.wakeLock = null;
            this.enabled = false;
        }
    }

    toggle() {
        if (this.enabled) {
            this.releaseWakeLock();
        } else {
            this.requestWakeLock();
        }
    }
}

// Initialize with config setting
const wakeLockManager = new WakeLockManager();

// Auto-enable if configured
if (dashboardConfig.keepScreenOn) {
    wakeLockManager.requestWakeLock();
}

// Handle visibility changes (re-acquire when tab becomes visible)
document.addEventListener('visibilitychange', () => {
    if (document.visibilityState === 'visible' && wakeLockManager.enabled) {
        wakeLockManager.requestWakeLock();
    }
});
```

### 3. UI Toggle

Add a toggle button in the dashboard header/settings:

```html
<!-- In dashboard header or settings panel -->
<button id="wake-lock-toggle" class="btn btn-sm" title="Prevent screen sleep">
    <span id="wake-lock-icon">🌙</span> Keep Screen On
</button>

<script>
document.getElementById('wake-lock-toggle').addEventListener('click', () => {
    wakeLockManager.toggle();
    updateWakeLockIcon();
});

function updateWakeLockIcon() {
    const icon = document.getElementById('wake-lock-icon');
    icon.textContent = wakeLockManager.enabled ? '☀️' : '🌙';
}
</script>
```

### 4. Backend Integration

Pass config setting to frontend via template or API:

```go
// In dashboard handler
data := BoardData{
    // ... existing fields
    KeepScreenOn: cfg.Dashboard.KeepScreenOn,
}
```

```html
<!-- In template -->
<script>
window.dashboardConfig = {
    keepScreenOn: {{.KeepScreenOn}}
};
</script>
```

## Browser Compatibility

- **Chrome/Edge**: Full support (Screen Wake Lock API)
- **Firefox**: Supported since v128
- **Safari**: Supported since iOS 16.4 / macOS 14.4
- **Fallback**: For unsupported browsers, show a warning or use legacy NoSleep.js library

## Alternative: NoSleep.js Fallback

For older browsers, we could include NoSleep.js as a fallback:

```javascript
// Fallback for browsers without native Wake Lock API
if (!('wakeLock' in navigator)) {
    // Load NoSleep.js dynamically
    const script = document.createElement('script');
    script.src = '/assets/nosleep.min.js';
    script.onload = () => {
        window.noSleep = new NoSleep();
    };
    document.head.appendChild(script);
}
```

## Files to Modify

1. **internal/config/config.go**
   - Add `KeepScreenOn bool` to `Dashboard` struct

2. **internal/dashboard/handlers.go**
   - Pass `KeepScreenOn` to template data

3. **internal/dashboard/templates/layout.html** or **board.html**
   - Add JavaScript for Wake Lock API
   - Add toggle button to UI
   - Inject config setting

4. **docs/configuration.md**
   - Document the new `keep_screen_on` option

## Configuration Example

```yaml
# .oda/config.yaml
dashboard:
    port: 7000
    keep_screen_on: true  # Prevent screen sleep when dashboard is open
```

## Acceptance Criteria

- [ ] New config option `dashboard.keep_screen_on` added (default: false)
- [ ] Config option properly parsed and available in dashboard handlers
- [ ] Screen Wake Lock API implemented in frontend JavaScript
- [ ] UI toggle button added to dashboard (header or settings)
- [ ] Wake lock is released when user leaves the page/closes tab
- [ ] Wake lock is re-acquired when tab becomes visible again (if enabled)
- [ ] Graceful fallback for unsupported browsers (console warning)
- [ ] Config documentation updated
- [ ] All existing tests pass
- [ ] Linter passes: `golangci-lint run ./...`

## Security & Privacy Considerations

1. **Opt-in only** - Must be explicitly enabled in config (default false)
2. **User control** - UI toggle allows users to disable even if config is enabled
3. **Page visibility** - Wake lock is automatically released when tab is hidden
4. **No persistent permission** - Each page load requires new wake lock request

## Benefits

1. **Better UX** - Dashboard stays visible during long processing tasks
2. **Monitoring** - Useful for shared screens/kiosks showing sprint status
3. **Battery conscious** - Only active when explicitly enabled and tab is visible
4. **Standard API** - Uses modern web standard, no hacks or workarounds

## Related

- Screen Wake Lock API: https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API
- NoSleep.js (fallback): https://github.com/richtr/NoSleep.js