### PR TITLE
Auto-assign stage:backlog to issues without stage labels during sync

### DIFF
--- a/internal/dashboard/sync.go
+++ b/internal/dashboard/sync.go
@@ -9,15 +9,6 @@ import (
 	"github.com/crazy-goat/one-dev-army/internal/github"
 )
 
-func hasStageLabel(issue github.Issue) bool {
-	for _, label := range issue.Labels {
-		if github.IsStageLabel(label.Name) {
-			return true
-		}
-	}
-	return false
-}
-
 // GitHubClient defines the interface for GitHub operations needed by SyncService
 type GitHubClient interface {
 	ListIssuesWithPRStatus(milestone string) ([]github.Issue, error)
@@ -158,6 +149,15 @@ func (s *SyncService) syncNow() {
 	s.doSync()
 }
 
+func hasStageLabel(issue github.Issue) bool {
+	for _, label := range issue.Labels {
+		if github.IsStageLabel(label.Name) {
+			return true
+		}
+	}
+	return false
+}
+
 // doSync performs the actual synchronization work
 func (s *SyncService) doSync() {
 	if s.gh == nil {
@@ -208,27 +208,26 @@ func (s *SyncService) doSync() {
 
 	// Cache each issue and notify orchestrator
 	cachedCount := 0
-	for _, issue := range issues {
-		if issue.State == "open" && !hasStageLabel(issue) {
-			log.Printf("[SyncService] Auto-assigning stage:backlog to issue #%d", issue.Number)
-			if err := s.gh.AddLabel(issue.Number, string(github.StageBacklog)); err != nil {
-				log.Printf("[SyncService] Error adding stage:backlog to issue #%d: %v", issue.Number, err)
+	for i := range issues {
+		if issues[i].State == "open" && !hasStageLabel(issues[i]) {
+			log.Printf("[SyncService] Auto-assigning stage:backlog to issue #%d", issues[i].Number)
+			if err := s.gh.AddLabel(issues[i].Number, string(github.StageBacklog)); err != nil {
+				log.Printf("[SyncService] Error adding stage:backlog to issue #%d: %v", issues[i].Number, err)
 			} else {
-				issue.Labels = append(issue.Labels, struct {
+				issues[i].Labels = append(issues[i].Labels, struct {
 					Name string `json:"name"`
 				}{Name: string(github.StageBacklog)})
 			}
 		}
 
-		if err := s.store.SaveIssueCache(issue, milestone, false); err != nil {
-			log.Printf("[SyncService] Error caching issue #%d: %v", issue.Number, err)
+		if err := s.store.SaveIssueCache(issues[i], milestone, false); err != nil {
+			log.Printf("[SyncService] Error caching issue #%d: %v", issues[i].Number, err)
 			continue
 		}
 		cachedCount++
 
-		// Notify orchestrator of sync event
 		if s.orchestrator != nil {
-			s.orchestrator.HandleSyncEvent(issue)
+			s.orchestrator.HandleSyncEvent(issues[i])
 		}
 	}
 

--- a/internal/dashboard/sync_test.go
+++ b/internal/dashboard/sync_test.go
@@ -455,6 +455,38 @@ func TestSyncService_AutoAssignStageBacklog_NoLabels(t *testing.T) {
 	}
 }
 
+func TestSyncService_AutoAssignStageBacklog_CachedIssueHasLabel(t *testing.T) {
+	gh := &mockGitHubClient{
+		issues: []github.Issue{
+			{Number: 1, Title: "Issue 1", State: "open", Labels: []struct {
+				Name string `json:"name"`
+			}{}},
+		},
+		oldestMilestone: &github.Milestone{Number: 1, Title: "Sprint 1"},
+	}
+	store := &mockStore{}
+	service := NewSyncService(gh, store, nil, nil)
+	service.SetActiveMilestone("Sprint 1")
+
+	service.syncNow()
+
+	cached := store.getCachedIssues()
+	if len(cached) != 1 {
+		t.Fatalf("Expected 1 cached issue, got %d", len(cached))
+	}
+
+	hasBacklog := false
+	for _, label := range cached[0].Labels {
+		if label.Name == "stage:backlog" {
+			hasBacklog = true
+			break
+		}
+	}
+	if !hasBacklog {
+		t.Error("Expected cached issue to have stage:backlog label after auto-assignment")
+	}
+}
+
 func TestSyncService_AutoAssignStageBacklog_NonStageLabels(t *testing.T) {
 	gh := &mockGitHubClient{
 		issues: []github.Issue{

--- a/internal/dashboard/templates/layout.html
+++ b/internal/dashboard/templates/layout.html
@@ -752,7 +752,6 @@ window.dashboardConfig = {
     window.toggleWorkerOptimistic = toggleWorkerOptimistic;
     window.toggleWorkerComplete = toggleWorkerComplete;
     
-<<<<<<< Updated upstream
     // LogStreamClient - Real-time log streaming with dual transport support
     function LogStreamClient(options) {
         this.options = Object.assign({
@@ -1144,8 +1143,6 @@ window.dashboardConfig = {
         }
     }
     
-=======
->>>>>>> Stashed changes
     // Auto-connect on page load
     document.addEventListener('DOMContentLoaded', connect);
     


### PR DESCRIPTION
Closes #505

## Problem

When importing issues from GitHub during sync, issues that have labels (like "bug", "feature", "priority:high") but no stage:* label don't appear on the ODA dashboard board. They are effectively invisible to the system.

## Current Behavior

- Issue with label "bug" → no stage label → invisible on board
- Issue with label "priority:high" → no stage label → invisible on board
- Issue with no labels at all → invisible on board

## Expected Behavior

All open issues without a stage:* label should automatically get stage:backlog assigned during sync, so they appear in the backlog column.

## Proposed Solution

Modify the sync service (`internal/dashboard/sync.go`) to:
1. Check if issue is open (not closed)
2. Check if issue has any label starting with "stage:"
3. If no stage label found → add "stage:backlog" via GitHub API

## Acceptance Criteria
- [ ] Add helper function `hasStageLabel()` to check for stage:* labels
- [ ] Modify sync loop to auto-assign stage:backlog to open issues without stage labels
- [ ] Write unit tests covering: no labels, non-stage labels, existing stage labels, closed issues
- [ ] All tests pass
- [ ] Linter passes