### PR TITLE
Fix API naming inconsistency: providerID vs provider_id

### DIFF
--- a/internal/dashboard/templates/llm-config.html
+++ b/internal/dashboard/templates/llm-config.html
@@ -313,7 +313,7 @@
 // Model data from server - use window object to avoid redeclaration errors on HTMX swaps
 window.availableModels = {{if .AvailableModels}}[
   {{range .AvailableModels}}
-  { id: "{{.ID}}", providerID: "{{.ProviderID}}", name: "{{.Name}}" },
+  { id: "{{.ID}}", provider_id: "{{.ProviderID}}", name: "{{.Name}}" },
   {{end}}
 ]{{else}}[]{{end}};
 
@@ -410,7 +410,7 @@ function filterModels(query) {
   return window.availableModels.filter(function(model) {
     return model.name.toLowerCase().includes(query) ||
            model.id.toLowerCase().includes(query) ||
-           model.providerID.toLowerCase().includes(query);
+           model.provider_id.toLowerCase().includes(query);
   });
 }
 
@@ -425,10 +425,10 @@ function renderDropdown(models, list, query) {
   // Group models by provider
   const grouped = {};
   models.forEach(function(model) {
-    if (!grouped[model.providerID]) {
-      grouped[model.providerID] = [];
+    if (!grouped[model.provider_id]) {
+      grouped[model.provider_id] = [];
     }
-    grouped[model.providerID].push(model);
+    grouped[model.provider_id].push(model);
   });
   
   // Render grouped models
@@ -442,7 +442,7 @@ function renderDropdown(models, list, query) {
       const item = document.createElement('div');
       item.className = 'model-dropdown-item';
       item.setAttribute('data-model-id', model.id);
-      item.setAttribute('data-provider-id', model.providerID);
+      item.setAttribute('data-provider-id', model.provider_id);
       item.innerHTML = '<div class="model-name">' + escapeHtml(model.name) + '</div>' +
                       '<div class="model-provider">' + escapeHtml(model.id) + '</div>';
       

--- a/internal/opencode/client.go
+++ b/internal/opencode/client.go
@@ -737,7 +737,7 @@ func (c *Client) GetMessages(sessionID string) (messages []Message, err error) {
 
 type ProviderModel struct {
 	ID         string `json:"id"`
-	ProviderID string `json:"providerID"`
+	ProviderID string `json:"provider_id"`
 	Name       string `json:"name"`
 }
 

--- a/internal/opencode/client_test.go
+++ b/internal/opencode/client_test.go
@@ -683,3 +683,44 @@ func TestSendMessageStream_WithSubagentToolCall(t *testing.T) {
 		t.Error("missing tool_result part — subagent results should be visible even when assistantMsgID changes")
 	}
 }
+
+func TestProviderModel_JSONSerialization(t *testing.T) {
+	model := opencode.ProviderModel{
+		ID:         "openai/gpt-4",
+		ProviderID: "openai",
+		Name:       "GPT-4",
+	}
+
+	data, err := json.Marshal(model)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"provider_id"`) {
+		t.Errorf("JSON should contain 'provider_id', got: %s", jsonStr)
+	}
+	if strings.Contains(jsonStr, `"providerID"`) {
+		t.Errorf("JSON should NOT contain 'providerID', got: %s", jsonStr)
+	}
+}
+
+func TestModelRef_JSONSerialization(t *testing.T) {
+	ref := opencode.ModelRef{
+		ProviderID: "anthropic",
+		ModelID:    "claude-sonnet-4",
+	}
+
+	data, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"providerID"`) {
+		t.Errorf("JSON should contain 'providerID' (upstream API format), got: %s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"modelID"`) {
+		t.Errorf("JSON should contain 'modelID' (upstream API format), got: %s", jsonStr)
+	}
+}


### PR DESCRIPTION
Closes #504

## Problem

The application crashes when typing in the ModelSelector component on the Settings page (/new/settings).

## Root Cause

Naming inconsistency between the API (Go) and frontend (TypeScript):

**Go API** returns (`internal/opencode/client.go:738-742`):
```go
type ProviderModel struct {
    ID         string `json:"id"`
    ProviderID string `json:"providerID"`  // ← camelCase
    Name       string `json:"name"`
}
```

**TypeScript expects** (`web/src/api/types.ts:136-140`):
```typescript
export interface ProviderModel {
  id: string
  name: string
  provider_id: string  // ← snake_case
}
```

As a result, `provider_id` is `undefined`, and when filtering models the code tries to call `m.provider_id.toLowerCase()` which causes a crash:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

## Proposed Fix

Change the JSON tag in Go from `json:"providerID"` to `json:"provider_id"` to be consistent with the rest of the API (which uses snake_case: `available_models`, `sprint_auto_start`, etc.).

## Acceptance Criteria
- [ ] Change `json:"providerID"` to `json:"provider_id"` in `internal/opencode/client.go`
- [ ] Test that the Settings page works correctly
- [ ] Check if there are other places with the same issue